### PR TITLE
Add PvD over DNS support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ LIST(APPEND neat_sources
     neat_log.c
     neat_stat.c
     neat_property_helpers.c
+    neat_pvd.c
     neat_resolver.c
     neat_resolver_conf.c
     neat_resolver_helpers.c

--- a/neat_addr.c
+++ b/neat_addr.c
@@ -24,13 +24,14 @@ static void neat_addr_print_src_addrs(struct neat_ctx *nc)
             src_addr4 = &(nsrc_addr->u.v4.addr4);
             inet_ntop(AF_INET, &(src_addr4->sin_addr), addr_str,
                     INET_ADDRSTRLEN);
-            neat_log(NEAT_LOG_INFO, "\tIPv4: %s", addr_str);
+            neat_log(NEAT_LOG_INFO, "\tIPv4: %s/%u", addr_str, nsrc_addr->prefix_length);
         } else {
             src_addr6 = &(nsrc_addr->u.v6.addr6);
             inet_ntop(AF_INET6, &(src_addr6->sin6_addr), addr_str,
                     INET6_ADDRSTRLEN);
-            neat_log(NEAT_LOG_INFO, "\tIPv6: %s pref %u valid %u", addr_str,
-                    nsrc_addr->u.v6.ifa_pref, nsrc_addr->u.v6.ifa_valid);
+            neat_log(NEAT_LOG_INFO, "\tIPv6: %s/%u pref %u valid %u", addr_str,
+                    nsrc_addr->prefix_length, nsrc_addr->u.v6.ifa_pref,
+                    nsrc_addr->u.v6.ifa_valid);
         }
     }
 }
@@ -45,7 +46,7 @@ uint8_t neat_addr_cmp_ip6_addr(struct in6_addr *aAddr,
 //Add/remove/update a source address based on information received from OS
 void neat_addr_update_src_list(struct neat_ctx *nc,
         struct sockaddr_storage *src_addr, uint32_t if_idx,
-        uint8_t newaddr, uint32_t ifa_pref, uint32_t ifa_valid)
+        uint8_t newaddr, uint8_t pref_length, uint32_t ifa_pref, uint32_t ifa_valid)
 {
     struct sockaddr_in *src_addr4 = NULL, *org_addr4 = NULL;
     struct sockaddr_in6 *src_addr6 = NULL, *org_addr6 = NULL;
@@ -116,6 +117,7 @@ void neat_addr_update_src_list(struct neat_ctx *nc,
 
     nsrc_addr->family = src_addr->ss_family;
     nsrc_addr->if_idx = if_idx;
+    nsrc_addr->prefix_length = pref_length;
 
     memcpy(&(nsrc_addr->u.generic.addr), src_addr, sizeof(*src_addr));
 

--- a/neat_addr.c
+++ b/neat_addr.c
@@ -37,6 +37,9 @@ static void neat_addr_print_src_addrs(struct neat_ctx *nc)
                     nsrc_addr->u.v6.ifa_valid);
         }
 
+        if (nc->pvd == NULL)
+            continue;
+
         LIST_FOREACH(pvd_result, &(nc->pvd->results), next_result) {
             if (pvd_result->src_addr != nsrc_addr) {
                 continue;

--- a/neat_addr.c
+++ b/neat_addr.c
@@ -15,6 +15,8 @@ static void neat_addr_print_src_addrs(struct neat_ctx *nc)
     char addr_str[INET6_ADDRSTRLEN];
     struct sockaddr_in *src_addr4;
     struct sockaddr_in6 *src_addr6;
+    struct pvd* pvd;
+    struct pvd_info* pvd_info;
 
     neat_log(NEAT_LOG_INFO, "Available src-addresses:");
     for (nsrc_addr = nc->src_addrs.lh_first; nsrc_addr != NULL;
@@ -34,8 +36,6 @@ static void neat_addr_print_src_addrs(struct neat_ctx *nc)
                     nsrc_addr->u.v6.ifa_valid);
         }
 
-        struct pvd* pvd;
-        struct pvd_info* pvd_info;
         LIST_FOREACH(pvd, &(nsrc_addr->pvds), next_pvd) {
             neat_log(NEAT_LOG_INFO, "\t\tPVD:");
             LIST_FOREACH(pvd_info, &(pvd->infos), next_info) {

--- a/neat_addr.c
+++ b/neat_addr.c
@@ -33,6 +33,15 @@ static void neat_addr_print_src_addrs(struct neat_ctx *nc)
                     nsrc_addr->prefix_length, nsrc_addr->u.v6.ifa_pref,
                     nsrc_addr->u.v6.ifa_valid);
         }
+
+        struct pvd* pvd;
+        struct pvd_info* pvd_info;
+        LIST_FOREACH(pvd, &(nsrc_addr->pvds), next_pvd) {
+            neat_log(NEAT_LOG_INFO, "\t\tPVD:");
+            LIST_FOREACH(pvd_info, &(pvd->infos), next_info) {
+                neat_log(NEAT_LOG_INFO, "\t\t\t%s => %s", pvd_info->key, pvd_info->value);
+            }
+        }
     }
 }
 

--- a/neat_addr.c
+++ b/neat_addr.c
@@ -17,6 +17,7 @@ static void neat_addr_print_src_addrs(struct neat_ctx *nc)
     struct sockaddr_in6 *src_addr6;
     struct pvd* pvd;
     struct pvd_info* pvd_info;
+    struct pvd_result* pvd_result;
 
     neat_log(NEAT_LOG_INFO, "Available src-addresses:");
     for (nsrc_addr = nc->src_addrs.lh_first; nsrc_addr != NULL;
@@ -36,10 +37,15 @@ static void neat_addr_print_src_addrs(struct neat_ctx *nc)
                     nsrc_addr->u.v6.ifa_valid);
         }
 
-        LIST_FOREACH(pvd, &(nsrc_addr->pvds), next_pvd) {
-            neat_log(NEAT_LOG_INFO, "\t\tPVD:");
-            LIST_FOREACH(pvd_info, &(pvd->infos), next_info) {
-                neat_log(NEAT_LOG_INFO, "\t\t\t%s => %s", pvd_info->key, pvd_info->value);
+        LIST_FOREACH(pvd_result, &(nc->pvd->results), next_result) {
+            if (pvd_result->src_addr != nsrc_addr) {
+                continue;
+            }
+            LIST_FOREACH(pvd, &(pvd_result->pvds), next_pvd) {
+                neat_log(NEAT_LOG_INFO, "\t\tPVD:");
+                LIST_FOREACH(pvd_info, &(pvd->infos), next_info) {
+                    neat_log(NEAT_LOG_INFO, "\t\t\t%s => %s", pvd_info->key, pvd_info->value);
+                }
             }
         }
     }

--- a/neat_addr.h
+++ b/neat_addr.h
@@ -39,8 +39,6 @@ struct neat_addr {
     uint8_t __pad;
     uint16_t __pad2;
     uint8_t prefix_length;
-
-    struct pvds pvds;
 };
 
 //Add/remove addresses from src. address list

--- a/neat_addr.h
+++ b/neat_addr.h
@@ -37,12 +37,13 @@ struct neat_addr {
     uint8_t family;
     uint8_t __pad;
     uint16_t __pad2;
+    uint8_t prefix_length;
 };
 
 //Add/remove addresses from src. address list
 void neat_addr_update_src_list(struct neat_ctx *nc,
         struct sockaddr_storage *src_addr, uint32_t if_idx,
-        uint8_t newaddr, uint32_t ifa_pref, uint32_t ifa_valid);
+        uint8_t newaddr, uint8_t pref_length, uint32_t ifa_pref, uint32_t ifa_valid);
 
 //Utility function for comparing two v6 addresses
 uint8_t neat_addr_cmp_ip6_addr(struct in6_addr *aAddr,

--- a/neat_addr.h
+++ b/neat_addr.h
@@ -10,6 +10,7 @@
 #endif
 
 #include "neat_queue.h"
+#include "neat_pvd.h"
 
 #define NEAT_UNLIMITED_LIFETIME 0xffffffff
 #define NEAT_ADDRESS_LIFETIME_TIMEOUT 1
@@ -38,6 +39,8 @@ struct neat_addr {
     uint8_t __pad;
     uint16_t __pad2;
     uint8_t prefix_length;
+
+    struct pvds pvds;
 };
 
 //Add/remove addresses from src. address list

--- a/neat_bsd.c
+++ b/neat_bsd.c
@@ -121,6 +121,7 @@ static void neat_bsd_get_addresses(struct neat_ctx *ctx)
                                   (struct sockaddr_storage *)ifa->ifa_addr,
                                   cached_ifindex,
                                   1,
+                                  0,
                                   preferred_lifetime,
                                   valid_lifetime);
     }
@@ -232,6 +233,7 @@ static void neat_bsd_route_recv(uv_udp_t *handle,
                               (struct sockaddr_storage *)rti_info[RTAX_IFA],
                               ifa->ifam_index,
                               ifa->ifam_type == RTM_NEWADDR ? 1 : 0,
+                              0,
                               preferred_lifetime,
                               valid_lifetime);
 }

--- a/neat_core.c
+++ b/neat_core.c
@@ -219,6 +219,9 @@ void neat_free_ctx(struct neat_ctx *nc)
     if (nc->event_cbs)
         free(nc->event_cbs);
 
