### PR TITLE
Update the valid and preferred lifetimes of temporary IPv6 addresses

### DIFF
--- a/neat_addr.c
+++ b/neat_addr.c
@@ -146,19 +146,17 @@ void neat_addr_lifetime_timeout_cb(uv_timer_t *handle)
 {
     struct neat_ctx *nc;
     struct neat_addr *addr;
-    uint64_t timeout;
     int notify;
 
     nc = (struct neat_ctx *)handle->data;
-    timeout = nc->addr_lifetime_timeout / 1000;
     LIST_FOREACH(addr, &(nc->src_addrs), next_addr) {
         notify = 0;
         if (addr->family != AF_INET6)
             continue;
         if (addr->u.v6.ifa_pref != NEAT_UNLIMITED_LIFETIME)
             if (addr->u.v6.ifa_pref > 0) {
-                if (addr->u.v6.ifa_pref >= timeout)
-                    addr->u.v6.ifa_pref -= timeout;
+                if (addr->u.v6.ifa_pref >= NEAT_ADDRESS_LIFETIME_TIMEOUT)
+                    addr->u.v6.ifa_pref -= NEAT_ADDRESS_LIFETIME_TIMEOUT;
                 else
                     addr->u.v6.ifa_pref = 0;
                 if (addr->u.v6.ifa_pref == 0)
@@ -166,8 +164,8 @@ void neat_addr_lifetime_timeout_cb(uv_timer_t *handle)
             }
         if (addr->u.v6.ifa_valid != NEAT_UNLIMITED_LIFETIME)
             if (addr->u.v6.ifa_valid > 0) {
-                if (addr->u.v6.ifa_valid >= timeout)
-                    addr->u.v6.ifa_valid -= timeout;
+                if (addr->u.v6.ifa_valid >= NEAT_ADDRESS_LIFETIME_TIMEOUT)
+                    addr->u.v6.ifa_valid -= NEAT_ADDRESS_LIFETIME_TIMEOUT;
                 else
                     addr->u.v6.ifa_valid = 0;
                 if (addr->u.v6.ifa_valid == 0)

--- a/neat_addr.h
+++ b/neat_addr.h
@@ -12,6 +12,7 @@
 #include "neat_queue.h"
 
 #define NEAT_UNLIMITED_LIFETIME 0xffffffff
+#define NEAT_ADDRESS_LIFETIME_TIMEOUT 1
 
 struct neat_ctx;
 

--- a/neat_core.c
+++ b/neat_core.c
@@ -37,13 +37,12 @@ struct neat_ctx *neat_init_ctx()
     uv_loop_init(nc->loop);
     LIST_INIT(&(nc->src_addrs));
 
-    nc->addr_lifetime_timeout = 1000; /* every second */
     uv_timer_init(nc->loop, &(nc->addr_lifetime_handle));
     nc->addr_lifetime_handle.data = nc;
     uv_timer_start(&(nc->addr_lifetime_handle),
                    neat_addr_lifetime_timeout_cb,
-                   nc->addr_lifetime_timeout,
-                   nc->addr_lifetime_timeout);
+                   1000 * NEAT_ADDRESS_LIFETIME_TIMEOUT,
+                   1000 * NEAT_ADDRESS_LIFETIME_TIMEOUT);
 
 #if defined(__linux__)
     return neat_linux_init_ctx(nc);

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -40,7 +40,6 @@ struct neat_ctx {
     struct neat_pib pib;
     struct neat_cib cib;
     uv_timer_t addr_lifetime_handle;
-    uint64_t addr_lifetime_timeout;
 
     // resolver
     NEAT_INTERNAL_CTX;


### PR DESCRIPTION
This fixes https://github.com/NEAT-project/neat/issues/11.

Thanks to Kristian for reviewing the patch.
