### PR TITLE
Bind socket to iface

### DIFF
--- a/neat_core.c
+++ b/neat_core.c
@@ -1135,7 +1135,7 @@ neat_connect_via_kernel(struct he_cb_ctx *he_ctx, uv_poll_cb callback_fx)
 
     /* Bind to address + interface (if Linux) */
     if (bind(he_ctx->fd, (struct sockaddr*) &(he_ctx->candidate->src_addr),
-            sizeof(struct sockaddr_storage))) {
+            he_ctx->candidate->src_addr_len)) {
         fprintf(stderr, "Failed to bind socket to IP. Error: %s\n",
                 strerror(errno));
         return -1;

--- a/neat_core.c
+++ b/neat_core.c
@@ -10,6 +10,11 @@
 #include <string.h>
 #include <unistd.h>
 #include <uv.h>
+#include <errno.h>
+
+#ifdef __linux__
+    #include <net/if.h>
+#endif
 
 #include "neat.h"
 #include "neat_internal.h"
@@ -1113,11 +1118,39 @@ neat_connect_via_kernel(struct he_cb_ctx *he_ctx, uv_poll_cb callback_fx)
     int enable = 1;
     socklen_t len;
     int size;
+#ifdef __linux__
+    char if_name[IF_NAMESIZE];
+#endif
+
     socklen_t slen =
             (he_ctx->candidate->ai_family == AF_INET) ? sizeof (struct sockaddr_in) : sizeof (struct sockaddr_in6);
     neat_log(NEAT_LOG_DEBUG, "%s", __FUNCTION__);
 
     he_ctx->fd = socket(he_ctx->candidate->ai_family, he_ctx->candidate->ai_socktype, he_ctx->candidate->ai_protocol);
+
+    if (he_ctx->fd < 0) {
+        fprintf(stderr, "Failed to create he socket\n");
+        return -1;
+    }
+
+    /* Bind to address + interface (if Linux) */
+    if (bind(he_ctx->fd, (struct sockaddr*) &(he_ctx->candidate->src_addr),
+            sizeof(struct sockaddr_storage))) {
+        fprintf(stderr, "Failed to bind socket to IP. Error: %s\n",
+                strerror(errno));
+        return -1;
+    }
+
+#ifdef __linux__
+    if (if_indextoname(he_ctx->candidate->if_idx, if_name)) {
+        if (setsockopt(he_ctx->fd, SOL_SOCKET, SO_BINDTODEVICE, if_name,
+                strlen(if_name)) < 0) {
+            //Not a critical error
+            fprintf(stderr, "Could not bind socket to interface %s\n", if_name);
+        }
+    }
+#endif
+
     len = (socklen_t)sizeof(int);
     if (getsockopt(he_ctx->fd, SOL_SOCKET, SO_SNDBUF, &size, &len) == 0) {
         he_ctx->writeSize = size;

--- a/neat_core.c
+++ b/neat_core.c
@@ -1142,13 +1142,13 @@ neat_connect_via_kernel(struct he_cb_ctx *he_ctx, uv_poll_cb callback_fx)
     }
 
 #ifdef __linux__
-    if (if_indextoname(he_ctx->candidate->if_idx, if_name)) {
+    /*if (if_indextoname(he_ctx->candidate->if_idx, if_name)) {
         if (setsockopt(he_ctx->fd, SOL_SOCKET, SO_BINDTODEVICE, if_name,
                 strlen(if_name)) < 0) {
             //Not a critical error
             fprintf(stderr, "Could not bind socket to interface %s\n", if_name);
         }
-    }
+    }*/
 #endif
 
     len = (socklen_t)sizeof(int);

--- a/neat_core.c
+++ b/neat_core.c
@@ -1119,7 +1119,7 @@ neat_connect_via_kernel(struct he_cb_ctx *he_ctx, uv_poll_cb callback_fx)
     socklen_t len;
     int size;
 #ifdef __linux__
-    //char if_name[IF_NAMESIZE];
+    char if_name[IF_NAMESIZE];
 #endif
 
     socklen_t slen =
@@ -1142,13 +1142,13 @@ neat_connect_via_kernel(struct he_cb_ctx *he_ctx, uv_poll_cb callback_fx)
     }
 
 #ifdef __linux__
-    /*if (if_indextoname(he_ctx->candidate->if_idx, if_name)) {
+    if (if_indextoname(he_ctx->candidate->if_idx, if_name)) {
         if (setsockopt(he_ctx->fd, SOL_SOCKET, SO_BINDTODEVICE, if_name,
                 strlen(if_name)) < 0) {
             //Not a critical error
             fprintf(stderr, "Could not bind socket to interface %s\n", if_name);
         }
-    }*/
+    }
 #endif
 
     len = (socklen_t)sizeof(int);

--- a/neat_core.c
+++ b/neat_core.c
@@ -1119,7 +1119,7 @@ neat_connect_via_kernel(struct he_cb_ctx *he_ctx, uv_poll_cb callback_fx)
     socklen_t len;
     int size;
 #ifdef __linux__
-    char if_name[IF_NAMESIZE];
+    //char if_name[IF_NAMESIZE];
 #endif
 
     socklen_t slen =


### PR DESCRIPTION
We need to bind socket to address/interface in neat_connect_via_kernel(), otherwise everything is void wrt multihoming. The approach probably needs to be refined for SCTP/MPTCP, since I don't quite know how they react to explicit bind.