+    if (nc->pvd)
+        free(nc->pvd);
+
     free(nc->loop);
 
     while (!LIST_EMPTY(&nc->flows)) {

--- a/neat_core.c
+++ b/neat_core.c
@@ -750,12 +750,12 @@ static int io_readable(neat_ctx *ctx, neat_flow *flow,
         return READ_WITH_ERROR;
     }
 
-    /* 
-     * The UDP Accept flow isn't going to have on_readable set, 
+    /*
+     * The UDP Accept flow isn't going to have on_readable set,
      * anything else will.
      */
     if (!flow->operations->on_readable) {
-        if (!(flow->sockStack == NEAT_STACK_UDP && flow->acceptPending)) { 
+        if (!(flow->sockStack == NEAT_STACK_UDP && flow->acceptPending)) {
             return READ_WITH_ERROR;
         }
     }
@@ -1709,6 +1709,9 @@ neat_error_code neat_accept(struct neat_ctx *ctx, struct neat_flow *flow,
     if (!ctx->resolver)
         ctx->resolver = neat_resolver_init(ctx, "/etc/resolv.conf");
 
+    if (!ctx->pvd)
+        ctx->pvd = neat_pvd_init(ctx);
+
     neat_resolve(ctx->resolver, AF_INET, flow->name, flow->port,
                  accept_resolve_cb, flow);
     return NEAT_OK;
@@ -2317,8 +2320,8 @@ neat_connect(struct he_cb_ctx *he_ctx, uv_poll_cb callback_fx)
 #endif
 
     uv_poll_init(he_ctx->nc->loop, he_ctx->handle, he_ctx->fd); // makes fd nb as side effect
-    
-    retval = connect(he_ctx->fd, (struct sockaddr *) &(he_ctx->candidate->dst_addr), slen);    
+
+    retval = connect(he_ctx->fd, (struct sockaddr *) &(he_ctx->candidate->dst_addr), slen);
     if (retval && errno != EINPROGRESS) {
         neat_log(NEAT_LOG_DEBUG, "%s: Connect failed for fd %d connect error (%d): %s", __func__, he_ctx->fd, errno, strerror(errno));
         return -2;
@@ -3038,7 +3041,7 @@ neat_find_flow(neat_ctx *ctx, struct sockaddr *src, struct sockaddr *dst)
 {
     neat_flow *flow;
     LIST_FOREACH(flow, &ctx->flows, next_flow) {
-        if ((sockaddr_cmp(&flow->dstAddr, dst) != 0) && 
+        if ((sockaddr_cmp(&flow->dstAddr, dst) != 0) &&
                (sockaddr_cmp(&flow->srcAddr, src) != 0)) {
                        return flow;
         }

--- a/neat_core.c
+++ b/neat_core.c
@@ -110,6 +110,7 @@ struct neat_ctx *neat_init_ctx()
         return NULL;
     }
     nc->loop = malloc(sizeof(uv_loop_t));
+    nc->pvd = NULL;
 
     if (nc->loop == NULL) {
         free(nc);

--- a/neat_core.c
+++ b/neat_core.c
@@ -220,8 +220,10 @@ void neat_free_ctx(struct neat_ctx *nc)
     if (nc->event_cbs)
         free(nc->event_cbs);
 
-    if (nc->pvd)
+    if (nc->pvd) {
+        neat_pvd_release(nc->pvd);
         free(nc->pvd);
+    }
 
     free(nc->loop);
 

--- a/neat_he.c
+++ b/neat_he.c
@@ -188,7 +188,7 @@ neat_error_code neat_he_lookup(neat_ctx *ctx, neat_flow *flow, uv_poll_cb callba
     uint8_t nr_of_stacks;
     uint8_t family;
     struct neat_he_resolver_data *resolver_data;
-    
+
     neat_log(NEAT_LOG_DEBUG, "%s", __func__);
 
     if ((flow->propertyMask & NEAT_PROPERTY_IPV4_REQUIRED) &&
@@ -225,6 +225,10 @@ neat_error_code neat_he_lookup(neat_ctx *ctx, neat_flow *flow, uv_poll_cb callba
 
     if (!ctx->resolver) {
         ctx->resolver = neat_resolver_init(ctx, "/etc/resolv.conf");
+    }
+
+    if (!ctx->pvd) {
+        ctx->pvd = neat_pvd_init(ctx);
     }
 
     /* FIXME: derivation of the socket type is wrong.

--- a/neat_he.c
+++ b/neat_he.c
@@ -227,9 +227,8 @@ neat_error_code neat_he_lookup(neat_ctx *ctx, neat_flow *flow, uv_poll_cb callba
         ctx->resolver = neat_resolver_init(ctx, "/etc/resolv.conf");
     }
 
-    if (!ctx->pvd) {
+    if (!ctx->pvd)
         ctx->pvd = neat_pvd_init(ctx);
-    }
 
     /* FIXME: derivation of the socket type is wrong.
      * FIXME: Make use of the array of protocols

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -34,6 +34,7 @@
 struct neat_event_cb;
 struct neat_addr;
 struct neat_resolver;
+struct neat_pvd;
 
 //TODO: One drawback with using LIST from queue.h, is that a callback can only
 //be member of one list. Decide if this is critical and improve if needed
@@ -60,6 +61,9 @@ struct neat_ctx
     struct neat_cib cib;
     struct neat_flow_list_head flows;
     uv_timer_t addr_lifetime_handle;
+
+    // PvD
+    struct neat_pvd* pvd;
 
     // resolver
     NEAT_INTERNAL_CTX;
@@ -315,6 +319,9 @@ void neat_io_error(neat_ctx *ctx, neat_flow *flow, int stream,
                    neat_error_code code);
 
 struct neat_iofilter *insert_neat_iofilter(neat_ctx *ctx, neat_flow *flow);
+
+//Initialize PvD
+struct neat_pvd *neat_pvd_init(struct neat_ctx *nc);
 
 enum neat_events{
     //A new address has been added to an interface

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -323,6 +323,9 @@ struct neat_iofilter *insert_neat_iofilter(neat_ctx *ctx, neat_flow *flow);
 //Initialize PvD
 struct neat_pvd *neat_pvd_init(struct neat_ctx *nc);
 
+//Free PvD resources
+void neat_pvd_release(struct neat_pvd *pvd);
+
 enum neat_events{
     //A new address has been added to an interface
     NEAT_NEWADDR = 0,

--- a/neat_linux.c
+++ b/neat_linux.c
@@ -102,7 +102,7 @@ static void neat_linux_handle_addr(struct neat_ctx *nc,
     //TODO: Should this function be a callback instead? Will we have multiple
     //addresses handlers/types of context?
     neat_addr_update_src_list(nc, &src_addr, ifm->ifa_index,
-            nl_hdr->nlmsg_type == RTM_NEWADDR, ifa_pref, ifa_valid);
+            nl_hdr->nlmsg_type == RTM_NEWADDR, ifm->ifa_prefixlen, ifa_pref, ifa_valid);
 }
 
 //libuv datagram socket alloc function, un-interesting

--- a/neat_pvd.c
+++ b/neat_pvd.c
@@ -16,7 +16,8 @@
 #include "neat_addr.h"
 
 char *
-compute_reverse_ip(struct neat_addr *src_addr) {
+compute_reverse_ip(struct neat_addr *src_addr)
+{
     struct in_addr src_addr4;
     struct in6_addr src_addr6;
     char reverse_ip[80]; // maximum length for a reverse /128 IPv6
@@ -80,7 +81,8 @@ compute_reverse_ip(struct neat_addr *src_addr) {
 }
 
 void
-add_pvd_result(struct pvds* pvds, ldns_rr_list *pvd_txt_list) {
+add_pvd_result(struct pvds* pvds, ldns_rr_list *pvd_txt_list)
+{
     struct pvd_infos pvd_infos;
     struct pvd_info *pvd_info;
     char *txt_record;

--- a/neat_pvd.c
+++ b/neat_pvd.c
@@ -44,13 +44,14 @@ char* compute_reverse_ip(struct neat_addr *src_addr) {
             sprintf(reverse_ip+string_offset, "%01x.", current_hex);
             string_offset = string_offset + 2;
         }
-        for (i = i; i >= 0; i--) {
+        while (i >= 0) {
             if (i % 2 == 0) {
                 current_hex = src_addr6.s6_addr[i/2] >> 4;
             } else {
                 current_hex = src_addr6.s6_addr[i/2] & 0x0f;
             }
             sprintf(reverse_ip + string_offset + 2*(addr_total_hex - 1 - i), "%01x.", current_hex);
+            i--;
         }
         sprintf(reverse_ip + string_offset + 2*addr_total_hex, "ip6.arpa.");
     } else if (family == AF_INET) {

--- a/neat_pvd.c
+++ b/neat_pvd.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "neat.h"
+#include "neat_internal.h"
+#include "neat_resolver.h"
+#include "neat_core.h"
+#include "neat_pvd.h"
+
+static void neat_pvd_handle_newaddr(struct neat_ctx *nc,
+                                         void *p_ptr,
+                                         void *data)
+{
+
+}
+
+struct neat_pvd *
+neat_pvd_init(struct neat_ctx *nc)
+{
+    struct neat_pvd *pvd = calloc(sizeof(struct neat_pvd), 1);
+    if (!pvd)
+        return NULL;
+
+    pvd->nc = nc;
+
+    pvd->newaddr_cb.event_cb = neat_pvd_handle_newaddr;
+    pvd->newaddr_cb.data = pvd;
+
+    if (neat_add_event_cb(nc, NEAT_NEWADDR, &(pvd->newaddr_cb))) {
+        neat_log(NEAT_LOG_ERROR, "%s - Could not add one pvd callbacks", __func__);
+        return NULL;
+    }
+
+    return pvd;
+}

--- a/neat_pvd.c
+++ b/neat_pvd.c
@@ -15,43 +15,44 @@
 #include "neat_pvd.h"
 #include "neat_addr.h"
 
-char* compute_reverse_ip(struct neat_addr *src_addr) {
+char *
+compute_reverse_ip(struct neat_addr *src_addr) {
     struct in_addr src_addr4;
     struct in6_addr src_addr6;
-    uint8_t family = src_addr->family;
     char reverse_ip[80]; // maximum length for a reverse /128 IPv6
     int i;
     char *out;
+    uint8_t family = src_addr->family;
 
     if (family == AF_INET6) {
         // From fd17:625c:f037:2:a00:27ff:fe37:86b6/69 => _.pvd.8.0.7.3.0.f.c.5.2.6.7.1.d.f.ip6.arpa.
-        src_addr6 = (src_addr->u.v6.addr6).sin6_addr;
-        sprintf(reverse_ip, "_.pvd.");
-        int addr_last_part = src_addr->prefix_length & 4;
-        int addr_total_hex = src_addr->prefix_length >> 2;
-        int string_offset = 6;
         int current_hex;
-        i = addr_total_hex-1;
+        src_addr6           = (src_addr->u.v6.addr6).sin6_addr;
+        int addr_last_part  = src_addr->prefix_length & 4;
+        int addr_total_hex  = src_addr->prefix_length >> 2;
+        int string_offset   = 6;
+        i                   = addr_total_hex-1;
+        sprintf(reverse_ip, "_.pvd.");
 
         // if the prefix length is not multiple of 4
         if (addr_last_part != 0) {
-            int last_index = addr_total_hex / 2;
-            bool divide = (addr_total_hex % 2) == 0;
-            if (divide) {
+            int last_index  = addr_total_hex / 2;
+            bool divide     = (addr_total_hex % 2) == 0;
+            if (divide)
                 current_hex = src_addr6.s6_addr[last_index] >> 4;
-            } else {
+            else
                 current_hex = src_addr6.s6_addr[last_index] & 0x0f;
-            }
+
             current_hex = current_hex - (current_hex % (1 << (4 - addr_last_part)));
             sprintf(reverse_ip+string_offset, "%01x.", current_hex);
             string_offset = string_offset + 2;
         }
         while (i >= 0) {
-            if (i % 2 == 0) {
+            if (i % 2 == 0)
                 current_hex = src_addr6.s6_addr[i/2] >> 4;
-            } else {
+            else
                 current_hex = src_addr6.s6_addr[i/2] & 0x0f;
-            }
+
             sprintf(reverse_ip + string_offset + 2*(addr_total_hex - 1 - i), "%01x.", current_hex);
             i--;
         }
@@ -78,15 +79,16 @@ char* compute_reverse_ip(struct neat_addr *src_addr) {
     return out;
 }
 
-void add_pvd_result(struct pvds* pvds, ldns_rr_list *pvd_txt_list) {
-    int nb_txt = ldns_rr_list_rr_count(pvd_txt_list);
+void
+add_pvd_result(struct pvds* pvds, ldns_rr_list *pvd_txt_list) {
     struct pvd_infos pvd_infos;
-    struct pvd_info* pvd_info;
-    char* txt_record;
-    char* dns_record_str;
+    struct pvd_info *pvd_info;
+    char *txt_record;
+    char *dns_record_str;
     ldns_rr *rr;
+    struct pvd *pvd;
+    int nb_txt = ldns_rr_list_rr_count(pvd_txt_list);
     ldns_rdf *dns_record = NULL;
-    struct pvd* pvd;
 
     if ((pvd = (struct pvd *) malloc(sizeof(struct pvd))) == NULL) {
         free(pvd);
@@ -97,10 +99,10 @@ void add_pvd_result(struct pvds* pvds, ldns_rr_list *pvd_txt_list) {
     LIST_INIT(&pvd_infos);
 
     for (int i = 0; i < nb_txt; i++) {
-        rr = ldns_rr_list_rr(pvd_txt_list, i);
-        dns_record = ldns_rr_set_rdf(rr, NULL, 0);
-        dns_record_str = ldns_rdf2str(dns_record);
-        txt_record = strdup(dns_record_str);
+        rr              = ldns_rr_list_rr(pvd_txt_list, i);
+        dns_record      = ldns_rr_set_rdf(rr, NULL, 0);
+        dns_record_str  = ldns_rdf2str(dns_record);
+        txt_record      = strdup(dns_record_str);
 
         // Removing quotes if any
         if (txt_record[0] == '"' && txt_record[strlen(txt_record)-1] == '"') {
@@ -115,7 +117,7 @@ void add_pvd_result(struct pvds* pvds, ldns_rr_list *pvd_txt_list) {
                     "%s: can't allocate buffer");
             continue;
         }
-        pvd_info->key = strsep(&txt_record, "=");
+        pvd_info->key   = strsep(&txt_record, "=");
         pvd_info->value = txt_record;
 
         LIST_INSERT_HEAD(&(pvd_infos), pvd_info, next_info);
@@ -127,9 +129,17 @@ void add_pvd_result(struct pvds* pvds, ldns_rr_list *pvd_txt_list) {
     }
 }
 
-static int neat_pvd_dns_async(uv_loop_t* loop, struct sockaddr_storage *dns_addr, struct neat_addr *src_addr, ldns_pkt *pkt, uv_alloc_cb alloc_cb, uv_udp_recv_cb recv_cb, uv_udp_send_cb send_cb, void *data)
+static int
+neat_pvd_dns_async(uv_loop_t *loop,
+                   struct sockaddr_storage *dns_addr,
+                   struct neat_addr *src_addr,
+                   ldns_pkt *pkt,
+                   uv_alloc_cb alloc_cb,
+                   uv_udp_recv_cb recv_cb,
+                   uv_udp_send_cb send_cb,
+                   void *data)
 {
-    struct sockaddr* dns_addr2 = (struct sockaddr*) dns_addr;
+    struct sockaddr *dns_addr2 = (struct sockaddr *) dns_addr;
     struct sockaddr_in *server_addr4;
     struct sockaddr_in6 *server_addr6;
 
@@ -138,8 +148,8 @@ static int neat_pvd_dns_async(uv_loop_t* loop, struct sockaddr_storage *dns_addr
     async_query->dns_uv_snd_buf = calloc(sizeof(uv_buf_t), 1);
     async_query->dns_snd_handle = calloc(sizeof(uv_udp_send_t), 1);
     async_query->resolve_handle = calloc(sizeof(uv_udp_t), 1);
-    async_query->dst_addr4 = NULL;
-    async_query->dst_addr6 = NULL;
+    async_query->dst_addr4      = NULL;
+    async_query->dst_addr6      = NULL;
 
     ldns_pkt_set_random_id(pkt);
     ldns_pkt_set_rd(pkt, 1);
@@ -153,18 +163,19 @@ static int neat_pvd_dns_async(uv_loop_t* loop, struct sockaddr_storage *dns_addr
         return 1;
     }
 
-    async_query->data = data;
-    async_query->resolve_handle->data = async_query;
+    async_query->data                   = data;
+    async_query->resolve_handle->data   = async_query;
 
     if (uv_udp_bind(async_query->resolve_handle,
-                (struct sockaddr*) &(src_addr->u.generic.addr),
-                0)) {
+                    (struct sockaddr*) &(src_addr->u.generic.addr),
+                    0)) {
         neat_log(NEAT_LOG_ERROR, "%s - Failed to bind UDP socket", __func__);
         return 1;
     }
 
-    if (uv_udp_recv_start(async_query->resolve_handle, alloc_cb,
-                recv_cb)) {
+    if (uv_udp_recv_start(async_query->resolve_handle,
+                          alloc_cb,
+                          recv_cb)) {
         neat_log(NEAT_LOG_ERROR, "%s - Failed to start receiving UDP", __func__);
         return 1;
     }
@@ -178,40 +189,44 @@ static int neat_pvd_dns_async(uv_loop_t* loop, struct sockaddr_storage *dns_addr
 
     ldns_pkt_free(pkt);
 
-    async_query->dns_uv_snd_buf->base = (char*) ldns_buffer_begin(async_query->dns_snd_buf);
-    async_query->dns_uv_snd_buf->len = ldns_buffer_position(async_query->dns_snd_buf);
+    async_query->dns_uv_snd_buf->base   = (char *) ldns_buffer_begin(async_query->dns_snd_buf);
+    async_query->dns_uv_snd_buf->len    = ldns_buffer_position(async_query->dns_snd_buf);
 
     if (dns_addr2->sa_family == AF_INET) {
-        server_addr4 = (struct sockaddr_in*) dns_addr;
-        async_query->dst_addr4 = calloc(sizeof(struct sockaddr_in), 1);
-        async_query->dst_addr4->sin_family = AF_INET;
-        async_query->dst_addr4->sin_port = htons(LDNS_PORT);
-        async_query->dst_addr4->sin_addr = server_addr4->sin_addr;
+        server_addr4                        = (struct sockaddr_in *) dns_addr;
+        async_query->dst_addr4              = calloc(sizeof(struct sockaddr_in), 1);
+        async_query->dst_addr4->sin_family  = AF_INET;
+        async_query->dst_addr4->sin_port    = htons(LDNS_PORT);
+        async_query->dst_addr4->sin_addr    = server_addr4->sin_addr;
 #ifdef HAVE_SIN_LEN
-        async_query->dst_addr4->sin_len = sizeof(struct sockaddr_in);
+        async_query->dst_addr4->sin_len     = sizeof(struct sockaddr_in);
 #endif
 
-        if (uv_udp_send(async_query->dns_snd_handle, async_query->resolve_handle,
-                async_query->dns_uv_snd_buf, 1,
-                (const struct sockaddr*) async_query->dst_addr4,
-                send_cb)) {
+        if (uv_udp_send(async_query->dns_snd_handle,
+                        async_query->resolve_handle,
+                        async_query->dns_uv_snd_buf,
+                        1,
+                        (const struct sockaddr*) async_query->dst_addr4,
+                        send_cb)) {
             neat_log(NEAT_LOG_ERROR, "%s - Failed to start DNS send", __func__);
             return 1;
         }
     } else {
-        server_addr6 = (struct sockaddr_in6*) dns_addr;
-        async_query->dst_addr6 = calloc(sizeof(struct sockaddr_in6), 1);
+        server_addr6                        = (struct sockaddr_in6 *) dns_addr;
+        async_query->dst_addr6              = calloc(sizeof(struct sockaddr_in6), 1);
         async_query->dst_addr6->sin6_family = AF_INET6;
-        async_query->dst_addr6->sin6_port = htons(LDNS_PORT);
-        async_query->dst_addr6->sin6_addr = server_addr6->sin6_addr;
+        async_query->dst_addr6->sin6_port   = htons(LDNS_PORT);
+        async_query->dst_addr6->sin6_addr   = server_addr6->sin6_addr;
 #ifdef HAVE_SIN6_LEN
-        async_query->dst_addr6->sin6_len = sizeof(struct sockaddr_in6);
+        async_query->dst_addr6->sin6_len    = sizeof(struct sockaddr_in6);
 #endif
 
-        if (uv_udp_send(async_query->dns_snd_handle, async_query->resolve_handle,
-                async_query->dns_uv_snd_buf, 1,
-                (const struct sockaddr*) async_query->dst_addr6,
-                send_cb)) {
+        if (uv_udp_send(async_query->dns_snd_handle,
+                        async_query->resolve_handle,
+                        async_query->dns_uv_snd_buf,
+                        1,
+                        (const struct sockaddr*) async_query->dst_addr6,
+                        send_cb)) {
             neat_log(NEAT_LOG_ERROR, "%s - Failed to start DNS send", __func__);
             return 1;
         }
@@ -222,13 +237,15 @@ static int neat_pvd_dns_async(uv_loop_t* loop, struct sockaddr_storage *dns_addr
 
 //Called when a DNS request has been (i.e., passed to socket). We will send the
 //second query (used for checking poisoning) here. If that is needed
-static void neat_pvd_dns_sent_cb(uv_udp_send_t *req, int status)
+static void
+neat_pvd_dns_sent_cb(uv_udp_send_t *req, int status)
 {
 }
 
 //This callback is called when we close a UDP socket (handle) and allows us to
 //free any allocated resource. In our case, this is only the dns_snd_buf
-static void neat_pvd_dns_close_cb(uv_handle_t *handle)
+static void
+neat_pvd_dns_close_cb(uv_handle_t *handle)
 {
     struct pvd_async_query *async_query = handle->data;
 
@@ -248,8 +265,10 @@ static void neat_pvd_dns_close_cb(uv_handle_t *handle)
 //libuv gives the user control of how memory is allocated. This callback is
 //called when a UDP packet is ready to received, and we have to fill out the
 //provided buf with the storage location (and available size)
-static void neat_pvd_dns_alloc_cb(uv_handle_t *handle,
-        size_t suggested_size, uv_buf_t *buf)
+static void
+neat_pvd_dns_alloc_cb(uv_handle_t *handle,
+                      size_t suggested_size,
+                      uv_buf_t *buf)
 {
     char *dns_rcv_buf = calloc(sizeof(char), 1472);
 
@@ -257,30 +276,36 @@ static void neat_pvd_dns_alloc_cb(uv_handle_t *handle,
     buf->len = sizeof(char)*1472;
 }
 
-static void neat_pvd_dns_recv_cb(uv_udp_t* handle, ssize_t nread,
-        const uv_buf_t* buf, const struct sockaddr* addr, unsigned flags)
+static void
+neat_pvd_dns_recv_cb(uv_udp_t *handle,
+                     ssize_t nread,
+                     const uv_buf_t *buf,
+                     const struct sockaddr *addr,
+                     unsigned flags)
 {
-    struct pvd_async_query *async_query = handle->data;
-    struct pvd_result *pvd_result = async_query->data;
     ldns_pkt *dns_reply;
-    ldns_rr_list *pvd_txt_list = NULL;
     size_t retval;
+    struct pvd_async_query *async_query = handle->data;
+    struct pvd_result *pvd_result       = async_query->data;
+    ldns_rr_list *pvd_txt_list          = NULL;
 
-    uv_close((uv_handle_t*) async_query->resolve_handle, neat_pvd_dns_close_cb);
+    uv_close((uv_handle_t *) async_query->resolve_handle, neat_pvd_dns_close_cb);
 
     if (nread == 0 && addr == NULL) {
         free(buf->base);
         return;
     }
 
-    retval = ldns_wire2pkt(&dns_reply, (const uint8_t*) buf->base, nread);
+    retval = ldns_wire2pkt(&dns_reply, (const uint8_t *) buf->base, nread);
     free(buf->base);
 
     if (retval != LDNS_STATUS_OK)
         return;
 
     //Parse result
-    pvd_txt_list = ldns_pkt_rr_list_by_type(dns_reply, LDNS_RR_TYPE_TXT, LDNS_SECTION_ANSWER);
+    pvd_txt_list = ldns_pkt_rr_list_by_type(dns_reply,
+                                            LDNS_RR_TYPE_TXT,
+                                            LDNS_SECTION_ANSWER);
 
     if (pvd_txt_list == NULL) {
         ldns_pkt_free(dns_reply);
@@ -293,19 +318,23 @@ static void neat_pvd_dns_recv_cb(uv_udp_t* handle, ssize_t nread,
     ldns_pkt_free(dns_reply);
 }
 
-static void neat_pvd_dns_ptr_recv_cb(uv_udp_t* handle, ssize_t nread,
-        const uv_buf_t* buf, const struct sockaddr* addr, unsigned flags)
+static void
+neat_pvd_dns_ptr_recv_cb(uv_udp_t *handle,
+                         ssize_t nread,
+                         const uv_buf_t *buf,
+                         const struct sockaddr *addr,
+                         unsigned flags)
 {
-    struct pvd_async_query *async_query = handle->data;
-    struct pvd_dns_query *dns_query = async_query->data;
     ldns_pkt *dns_reply;
-    ldns_rr_list *pvd_ptr_list = NULL;
     size_t retval;
     int i;
     ldns_rr *rr;
-    ldns_rdf *dns_record = NULL;
-    char* ptr_record;
-    char* dns_record_str;
+    char *ptr_record;
+    char *dns_record_str;
+    struct pvd_async_query *async_query = handle->data;
+    struct pvd_dns_query *dns_query     = async_query->data;
+    ldns_rr_list *pvd_ptr_list          = NULL;
+    ldns_rdf *dns_record                = NULL;
 
     uv_close((uv_handle_t*) async_query->resolve_handle, neat_pvd_dns_close_cb);
 
@@ -315,7 +344,7 @@ static void neat_pvd_dns_ptr_recv_cb(uv_udp_t* handle, ssize_t nread,
         return;
     }
 
-    retval = ldns_wire2pkt(&dns_reply, (const uint8_t*) buf->base, nread);
+    retval = ldns_wire2pkt(&dns_reply, (const uint8_t *) buf->base, nread);
     free(buf->base);
 
     if (retval != LDNS_STATUS_OK) {
@@ -324,7 +353,9 @@ static void neat_pvd_dns_ptr_recv_cb(uv_udp_t* handle, ssize_t nread,
     }
 
     //Parse result
-    pvd_ptr_list = ldns_pkt_rr_list_by_type(dns_reply, LDNS_RR_TYPE_PTR, LDNS_SECTION_ANSWER);
+    pvd_ptr_list = ldns_pkt_rr_list_by_type(dns_reply,
+                                            LDNS_RR_TYPE_PTR,
+                                            LDNS_SECTION_ANSWER);
 
     if (pvd_ptr_list == NULL) {
         ldns_pkt_free(dns_reply);
@@ -336,21 +367,31 @@ static void neat_pvd_dns_ptr_recv_cb(uv_udp_t* handle, ssize_t nread,
 
     // There can be multiple PvDs
     for (i = 0; i < nb_ptr; i++) {
-        rr = ldns_rr_list_rr(pvd_ptr_list, i);
-        dns_record = ldns_rr_set_rdf(rr, NULL, 0);
-        dns_record_str = ldns_rdf2str(dns_record);
-        ptr_record = strdup(dns_record_str);
+        rr              = ldns_rr_list_rr(pvd_ptr_list, i);
+        dns_record      = ldns_rr_set_rdf(rr, NULL, 0);
+        dns_record_str  = ldns_rdf2str(dns_record);
+        ptr_record      = strdup(dns_record_str);
 
         ldns_pkt *pkt;
-        if (ldns_pkt_query_new_frm_str(&pkt, ptr_record, LDNS_RR_TYPE_TXT,
-                    LDNS_RR_CLASS_IN, LDNS_RD) != LDNS_STATUS_OK) {
+        if (ldns_pkt_query_new_frm_str(&pkt,
+                                       ptr_record,
+                                       LDNS_RR_TYPE_TXT,
+                                       LDNS_RR_CLASS_IN, LDNS_RD)
+            != LDNS_STATUS_OK) {
             neat_log(NEAT_LOG_ERROR, "%s - Could not create DNS packet", __func__);
             continue;
         }
         free(dns_record_str);
         free(ptr_record);
 
-        neat_pvd_dns_async(dns_query->loop, dns_query->dns_addr, dns_query->src_addr, pkt, neat_pvd_dns_alloc_cb, neat_pvd_dns_recv_cb, neat_pvd_dns_sent_cb, dns_query->pvd_result);
+        neat_pvd_dns_async(dns_query->loop,
+                           dns_query->dns_addr,
+                           dns_query->src_addr,
+                           pkt,
+                           neat_pvd_dns_alloc_cb,
+                           neat_pvd_dns_recv_cb,
+                           neat_pvd_dns_sent_cb,
+                           dns_query->pvd_result);
     }
 
     ldns_rr_list_deep_free(pvd_ptr_list);
@@ -358,19 +399,20 @@ static void neat_pvd_dns_ptr_recv_cb(uv_udp_t* handle, ssize_t nread,
     free(dns_query);
 }
 
-static void neat_pvd_handle_newaddr(struct neat_ctx *nc,
-                                    void *p_ptr,
-                                    void *data)
+static void
+neat_pvd_handle_newaddr(struct neat_ctx *nc,
+                        void *p_ptr,
+                        void *data)
 {
     if (LIST_EMPTY(&(nc->resolver->server_list))) {
         // No DNS servers
         return;
     }
 
-    struct neat_addr *src_addr = (struct neat_addr*) data;
     struct neat_resolver_server *dns_server;
-    char* reverse_ip = compute_reverse_ip(src_addr);
-    struct pvd_result* pvd_result;
+    struct pvd_result *pvd_result;
+    struct neat_addr *src_addr  = (struct neat_addr *) data;
+    char *reverse_ip            = compute_reverse_ip(src_addr);
 
     if ((pvd_result = (struct pvd_result *) malloc(sizeof(struct pvd_result))) == NULL) {
         neat_log(NEAT_LOG_ERROR,
@@ -394,19 +436,29 @@ static void neat_pvd_handle_newaddr(struct neat_ctx *nc,
         struct sockaddr_storage *dns_addr = &(dns_server->server_addr);
 
         struct pvd_dns_query *dns_query = malloc(sizeof(struct pvd_dns_query));
-        dns_query->loop = nc->loop;
-        dns_query->src_addr = src_addr;
-        dns_query->dns_addr = dns_addr;
-        dns_query->pvd_result = pvd_result;
+        dns_query->loop                 = nc->loop;
+        dns_query->src_addr             = src_addr;
+        dns_query->dns_addr             = dns_addr;
+        dns_query->pvd_result           = pvd_result;
 
         ldns_pkt *pkt;
-        if (ldns_pkt_query_new_frm_str(&pkt, reverse_ip, LDNS_RR_TYPE_PTR,
-                    LDNS_RR_CLASS_IN, LDNS_RD) != LDNS_STATUS_OK) {
+        if (ldns_pkt_query_new_frm_str(&pkt,
+                                       reverse_ip,
+                                       LDNS_RR_TYPE_PTR,
+                                       LDNS_RR_CLASS_IN, LDNS_RD)
+            != LDNS_STATUS_OK) {
             neat_log(NEAT_LOG_ERROR, "%s - Could not create DNS packet", __func__);
             continue;
         }
 
-        neat_pvd_dns_async(nc->loop, dns_addr, src_addr, pkt, neat_pvd_dns_alloc_cb, neat_pvd_dns_ptr_recv_cb, neat_pvd_dns_sent_cb, dns_query);
+        neat_pvd_dns_async(nc->loop,
+                           dns_addr,
+                           src_addr,
+                           pkt,
+                           neat_pvd_dns_alloc_cb,
+                           neat_pvd_dns_ptr_recv_cb,
+                           neat_pvd_dns_sent_cb,
+                           dns_query);
 
         // ldns_rdf_deep_free(dns_src);
         // ldns_resolver_deep_free(resolver);
@@ -426,8 +478,8 @@ neat_pvd_init(struct neat_ctx *nc)
 
     pvd->nc = nc;
 
-    pvd->newaddr_cb.event_cb = neat_pvd_handle_newaddr;
-    pvd->newaddr_cb.data = pvd;
+    pvd->newaddr_cb.event_cb    = neat_pvd_handle_newaddr;
+    pvd->newaddr_cb.data        = pvd;
     LIST_INIT(&(pvd->results));
 
     if (neat_add_event_cb(nc, NEAT_NEWADDR, &(pvd->newaddr_cb))) {

--- a/neat_pvd.c
+++ b/neat_pvd.c
@@ -19,6 +19,7 @@ char* compute_reverse_ip(struct neat_addr *src_addr) {
     uint8_t family = src_addr->family;
     char reverse_ip[80]; // maximum length for a reverse /128 IPv6
     int i;
+    char *out;
 
     if (family == AF_INET6) {
         // From fd17:625c:f037:2:a00:27ff:fe37:86b6/69 => _.pvd.8.0.7.3.0.f.c.5.2.6.7.1.d.f.ip6.arpa.
@@ -65,7 +66,11 @@ char* compute_reverse_ip(struct neat_addr *src_addr) {
         sprintf(reverse_ip + strlen(reverse_ip), "in-addr.arpa.");
     }
 
-    char *out = (char *) malloc(sizeof(char) * strlen(reverse_ip));
+    if ((out = (char *) malloc(sizeof(char) * strlen(reverse_ip))) == NULL) {
+        neat_log(NEAT_LOG_ERROR,
+                "%s: can't allocate buffer");
+        return NULL;
+    }
     strcpy(out, reverse_ip);
     return out;
 }
@@ -77,8 +82,13 @@ void add_pvd_to_addr(struct neat_addr* src_addr, ldns_rr_list *pvd_txt_list) {
     char* txt_record;
     ldns_rr *rr;
     ldns_rdf *dns_record = NULL;
+    struct pvd* pvd;
 
-    struct pvd* pvd = (struct pvd *) malloc(sizeof(struct pvd));
+    if ((pvd = (struct pvd *) malloc(sizeof(struct pvd))) == NULL) {
+        neat_log(NEAT_LOG_ERROR,
+                "%s: can't allocate buffer");
+        return;
+    }
     LIST_INIT(&pvd_infos);
 
     for (int i = 0; i < nb_txt; i++) {
@@ -92,7 +102,11 @@ void add_pvd_to_addr(struct neat_addr* src_addr, ldns_rr_list *pvd_txt_list) {
             txt_record++;
         }
 
-        pvd_info = (struct pvd_info *) malloc(sizeof(struct pvd_info));
+        if ((pvd_info = (struct pvd_info *) malloc(sizeof(struct pvd_info))) == NULL) {
+            neat_log(NEAT_LOG_ERROR,
+                    "%s: can't allocate buffer");
+            continue;
+        }
         pvd_info->key = strsep(&txt_record, "=");
         pvd_info->value = txt_record;
 

--- a/neat_pvd.c
+++ b/neat_pvd.c
@@ -5,6 +5,9 @@
 #include <netinet/in.h>
 #include <ldns/ldns.h>
 #include <arpa/inet.h>
+#ifdef __linux__
+    #include <net/if.h>
+#endif
 
 #include "neat.h"
 #include "neat_internal.h"
@@ -125,6 +128,203 @@ void add_pvd_result(struct pvds* pvds, ldns_rr_list *pvd_txt_list) {
     }
 }
 
+static int neat_pvd_dns_async(uv_loop_t* loop, struct sockaddr_storage *dns_addr, struct neat_addr *src_addr, ldns_pkt *pkt, uv_alloc_cb alloc_cb, uv_udp_recv_cb recv_cb, uv_udp_send_cb send_cb, void *data)
+{
+    struct sockaddr* dns_addr2 = (struct sockaddr*) dns_addr;
+    struct sockaddr_in *dst_addr4, *server_addr4;
+    struct sockaddr_in6 *dst_addr6, *server_addr6;
+
+    ldns_buffer *dns_snd_buf = calloc(sizeof(ldns_buffer), 1);
+    uv_buf_t *dns_uv_snd_buf = calloc(sizeof(uv_buf_t), 1);
+    uv_udp_send_t *dns_snd_handle = calloc(sizeof(uv_udp_send_t), 1);
+    uv_udp_t *resolve_handle = calloc(sizeof(uv_udp_t), 1);
+
+    ldns_pkt_set_random_id(pkt);
+    ldns_pkt_set_rd(pkt, 1);
+    ldns_pkt_set_ad(pkt, 1);
+
+    if (uv_udp_init(loop, resolve_handle)) {
+        //Closed is normally set in close_cb, but since we will never get that
+        //far, set it here instead
+        //pair->closed = 1;
+        neat_log(NEAT_LOG_ERROR, "%s - Failure to initialize UDP handle", __func__);
+        return 1;
+    }
+
+    resolve_handle->data = data;
+
+    if (uv_udp_bind(resolve_handle,
+                (struct sockaddr*) &(src_addr->u.generic.addr),
+                0)) {
+        neat_log(NEAT_LOG_ERROR, "%s - Failed to bind UDP socket", __func__);
+        return 1;
+    }
+
+    if (uv_udp_recv_start(resolve_handle, alloc_cb,
+                recv_cb)) {
+        neat_log(NEAT_LOG_ERROR, "%s - Failed to start receiving UDP", __func__);
+        return 1;
+    }
+
+    dns_snd_buf = ldns_buffer_new(LDNS_MIN_BUFLEN);
+    if (ldns_pkt2buffer_wire(dns_snd_buf, pkt) != LDNS_STATUS_OK) {
+        neat_log(NEAT_LOG_ERROR, "%s - Could not convert pkt to buf", __func__);
+        ldns_pkt_free(pkt);
+        return 1;
+    }
+
+    ldns_pkt_free(pkt);
+
+    dns_uv_snd_buf->base = (char*) ldns_buffer_begin(dns_snd_buf);
+    dns_uv_snd_buf->len = ldns_buffer_position(dns_snd_buf);
+
+    if (dns_addr2->sa_family == AF_INET) {
+        server_addr4 = (struct sockaddr_in*) dns_addr;
+        dst_addr4 = calloc(sizeof(struct sockaddr_in), 1);
+        dst_addr4->sin_family = AF_INET;
+        dst_addr4->sin_port = htons(LDNS_PORT);
+        dst_addr4->sin_addr = server_addr4->sin_addr;
+#ifdef HAVE_SIN_LEN
+        dst_addr4->sin_len = sizeof(struct sockaddr_in);
+#endif
+
+        if (uv_udp_send(dns_snd_handle, resolve_handle,
+                dns_uv_snd_buf, 1,
+                (const struct sockaddr*) dst_addr4,
+                send_cb)) {
+            neat_log(NEAT_LOG_ERROR, "%s - Failed to start DNS send", __func__);
+            return 1;
+        }
+    } else {
+        server_addr6 = (struct sockaddr_in6*) dns_addr;
+        dst_addr6 = calloc(sizeof(struct sockaddr_in6), 1);
+        dst_addr6->sin6_family = AF_INET6;
+        dst_addr6->sin6_port = htons(LDNS_PORT);
+        dst_addr6->sin6_addr = server_addr6->sin6_addr;
+#ifdef HAVE_SIN6_LEN
+        dst_addr6->sin6_len = sizeof(struct sockaddr_in6);
+#endif
+
+        if (uv_udp_send(dns_snd_handle, resolve_handle,
+                dns_uv_snd_buf, 1,
+                (const struct sockaddr*) dst_addr6,
+                send_cb)) {
+            neat_log(NEAT_LOG_ERROR, "%s - Failed to start DNS send", __func__);
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+//Called when a DNS request has been (i.e., passed to socket). We will send the
+//second query (used for checking poisoning) here. If that is needed
+static void neat_pvd_dns_sent_cb(uv_udp_send_t *req, int status)
+{
+}
+
+//libuv gives the user control of how memory is allocated. This callback is
+//called when a UDP packet is ready to received, and we have to fill out the
+//provided buf with the storage location (and available size)
+static void neat_pvd_dns_alloc_cb(uv_handle_t *handle,
+        size_t suggested_size, uv_buf_t *buf)
+{
+    char *dns_rcv_buf = calloc(sizeof(char), 1472);
+
+    buf->base = dns_rcv_buf;
+    buf->len = sizeof(char)*1472;
+}
+
+static void neat_pvd_dns_recv_cb(uv_udp_t* handle, ssize_t nread,
+        const uv_buf_t* buf, const struct sockaddr* addr, unsigned flags)
+{
+    struct pvd_result *pvd_result = handle->data;
+    ldns_pkt *dns_reply;
+    ldns_rr_list *pvd_txt_list = NULL;
+    size_t retval;
+
+    if (nread == 0 && addr == NULL) {
+        free(buf->base);
+        return;
+    }
+
+    retval = ldns_wire2pkt(&dns_reply, (const uint8_t*) buf->base, nread);
+    free(buf->base);
+
+    if (retval != LDNS_STATUS_OK)
+        return;
+
+    //Parse result
+    pvd_txt_list = ldns_pkt_rr_list_by_type(dns_reply, LDNS_RR_TYPE_TXT, LDNS_SECTION_ANSWER);
+
+    if (pvd_txt_list == NULL) {
+        ldns_pkt_free(dns_reply);
+        return;
+    }
+
+    add_pvd_result(&(pvd_result->pvds), pvd_txt_list);
+
+    ldns_rr_list_deep_free(pvd_txt_list);
+    ldns_pkt_free(dns_reply);
+}
+
+static void neat_pvd_dns_ptr_recv_cb(uv_udp_t* handle, ssize_t nread,
+        const uv_buf_t* buf, const struct sockaddr* addr, unsigned flags)
+{
+    struct pvd_dns_query *dns_query = handle->data;
+    ldns_pkt *dns_reply;
+    ldns_rr_list *pvd_ptr_list = NULL;
+    size_t retval;
+    int i;
+    ldns_rr *rr;
+    ldns_rdf *dns_record = NULL;
+    char* ptr_record;
+    char* dns_record_str;
+
+    if (nread == 0 && addr == NULL) {
+        free(buf->base);
+        return;
+    }
+
+    retval = ldns_wire2pkt(&dns_reply, (const uint8_t*) buf->base, nread);
+    free(buf->base);
+
+    if (retval != LDNS_STATUS_OK)
+        return;
+
+    //Parse result
+    pvd_ptr_list = ldns_pkt_rr_list_by_type(dns_reply, LDNS_RR_TYPE_PTR, LDNS_SECTION_ANSWER);
+
+    if (pvd_ptr_list == NULL) {
+        ldns_pkt_free(dns_reply);
+        return;
+    }
+
+    int nb_ptr = ldns_rr_list_rr_count(pvd_ptr_list);
+
+    // There can be multiple PvDs
+    for (i = 0; i < nb_ptr; i++) {
+        rr = ldns_rr_list_rr(pvd_ptr_list, i);
+        dns_record = ldns_rr_set_rdf(rr, NULL, 0);
+        dns_record_str = ldns_rdf2str(dns_record);
+        ptr_record = strdup(dns_record_str);
+
+        ldns_pkt *pkt;
+        if (ldns_pkt_query_new_frm_str(&pkt, ptr_record, LDNS_RR_TYPE_TXT,
+                    LDNS_RR_CLASS_IN, LDNS_RD) != LDNS_STATUS_OK) {
+            neat_log(NEAT_LOG_ERROR, "%s - Could not create DNS packet", __func__);
+            continue;
+        }
+        free(dns_record_str);
+        free(ptr_record);
+
+        neat_pvd_dns_async(dns_query->loop, dns_query->dns_addr, dns_query->src_addr, pkt, neat_pvd_dns_alloc_cb, neat_pvd_dns_recv_cb, neat_pvd_dns_sent_cb, dns_query->pvd_result);
+    }
+
+     ldns_rr_list_deep_free(pvd_ptr_list);
+     ldns_pkt_free(dns_reply);
+}
+
 static void neat_pvd_handle_newaddr(struct neat_ctx *nc,
                                     void *p_ptr,
                                     void *data)
@@ -134,23 +334,9 @@ static void neat_pvd_handle_newaddr(struct neat_ctx *nc,
         return;
     }
 
-    struct in_addr dns_addr4;
-    struct in6_addr dns_addr6;
     struct neat_addr *src_addr = (struct neat_addr*) data;
     struct neat_resolver_server *dns_server;
-    int i, nb_ptr;
-    ldns_resolver *resolver;
-    ldns_rdf *domain;
-    ldns_rdf *dns_src;
-    ldns_rdf *ptr;
-    ldns_pkt *p;
-    ldns_rr_list *pvd_txt_list;
-    ldns_rr_list *pvd_ptr_list;
-    ldns_rr *rr;
-    ldns_rdf *dns_record = NULL;
-    char* ptr_record;
     char* reverse_ip = compute_reverse_ip(src_addr);
-    char* dns_record_str;
     struct pvd_result* pvd_result;
 
     if ((pvd_result = (struct pvd_result *) malloc(sizeof(struct pvd_result))) == NULL) {
@@ -173,61 +359,25 @@ static void neat_pvd_handle_newaddr(struct neat_ctx *nc,
         }
 
         struct sockaddr_storage *dns_addr = &(dns_server->server_addr);
-        if (dns_addr->ss_family == AF_INET6) {
-            dns_addr6 = ((struct sockaddr_in6*) dns_addr)->sin6_addr;
-            dns_src = ldns_rdf_new_frm_data(LDNS_RDF_TYPE_AAAA, 16, &dns_addr6);
-        } else if (dns_addr->ss_family == AF_INET) {
-            dns_addr4 = ((struct sockaddr_in*) dns_addr)->sin_addr;
-            dns_src = ldns_rdf_new_frm_data(LDNS_RDF_TYPE_A, 4, &dns_addr4);
-        } else {
+
+        struct pvd_dns_query *dns_query = malloc(sizeof(struct pvd_dns_query));
+        dns_query->loop = nc->loop;
+        dns_query->src_addr = src_addr;
+        dns_query->dns_addr = dns_addr;
+        dns_query->pvd_result = pvd_result;
+
+        ldns_pkt *pkt;
+        if (ldns_pkt_query_new_frm_str(&pkt, reverse_ip, LDNS_RR_TYPE_PTR,
+                    LDNS_RR_CLASS_IN, LDNS_RD) != LDNS_STATUS_OK) {
+            neat_log(NEAT_LOG_ERROR, "%s - Could not create DNS packet", __func__);
             continue;
         }
 
-        domain = ldns_dname_new_frm_str(reverse_ip);
-        resolver = ldns_resolver_new();
-        ldns_resolver_push_nameserver(resolver, dns_src);
+        neat_pvd_dns_async(nc->loop, dns_addr, src_addr, pkt, neat_pvd_dns_alloc_cb, neat_pvd_dns_ptr_recv_cb, neat_pvd_dns_sent_cb, dns_query);
 
-        // Performing DNS query to 'dns_addr', for PTR records of 'reverse_ip'
-        p = ldns_resolver_query(resolver, domain, LDNS_RR_TYPE_PTR, LDNS_RR_CLASS_IN, LDNS_RD);
-        ldns_rdf_deep_free(domain);
-        if (!p)  {
-            continue;
-        }
-        pvd_ptr_list = ldns_pkt_rr_list_by_type(p, LDNS_RR_TYPE_PTR, LDNS_SECTION_ANSWER);
-        ldns_pkt_free(p);
-        ldns_rr_list_sort(pvd_ptr_list);
-        nb_ptr = ldns_rr_list_rr_count(pvd_ptr_list);
-
-        // There can be multiple PvDs
-        for (i = 0; i < nb_ptr; i++) {
-            rr = ldns_rr_list_rr(pvd_ptr_list, i);
-            dns_record = ldns_rr_set_rdf(rr, NULL, 0);
-            dns_record_str = ldns_rdf2str(dns_record);
-            ptr_record = strdup(dns_record_str);
-            ptr = ldns_dname_new_frm_str(ptr_record);
-
-            // Performing DNS query to 'dns_addr' for TXT records of 'ptr'
-            p = ldns_resolver_query(resolver, ptr, LDNS_RR_TYPE_TXT, LDNS_RR_CLASS_IN, LDNS_RD);
-            ldns_rdf_deep_free(ptr);
-            free(dns_record_str);
-            free(ptr_record);
-            // ldns_rr_list_free(rr);
-            // ldns_rr_free(dns_record);
-            if (!p)  {
-                continue;
-            }
-            pvd_txt_list = ldns_pkt_rr_list_by_type(p, LDNS_RR_TYPE_TXT, LDNS_SECTION_ANSWER);
-            ldns_pkt_free(p);
-            ldns_rr_list_sort(pvd_txt_list);
-
-            // Adding txt records as new pvd record to src_addr
-            add_pvd_result(&(pvd_result->pvds), pvd_txt_list);
-            ldns_rr_list_deep_free(pvd_txt_list);
-        }
-
-        ldns_rdf_deep_free(dns_src);
-        ldns_resolver_deep_free(resolver);
-        ldns_rr_list_deep_free(pvd_ptr_list);
+        // ldns_rdf_deep_free(dns_src);
+        // ldns_resolver_deep_free(resolver);
+        // ldns_rr_list_deep_free(pvd_ptr_list);
     }
     free(reverse_ip);
 

--- a/neat_pvd.c
+++ b/neat_pvd.c
@@ -67,7 +67,7 @@ char* compute_reverse_ip(struct neat_addr *src_addr) {
         sprintf(reverse_ip + strlen(reverse_ip), "in-addr.arpa.");
     }
 
-    if ((out = (char *) malloc(sizeof(char) * strlen(reverse_ip))) == NULL) {
+    if ((out = (char *) malloc(sizeof(char) * (strlen(reverse_ip)+1))) == NULL) {
         neat_log(NEAT_LOG_ERROR,
                 "%s: can't allocate buffer");
         return NULL;
@@ -81,11 +81,13 @@ void add_pvd_to_addr(struct neat_addr* src_addr, ldns_rr_list *pvd_txt_list) {
     struct pvd_infos pvd_infos;
     struct pvd_info* pvd_info;
     char* txt_record;
+    char* dns_record_str;
     ldns_rr *rr;
     ldns_rdf *dns_record = NULL;
     struct pvd* pvd;
 
     if ((pvd = (struct pvd *) malloc(sizeof(struct pvd))) == NULL) {
+        free(pvd);
         neat_log(NEAT_LOG_ERROR,
                 "%s: can't allocate buffer");
         return;
@@ -95,13 +97,16 @@ void add_pvd_to_addr(struct neat_addr* src_addr, ldns_rr_list *pvd_txt_list) {
     for (int i = 0; i < nb_txt; i++) {
         rr = ldns_rr_list_rr(pvd_txt_list, i);
         dns_record = ldns_rr_set_rdf(rr, NULL, 0);
-        txt_record = strdup(ldns_rdf2str(dns_record));
+        dns_record_str = ldns_rdf2str(dns_record);
+        txt_record = strdup(dns_record_str);
 
         // Removing quotes if any
         if (txt_record[0] == '"' && txt_record[strlen(txt_record)-1] == '"') {
             txt_record[strlen(txt_record)-1] = 0;
             txt_record++;
         }
+
+        free(dns_record_str);
 
         if ((pvd_info = (struct pvd_info *) malloc(sizeof(struct pvd_info))) == NULL) {
             neat_log(NEAT_LOG_ERROR,
@@ -118,8 +123,6 @@ void add_pvd_to_addr(struct neat_addr* src_addr, ldns_rr_list *pvd_txt_list) {
         pvd->infos = pvd_infos;
         LIST_INSERT_HEAD(&(src_addr->pvds), pvd, next_pvd);
     }
-
-    ldns_rr_list_deep_free(pvd_txt_list);
 }
 
 static void neat_pvd_handle_newaddr(struct neat_ctx *nc,
@@ -147,6 +150,7 @@ static void neat_pvd_handle_newaddr(struct neat_ctx *nc,
     ldns_rdf *dns_record = NULL;
     char* ptr_record;
     char* reverse_ip = compute_reverse_ip(src_addr);
+    char* dns_record_str;
 
     if (strlen(reverse_ip) == 0) {
         return;
@@ -190,12 +194,17 @@ static void neat_pvd_handle_newaddr(struct neat_ctx *nc,
         for (i = 0; i < nb_ptr; i++) {
             rr = ldns_rr_list_rr(pvd_ptr_list, i);
             dns_record = ldns_rr_set_rdf(rr, NULL, 0);
-            ptr_record = strdup(ldns_rdf2str(dns_record));
+            dns_record_str = ldns_rdf2str(dns_record);
+            ptr_record = strdup(dns_record_str);
             ptr = ldns_dname_new_frm_str(ptr_record);
 
             // Performing DNS query to 'dns_addr' for TXT records of 'ptr'
             p = ldns_resolver_query(resolver, ptr, LDNS_RR_TYPE_TXT, LDNS_RR_CLASS_IN, LDNS_RD);
             ldns_rdf_deep_free(ptr);
+            free(dns_record_str);
+            free(ptr_record);
+            // ldns_rr_list_free(rr);
+            // ldns_rr_free(dns_record);
             if (!p)  {
                 continue;
             }
@@ -205,11 +214,12 @@ static void neat_pvd_handle_newaddr(struct neat_ctx *nc,
 
             // Adding txt records as new pvd record to src_addr
             add_pvd_to_addr(src_addr, pvd_txt_list);
+            ldns_rr_list_deep_free(pvd_txt_list);
         }
 
         ldns_rdf_deep_free(dns_src);
-        // ldns_rdf_deep_free(dns_record);
         ldns_resolver_deep_free(resolver);
+        ldns_rr_list_deep_free(pvd_ptr_list);
     }
 }
 

--- a/neat_pvd.c
+++ b/neat_pvd.c
@@ -229,6 +229,7 @@ static void neat_pvd_handle_newaddr(struct neat_ctx *nc,
         ldns_resolver_deep_free(resolver);
         ldns_rr_list_deep_free(pvd_ptr_list);
     }
+    free(reverse_ip);
 
     LIST_INSERT_HEAD(&(nc->pvd->results), pvd_result, next_result);
 }

--- a/neat_pvd.c
+++ b/neat_pvd.c
@@ -2,18 +2,200 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <netinet/in.h>
+#include <ldns/ldns.h>
+#include <arpa/inet.h>
 
 #include "neat.h"
 #include "neat_internal.h"
 #include "neat_resolver.h"
 #include "neat_core.h"
 #include "neat_pvd.h"
+#include "neat_addr.h"
+
+char* compute_reverse_ip(struct neat_addr *src_addr) {
+    struct in_addr src_addr4;
+    struct in6_addr src_addr6;
+    uint8_t family = src_addr->family;
+    char reverse_ip[80]; // maximum length for a reverse /128 IPv6
+    int i;
+
+    if (family == AF_INET6) {
+        // From fd17:625c:f037:2:a00:27ff:fe37:86b6/69 => _.pvd.8.0.7.3.0.f.c.5.2.6.7.1.d.f.ip6.arpa.
+        src_addr6 = (src_addr->u.v6.addr6).sin6_addr;
+        sprintf(reverse_ip, "_.pvd.");
+        int addr_last_part = src_addr->prefix_length & 4;
+        int addr_total_hex = src_addr->prefix_length >> 2;
+        int string_offset = 6;
+        int current_hex;
+        i = addr_total_hex-1;
+
+        // if the prefix length is not multiple of 4
+        if (addr_last_part != 0) {
+            int last_index = addr_total_hex / 2;
+            bool divide = (addr_total_hex % 2) == 0;
+            if (divide) {
+                current_hex = src_addr6.s6_addr[last_index] >> 4;
+            } else {
+                current_hex = src_addr6.s6_addr[last_index] & 0x0f;
+            }
+            current_hex = current_hex - (current_hex % (1 << (4 - addr_last_part)));
+            sprintf(reverse_ip+string_offset, "%01x.", current_hex);
+            string_offset = string_offset + 2;
+        }
+        for (i = i; i >= 0; i--) {
+            if (i % 2 == 0) {
+                current_hex = src_addr6.s6_addr[i/2] >> 4;
+            } else {
+                current_hex = src_addr6.s6_addr[i/2] & 0x0f;
+            }
+            sprintf(reverse_ip + string_offset + 2*(addr_total_hex - 1 - i), "%01x.", current_hex);
+        }
+        sprintf(reverse_ip + string_offset + 2*addr_total_hex, "ip6.arpa.");
+    } else if (family == AF_INET) {
+        // From 192.168.145.2/19 => _.pvd.128.168.192.in-addr.arpa.
+        src_addr4 = (src_addr->u.v4.addr4).sin_addr;
+        uint32_t src_addr4_prefix = src_addr4.s_addr & ((1 << src_addr->prefix_length) - 1);
+
+        sprintf(reverse_ip, "_.pvd.");
+        for (i = ((src_addr->prefix_length >> 3) << 3) - 8; i >= 0; i -= 8) {
+            sprintf(reverse_ip + strlen(reverse_ip), "%u.", ((src_addr4_prefix & (0xff << i)) >> i));
+        }
+
+        sprintf(reverse_ip + strlen(reverse_ip), "in-addr.arpa.");
+    }
+
+    char *out = (char *) malloc(sizeof(char) * strlen(reverse_ip));
+    strcpy(out, reverse_ip);
+    return out;
+}
+
+void add_pvd_to_addr(struct neat_addr* src_addr, ldns_rr_list *pvd_txt_list) {
+    int nb_txt = ldns_rr_list_rr_count(pvd_txt_list);
+    struct pvd_infos pvd_infos;
+    struct pvd_info* pvd_info;
+    char* txt_record;
+    ldns_rr *rr;
+    ldns_rdf *dns_record = NULL;
+
+    struct pvd* pvd = (struct pvd *) malloc(sizeof(struct pvd));
+    LIST_INIT(&pvd_infos);
+
+    for (int i = 0; i < nb_txt; i++) {
+        rr = ldns_rr_list_rr(pvd_txt_list, i);
+        dns_record = ldns_rr_set_rdf(rr, NULL, 0);
+        txt_record = strdup(ldns_rdf2str(dns_record));
+
+        // Removing quotes if any
+        if (txt_record[0] == '"' && txt_record[strlen(txt_record)-1] == '"') {
+            txt_record[strlen(txt_record)-1] = 0;
+            txt_record++;
+        }
+
+        pvd_info = (struct pvd_info *) malloc(sizeof(struct pvd_info));
+        pvd_info->key = strsep(&txt_record, "=");
+        pvd_info->value = txt_record;
+
+        LIST_INSERT_HEAD(&(pvd_infos), pvd_info, next_info);
+    }
+
+    if (nb_txt > 0) {
+        pvd->infos = pvd_infos;
+        LIST_INSERT_HEAD(&(src_addr->pvds), pvd, next_pvd);
+    }
+
+    ldns_rr_list_deep_free(pvd_txt_list);
+}
 
 static void neat_pvd_handle_newaddr(struct neat_ctx *nc,
-                                         void *p_ptr,
-                                         void *data)
+                                    void *p_ptr,
+                                    void *data)
 {
+    if (LIST_EMPTY(&(nc->resolver->server_list))) {
+        // No DNS servers
+        return;
+    }
 
+    struct in_addr dns_addr4;
+    struct in6_addr dns_addr6;
+    struct neat_addr *src_addr = (struct neat_addr*) data;
+    struct neat_resolver_server *dns_server;
+    int i, nb_ptr;
+    ldns_resolver *resolver;
+    ldns_rdf *domain;
+    ldns_rdf *dns_src;
+    ldns_rdf *ptr;
+    ldns_pkt *p;
+    ldns_rr_list *pvd_txt_list;
+    ldns_rr_list *pvd_ptr_list;
+    ldns_rr *rr;
+    ldns_rdf *dns_record = NULL;
+    char* ptr_record;
+    char* reverse_ip = compute_reverse_ip(src_addr);
+
+    if (strlen(reverse_ip) == 0) {
+        return;
+    }
+
+    LIST_INIT(&(src_addr->pvds));
+
+    LIST_FOREACH(dns_server, &(nc->resolver->server_list), next_server) {
+        // Avoid static servers
+        if (dns_server->mark != NEAT_RESOLVER_SERVER_ACTIVE) {
+            continue;
+        }
+
+        struct sockaddr_storage *dns_addr = &(dns_server->server_addr);
+        if (dns_addr->ss_family == AF_INET6) {
+            dns_addr6 = ((struct sockaddr_in6*) dns_addr)->sin6_addr;
+            dns_src = ldns_rdf_new_frm_data(LDNS_RDF_TYPE_AAAA, 16, &dns_addr6);
+        } else if (dns_addr->ss_family == AF_INET) {
+            dns_addr4 = ((struct sockaddr_in*) dns_addr)->sin_addr;
+            dns_src = ldns_rdf_new_frm_data(LDNS_RDF_TYPE_A, 4, &dns_addr4);
+        } else {
+            continue;
+        }
+
+        domain = ldns_dname_new_frm_str(reverse_ip);
+        resolver = ldns_resolver_new();
+        ldns_resolver_push_nameserver(resolver, dns_src);
+
+        // Performing DNS query to 'dns_addr', for PTR records of 'reverse_ip'
+        p = ldns_resolver_query(resolver, domain, LDNS_RR_TYPE_PTR, LDNS_RR_CLASS_IN, LDNS_RD);
+        ldns_rdf_deep_free(domain);
+        if (!p)  {
+            continue;
+        }
+        pvd_ptr_list = ldns_pkt_rr_list_by_type(p, LDNS_RR_TYPE_PTR, LDNS_SECTION_ANSWER);
+        ldns_pkt_free(p);
+        ldns_rr_list_sort(pvd_ptr_list);
+        nb_ptr = ldns_rr_list_rr_count(pvd_ptr_list);
+
+        // There can be multiple PvDs
+        for (i = 0; i < nb_ptr; i++) {
+            rr = ldns_rr_list_rr(pvd_ptr_list, i);
+            dns_record = ldns_rr_set_rdf(rr, NULL, 0);
+            ptr_record = strdup(ldns_rdf2str(dns_record));
+            ptr = ldns_dname_new_frm_str(ptr_record);
+
+            // Performing DNS query to 'dns_addr' for TXT records of 'ptr'
+            p = ldns_resolver_query(resolver, ptr, LDNS_RR_TYPE_TXT, LDNS_RR_CLASS_IN, LDNS_RD);
+            ldns_rdf_deep_free(ptr);
+            if (!p)  {
+                continue;
+            }
+            pvd_txt_list = ldns_pkt_rr_list_by_type(p, LDNS_RR_TYPE_TXT, LDNS_SECTION_ANSWER);
+            ldns_pkt_free(p);
+            ldns_rr_list_sort(pvd_txt_list);
+
+            // Adding txt records as new pvd record to src_addr
+            add_pvd_to_addr(src_addr, pvd_txt_list);
+        }
+
+        ldns_rdf_deep_free(dns_src);
+        // ldns_rdf_deep_free(dns_record);
+        ldns_resolver_deep_free(resolver);
+    }
 }
 
 struct neat_pvd *

--- a/neat_pvd.h
+++ b/neat_pvd.h
@@ -8,6 +8,7 @@
     #include <inaddr.h>
     #include <in6addr.h>
 #endif
+#include <ldns/ldns.h>
 
 #include "neat_queue.h"
 
@@ -46,6 +47,16 @@ struct pvd_dns_query {
     struct neat_addr *src_addr;
     struct sockaddr_storage *dns_addr;
     struct pvd_result *pvd_result;
+};
+
+struct pvd_async_query {
+    void *data;
+    ldns_buffer *dns_snd_buf;
+    uv_buf_t *dns_uv_snd_buf;
+    uv_udp_send_t *dns_snd_handle;
+    uv_udp_t *resolve_handle;
+    struct sockaddr_in *dst_addr4;
+    struct sockaddr_in6 *dst_addr6;
 };
 
 struct neat_pvd {

--- a/neat_pvd.h
+++ b/neat_pvd.h
@@ -1,0 +1,26 @@
+#ifndef NEAT_PVD_H
+#define NEAT_PVD_H
+
+#include <stdint.h>
+#ifdef __linux__
+    #include <netinet/in.h>
+#elif _WIN32
+    #include <inaddr.h>
+    #include <in6addr.h>
+#endif
+
+#include "neat_queue.h"
+
+struct neat_ctx;
+
+struct neat_pvd {
+    struct neat_ctx *nc;
+    struct neat_event_cb newaddr_cb;
+};
+
+//Add/remove addresses from src. address list
+// void neat_addr_update_src_list(struct neat_ctx *nc,
+//         struct sockaddr_storage *src_addr, uint32_t if_idx,
+//         uint8_t newaddr, uint32_t ifa_pref, uint32_t ifa_valid);
+
+#endif

--- a/neat_pvd.h
+++ b/neat_pvd.h
@@ -57,12 +57,18 @@ struct pvd_async_query {
     uv_udp_t *resolve_handle;
     struct sockaddr_in *dst_addr4;
     struct sockaddr_in6 *dst_addr6;
+    struct neat_pvd *pvd;
+    LIST_ENTRY(pvd_async_query) next_query;
 };
+
+struct pvd_async_query;
+LIST_HEAD(pvd_async_queries, pvd_async_query);
 
 struct neat_pvd {
     struct neat_ctx *nc;
     struct neat_event_cb newaddr_cb;
     struct pvd_results results;
+    struct pvd_async_queries queries;
 };
 //Add/remove addresses from src. address list
 // void neat_addr_update_src_list(struct neat_ctx *nc,

--- a/neat_pvd.h
+++ b/neat_pvd.h
@@ -12,11 +12,7 @@
 #include "neat_queue.h"
 
 struct neat_ctx;
-
-struct neat_pvd {
-    struct neat_ctx *nc;
-    struct neat_event_cb newaddr_cb;
-};
+struct neat_addr;
 
 struct pvd_infos;
 LIST_HEAD(pvd_infos, pvd_info);
@@ -36,6 +32,20 @@ struct pvd {
 struct pvds;
 LIST_HEAD(pvds, pvd);
 
+struct pvd_result {
+    struct neat_addr* src_addr;
+    struct pvds pvds;
+    LIST_ENTRY(pvd_result) next_result;
+};
+
+struct pvd_results;
+LIST_HEAD(pvd_results, pvd_result);
+
+struct neat_pvd {
+    struct neat_ctx *nc;
+    struct neat_event_cb newaddr_cb;
+    struct pvd_results results;
+};
 //Add/remove addresses from src. address list
 // void neat_addr_update_src_list(struct neat_ctx *nc,
 //         struct sockaddr_storage *src_addr, uint32_t if_idx,

--- a/neat_pvd.h
+++ b/neat_pvd.h
@@ -41,6 +41,13 @@ struct pvd_result {
 struct pvd_results;
 LIST_HEAD(pvd_results, pvd_result);
 
+struct pvd_dns_query {
+    uv_loop_t* loop;
+    struct neat_addr *src_addr;
+    struct sockaddr_storage *dns_addr;
+    struct pvd_result *pvd_result;
+};
+
 struct neat_pvd {
     struct neat_ctx *nc;
     struct neat_event_cb newaddr_cb;

--- a/neat_pvd.h
+++ b/neat_pvd.h
@@ -18,6 +18,24 @@ struct neat_pvd {
     struct neat_event_cb newaddr_cb;
 };
 
+struct pvd_infos;
+LIST_HEAD(pvd_infos, pvd_info);
+
+struct pvd_info {
+    char* key;
+    char* value;
+    LIST_ENTRY(pvd_info) next_info;
+};
+
+struct pvd {
+    struct pvd_infos infos;
+    LIST_ENTRY(pvd) next_pvd;
+    // Eventually an identifier
+};
+
+struct pvds;
+LIST_HEAD(pvds, pvd);
+
 //Add/remove addresses from src. address list
 // void neat_addr_update_src_list(struct neat_ctx *nc,
 //         struct sockaddr_storage *src_addr, uint32_t if_idx,


### PR DESCRIPTION
Here is my proposition to add PvD over DNS support to NEAT, according to [draft-stenberg-mif-mpvd-dns-00](https://tools.ietf.org/html/draft-stenberg-mif-mpvd-dns-00).

I had to store the `prefix_length` of an address, and PvD information in `struct neat_addr`.

When a new address becomes available, `neat_pvd.c:neat_pvd_handle_newaddr(...)` is called. It sends a PTR request to every DNS server, and for each answer sends a request for TXT records matching the answer. As specified in [draft-stenberg-mif-mpvd-dns-00](https://tools.ietf.org/html/draft-stenberg-mif-mpvd-dns-00#section-3.2.1) each TXT record is a piece of information (format is `key=value`) which is added to a `struct pvd_infos` which at the end is added to the list of PvDs attached to an address (`neat_addr.pvds`).

It is my first contribution to the project, so don't hesitate to make comments.


Here is an example of output in debug mode:
```
[INF] Available src-addresses:
[INF] 	IPv6: fd17:625d:a138:2:a00:27ff::86b6/64 pref 4294967295 valid 4294967295
[INF] 	IPv6: 2001:db8:bad:a55::198/64 pref 0 valid 4294967295
[INF] 		PVD:
[INF] 			r => 2001:db8:bad:a55::2
[INF] 			z => neat.eu
[INF] 		PVD:
[INF] 			z => cisco.com,mail.cisco.com
[INF] 			6 => 2001:db8:bad:a55::/64
[INF] 	IPv4: 192.168.55.198/24
[INF] 		PVD:
[INF] 			r => 2001:db8:bad:a55::2
[INF] 			z => neat.eu
[INF] 		PVD:
[INF] 			s => (null)
[INF] 	IPv4: 10.0.2.15/24
```