### PR TITLE
Support for multistreaming with SCTP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ SET(CMAKE_MACOSX_RPATH 1)
 LIST(APPEND neat_headers
     neat.h
     neat_queue.h
+    neat_tlv.h
 )
 
 LIST(APPEND neat_sources

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,6 @@ SET(CMAKE_MACOSX_RPATH 1)
 LIST(APPEND neat_headers
     neat.h
     neat_queue.h
-    neat_tlv.h
 )
 
 LIST(APPEND neat_sources

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,11 +2,13 @@
 #################################################
 LIST(APPEND neat_programs
     client.c
+    client_multi.c
     client_http_get.c
     server_chargen.c
     server_daytime.c
     server_discard.c
     server_echo.c
+    server_echo_multi.c
     tneat.c
 )
 

--- a/examples/client_multi.c
+++ b/examples/client_multi.c
@@ -1,0 +1,532 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <uv.h>
+#include "../neat.h"
+#include "../neat_internal.h"
+
+/**********************************************************************
+
+    simple neat client
+
+    * connect to HOST and PORT
+    * read from stdin and send data to HOST
+    * write received data from peer to stdout
+
+    client [OPTIONS] HOST PORT
+    -P : neat properties
+    -R : receive buffer in byte
+    -S : send buffer in byte
+    -v : log level (0 .. 2)
+    -A : set primary destination address
+    
+**********************************************************************/
+
+static uint32_t config_rcv_buffer_size = 256;
+static uint32_t config_snd_buffer_size = 128;
+static uint16_t config_log_level = 1;
+static char *config_primary_dest_addr = NULL;
+static char config_property[] = "NEAT_PROPERTY_TCP_REQUIRED,NEAT_PROPERTY_IPV4_REQUIRED";
+
+struct std_buffer {
+    unsigned char *buffer;
+    uint32_t buffer_filled;
+};
+
+static struct neat_flow_operations ops;
+static struct std_buffer stdin_buffer;
+static struct neat_ctx *ctx = NULL;
+static struct neat_flow *flow = NULL;
+static unsigned char *buffer_rcv = NULL;
+static unsigned char *buffer_snd= NULL;
+static uv_tty_t tty;
+
+void tty_read(uv_stream_t *stream, ssize_t bytes_read, const uv_buf_t *buffer);
+void tty_alloc(uv_handle_t *handle, size_t suggested, uv_buf_t *buf);
+static neat_error_code on_all_written(struct neat_flow_operations *opCB);
+
+/*
+    Print usage and exit
+*/
+static void print_usage()
+{
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    printf("client [OPTIONS] HOST PORT\n");
+    printf("\t- P \tneat properties (%s)\n", config_property);
+    printf("\t- R \treceive buffer in byte (%d)\n", config_rcv_buffer_size);
+    printf("\t- S \tsend buffer in byte (%d)\n", config_snd_buffer_size);
+    printf("\t- v \tlog level 0..2 (%d)\n", config_log_level);
+    printf("\t- A \tprimary dest. addr. (auto)\n");
+}
+
+/*
+    Error handler
+*/
+static neat_error_code on_error(struct neat_flow_operations *opCB)
+{
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    exit(EXIT_FAILURE);
+}
+
+/*
+    Abort handler
+*/
+static neat_error_code on_abort(struct neat_flow_operations *opCB)
+{
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    fprintf(stderr, "The flow was aborted!\n");
+
+    exit(EXIT_FAILURE);
+}
+
+/*
+    Network change handler
+*/
+static neat_error_code on_network_changed(struct neat_flow_operations *opCB)
+{
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    if (config_log_level >= 1) {
+	fprintf(stderr, "Something happened in the network: %d\n", (int)opCB->status);
+    }
+
+    return NEAT_OK;
+}
+
+
+/*
+    Read data from neat
+*/
+static neat_error_code on_readable(struct neat_flow_operations *opCB)
+{
+    // data is available to read
+    uint32_t buffer_filled;
+    neat_error_code code;
+
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    code = neat_read(opCB->ctx, opCB->flow, buffer_rcv, config_rcv_buffer_size, &buffer_filled);
+    if (code != NEAT_OK) {
+        if (code == NEAT_ERROR_WOULD_BLOCK) {
+            if (config_log_level >= 1) {
+                fprintf(stderr, "%s - neat_read - NEAT_ERROR_WOULD_BLOCK\n", __func__);
+            }
+            return NEAT_OK;
+        } else {
+            fprintf(stderr, "%s - neat_read - error: %d\n", __func__, (int)code);
+            return on_error(opCB);
+        }
+    }
+
+    // all fine
+    if (buffer_filled > 0) {
+        if (config_log_level >= 1) {
+            if (opCB->stream_id != -1) {
+                fprintf(stderr, "%s - received %d bytes on stream %d\n", __func__, buffer_filled, opCB->stream_id);
+            } else {
+                fprintf(stderr, "%s - received %d bytes\n", __func__, buffer_filled);
+            }
+        }
+
+        fwrite(buffer_rcv, sizeof(char), buffer_filled, stdout);
+        fflush(stdout);
+
+    } else {
+        if (config_log_level >= 1) {
+            fprintf(stderr, "%s - disconnected\n", __func__);
+        }
+        ops.on_readable = NULL;
+        ops.on_writable = NULL;
+        neat_set_operations(ctx, flow, &ops);
+        neat_stop_event_loop(opCB->ctx);
+    }
+
+    return NEAT_OK;
+}
+
+/*
+    Send data from stdin
+*/
+static neat_error_code on_writable(struct neat_flow_operations *opCB)
+{
+    static int message_number = 0;
+    static int last_message_number = 0;
+    neat_error_code code;
+    unsigned char buf[64];
+    int len;
+
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    switch (opCB->stream_id) {
+        case 0:
+            if (message_number > last_message_number) {
+                break;
+            }
+            code = neat_write_ex(opCB->ctx, opCB->flow, stdin_buffer.buffer, stdin_buffer.buffer_filled, 0);
+            if (code != NEAT_OK) {
+                fprintf(stderr, "%s - neat_write_ex - error: %d\n", __func__, (int)code);
+                return on_error(opCB);
+            }
+
+            if (config_log_level >= 1) {
+                fprintf(stderr, "%s - sent %d bytes\n", __func__, stdin_buffer.buffer_filled);
+            }
+
+            message_number++;
+            break;
+        case 1:
+            if (message_number <= last_message_number) {
+                break;
+            }
+
+            last_message_number = message_number;
+
+            len = snprintf((char*)buf, 64, "Sent message number %d\n", message_number);
+
+            code = neat_write_ex(opCB->ctx, opCB->flow, buf, len, 1);
+            if (code != NEAT_OK) {
+                fprintf(stderr, "%s - neat_write_ex - error: %d\n", __func__, (int)code);
+                return on_error(opCB);
+            }
+
+            // stop writing
+            ops.on_writable = NULL;
+            neat_set_operations(ctx, flow, &ops);
+
+            break;
+        default:
+            fprintf(stderr, "Illegal stream id %d passed to on_writable\n", opCB->stream_id);
+            return NEAT_ERROR_BAD_ARGUMENT;
+    }
+
+    return NEAT_OK;
+}
+
+static neat_error_code on_all_written(struct neat_flow_operations *opCB)
+{
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    // data sent completely - continue reading from stdin
+    uv_read_start((uv_stream_t*) &tty, tty_alloc, tty_read);
+    return NEAT_OK;
+}
+
+static neat_error_code on_connected(struct neat_flow_operations *opCB)
+{
+    int rc;
+
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    uv_tty_init(ctx->loop, &tty, 0, 1);
+    uv_read_start((uv_stream_t*) &tty, tty_alloc, tty_read);
+
+    ops.on_readable = on_readable;
+    neat_set_operations(ctx, flow, &ops);
+
+    if (config_primary_dest_addr != NULL) {
+	rc = neat_set_primary_dest(ctx, flow, config_primary_dest_addr);
+	if (rc) {
+	    fprintf(stderr, "Failed to set primary dest. addr.: %u\n", rc);
+	} else {
+	    if (config_log_level > 1)
+		fprintf(stderr, "Primary dest. addr. set to: '%s'.\n",
+			config_primary_dest_addr);
+	}
+    }
+
+    return NEAT_OK;
+}
+
+static neat_error_code on_close(struct neat_flow_operations *opCB)
+{
+  if (config_log_level >= 2) {
+    fprintf(stderr, "%s()\n", __func__);
+  }
+
+  fprintf(stderr, "%s - flow closed OK!\n", __func__);
+
+  return NEAT_OK;
+}
+
+/*
+    Read from stdin
+*/
+void tty_read(uv_stream_t *stream, ssize_t buffer_filled, const uv_buf_t *buffer)
+{
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    if (config_log_level >= 1) {
+        fprintf(stderr, "%s - tty_read called with buffer_filled %zd\n", __func__, buffer_filled);
+    }
+
+    // error case
+    if (buffer_filled == UV_EOF) {
+        if (config_log_level >= 1) {
+            fprintf(stderr, "%s - tty_read - UV_EOF\n", __func__);
+        }
+        uv_read_stop(stream);
+        ops.on_writable = NULL;
+        neat_set_operations(ctx, flow, &ops);
+        neat_shutdown(ctx, flow);
+    } else if (strncmp(buffer->base, "close\n", buffer_filled) == 0) {
+	if (config_log_level >= 1) {
+            fprintf(stderr, "%s - tty_read - CLOSE\n", __func__);
+        }
+        uv_read_stop(stream);
+        ops.on_writable = NULL;
+        neat_set_operations(ctx, flow, &ops);
+        neat_close(ctx, flow);
+	buffer_filled = UV_EOF;
+    } else if (strncmp(buffer->base, "abort\n", buffer_filled) == 0) {
+	if (config_log_level >= 1) {
+            fprintf(stderr, "%s - tty_read - ABORT\n", __func__);
+        }
+        uv_read_stop(stream);
+        ops.on_writable = NULL;
+        neat_set_operations(ctx, flow, &ops);
+        neat_abort(ctx, flow);
+	buffer_filled = UV_EOF;
+    }
+
+    // all fine
+    if (buffer_filled > 0) {
+        // copy input to app buffer
+        stdin_buffer.buffer_filled = buffer_filled;
+        memcpy(stdin_buffer.buffer, buffer->base, buffer_filled);
+
+        // stop reading from stdin and set write callbacks
+        uv_read_stop(stream);
+        ops.on_writable = on_writable;
+        ops.on_all_written = on_all_written;
+        neat_set_operations(ctx, flow, &ops);
+    }
+
+    free(buffer->base);
+}
+
+void tty_alloc(uv_handle_t *handle, size_t suggested, uv_buf_t *buffer)
+{
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    buffer->len = config_rcv_buffer_size;
+    buffer->base = malloc(config_rcv_buffer_size);
+}
+
+int main(int argc, char *argv[])
+{
+    uint64_t prop;
+    int arg, result;
+    char *arg_property = config_property;
+    char *arg_property_ptr = NULL;
+    char arg_property_delimiter[] = ",;";
+
+    memset(&ops, 0, sizeof(ops));
+    memset(&stdin_buffer, 0, sizeof(stdin_buffer));
+
+    result = EXIT_SUCCESS;
+
+    while ((arg = getopt(argc, argv, "P:R:S:v:A:")) != -1) {
+        switch(arg) {
+        case 'P':
+            arg_property = optarg;
+            if (config_log_level >= 1) {
+                fprintf(stderr, "%s - option - properties: %s\n", __func__, arg_property);
+            }
+            break;
+        case 'R':
+            config_rcv_buffer_size = atoi(optarg);
+            if (config_log_level >= 1) {
+                fprintf(stderr, "%s - option - receive buffer size: %d\n", __func__, config_rcv_buffer_size);
+            }
+            break;
+        case 'S':
+            config_snd_buffer_size = atoi(optarg);
+            if (config_log_level >= 1) {
+                fprintf(stderr, "%s - option - send buffer size: %d\n", __func__, config_snd_buffer_size);
+            }
+            break;
+        case 'v':
+            config_log_level = atoi(optarg);
+            if (config_log_level >= 1) {
+                fprintf(stderr, "%s - option - log level: %d\n", __func__, config_log_level);
+            }
+            break;
+	case 'A':
+	    config_primary_dest_addr = optarg;
+	    if (config_log_level >= 1) {
+                fprintf(stderr, "%s - option - primary dest. address: %s\n", __func__,
+			config_primary_dest_addr);
+            }
+            break;
+        default:
+            print_usage();
+            goto cleanup;
+            break;
+        }
+    }
+
+    if (optind + 2 != argc) {
+        fprintf(stderr, "%s - error: option - argument error\n", __func__);
+        print_usage();
+        goto cleanup;
+    }
+
+    if ((buffer_rcv = malloc(config_rcv_buffer_size)) == NULL) {
+        fprintf(stderr, "%s - error: could not allocate receive buffer\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+    if ((buffer_snd = malloc(config_snd_buffer_size)) == NULL) {
+        fprintf(stderr, "%s - error: could not allocate send buffer\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+    if ((stdin_buffer.buffer = malloc(config_snd_buffer_size)) == NULL) {
+        fprintf(stderr, "%s - error: could not allocate stdin buffer\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    if ((ctx = neat_init_ctx()) == NULL) {
+        fprintf(stderr, "%s - error: could not initialize context\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    // new neat flow
+    if ((flow = neat_new_flow(ctx)) == NULL) {
+        fprintf(stderr, "%s - error: could not create new neat flow\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    // set properties (TCP only etc..)
+    if (neat_get_property(ctx, flow, &prop)) {
+        fprintf(stderr, "%s - error: neat_get_property\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    // read property arguments
+    arg_property_ptr = strtok(arg_property, arg_property_delimiter);
+
+    while (arg_property_ptr != NULL) {
+        if (config_log_level >= 1) {
+            fprintf(stderr, "%s - setting property: %s\n", __func__, arg_property_ptr);
+        }
+
+        if (strcmp(arg_property_ptr,"NEAT_PROPERTY_OPTIONAL_SECURITY") == 0) {
+            prop |= NEAT_PROPERTY_TCP_REQUIRED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_REQUIRED_SECURITY") == 0) {
+            prop |= NEAT_PROPERTY_REQUIRED_SECURITY;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_MESSAGE") == 0) {
+            prop |= NEAT_PROPERTY_MESSAGE;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_IPV4_REQUIRED") == 0) {
+            prop |= NEAT_PROPERTY_IPV4_REQUIRED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_IPV4_BANNED") == 0) {
+            prop |= NEAT_PROPERTY_IPV4_BANNED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_IPV6_REQUIRED") == 0) {
+            prop |= NEAT_PROPERTY_IPV6_REQUIRED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_IPV6_BANNED") == 0) {
+            prop |= NEAT_PROPERTY_IPV6_BANNED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_SCTP_REQUIRED") == 0) {
+            prop |= NEAT_PROPERTY_SCTP_REQUIRED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_SCTP_BANNED") == 0) {
+            prop |= NEAT_PROPERTY_SCTP_BANNED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_TCP_REQUIRED") == 0) {
+            prop |= NEAT_PROPERTY_TCP_REQUIRED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_TCP_BANNED") == 0) {
+            prop |= NEAT_PROPERTY_TCP_BANNED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_UDP_REQUIRED") == 0) {
+            prop |= NEAT_PROPERTY_UDP_REQUIRED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_UDP_BANNED") == 0) {
+            prop |= NEAT_PROPERTY_UDP_BANNED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_UDPLITE_REQUIRED") == 0) {
+            prop |= NEAT_PROPERTY_UDPLITE_REQUIRED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_UDPLITE_BANNED") == 0) {
+            prop |= NEAT_PROPERTY_UDPLITE_BANNED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_CONGESTION_CONTROL_REQUIRED") == 0) {
+            prop |= NEAT_PROPERTY_CONGESTION_CONTROL_REQUIRED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_CONGESTION_CONTROL_BANNED") == 0) {
+            prop |= NEAT_PROPERTY_CONGESTION_CONTROL_BANNED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_RETRANSMISSIONS_REQUIRED") == 0) {
+            prop |= NEAT_PROPERTY_RETRANSMISSIONS_REQUIRED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_RETRANSMISSIONS_BANNED") == 0) {
+            prop |= NEAT_PROPERTY_RETRANSMISSIONS_BANNED;
+        } else {
+            fprintf(stderr, "%s - error: unknown property: %s\n", __func__, arg_property_ptr);
+            print_usage();
+            goto cleanup;
+        }
+
+        // get next property
+        arg_property_ptr = strtok(NULL, arg_property_delimiter);
+    }
+
+    // set properties
+    if (neat_set_property(ctx, flow, prop)) {
+        fprintf(stderr, "%s - error: neat_set_property\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    // set callbacks
+    ops.on_connected = on_connected;
+    ops.on_error = on_error;
+    ops.on_close = on_close;
+    ops.on_aborted = on_abort;
+    ops.on_network_status_changed = on_network_changed;
+
+    if (neat_set_operations(ctx, flow, &ops)) {
+        fprintf(stderr, "%s - error: neat_set_operations\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    // wait for on_connected or on_error to be invoked
+    if (neat_open_multistream(ctx, flow, argv[argc - 2], strtoul (argv[argc - 1], NULL, 0), 2) == NEAT_OK) {
+        neat_start_event_loop(ctx, NEAT_RUN_DEFAULT);
+    } else {
+        fprintf(stderr, "%s - error: neat_open\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+cleanup:
+    free(buffer_rcv);
+    free(buffer_snd);
+    free(stdin_buffer.buffer);
+
+    // cleanup
+    if (flow != NULL) {
+        neat_free_flow(flow);
+    }
+    if (ctx != NULL) {
+        neat_free_ctx(ctx);
+    }
+    exit(result);
+}

--- a/examples/server_echo_multi.c
+++ b/examples/server_echo_multi.c
@@ -1,0 +1,359 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include "../neat.h"
+
+/**********************************************************************
+
+    echo server
+
+    server_echo [OPTIONS]
+
+    https://tools.ietf.org/html/rfc862
+
+**********************************************************************/
+
+static uint32_t config_buffer_size = 512;
+static uint16_t config_log_level = 1;
+static char config_property[] = "NEAT_PROPERTY_TCP_REQUIRED,NEAT_PROPERTY_IPV4_REQUIRED";
+
+static neat_error_code on_writable(struct neat_flow_operations *opCB);
+
+/*
+    print usage and exit
+*/
+static void print_usage()
+{
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    printf("server_echo [OPTIONS]\n");
+    printf("\t- P \tneat properties (%s)\n", config_property);
+    printf("\t- S \tbuffer in byte (%d)\n", config_buffer_size);
+    printf("\t- v \tlog level 0..2 (%d)\n", config_log_level);
+}
+
+struct echo_flow {
+    unsigned char *buffer;
+    uint32_t bytes;
+    int stream_id;
+};
+
+/*
+    Error handler
+*/
+static neat_error_code on_error(struct neat_flow_operations *opCB)
+{
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    exit(EXIT_FAILURE);
+}
+
+/*
+    Read data until buffered_amount == 0 - then stop event loop!
+*/
+static neat_error_code on_readable(struct neat_flow_operations *opCB)
+{
+    // data is available to read
+    neat_error_code code;
+    struct echo_flow *ef = opCB->userData;
+
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    code = neat_read(opCB->ctx, opCB->flow, ef->buffer, config_buffer_size, &ef->bytes);
+    if (code != NEAT_OK) {
+        if (code == NEAT_ERROR_WOULD_BLOCK) {
+            if (config_log_level >= 1) {
+                printf("on_readable - NEAT_ERROR_WOULD_BLOCK\n");
+            }
+            return NEAT_OK;
+        } else {
+            fprintf(stderr, "%s - neat_read error: %d\n", __func__, (int)code);
+            return on_error(opCB);
+        }
+    }
+
+    // we got some data
+    if (ef->bytes > 0) {
+        if (config_log_level >= 1) {
+            printf("received data - %d byte\n", ef->bytes);
+        }
+        if (config_log_level >= 2) {
+            fwrite(ef->buffer, sizeof(char), ef->bytes, stdout);
+            printf("\n");
+            fflush(stdout);
+        }
+
+        ef->stream_id = opCB->stream_id;
+
+        // echo data
+        opCB->on_readable = NULL;
+        opCB->on_writable = on_writable;
+        opCB->on_all_written = NULL;
+        neat_set_operations(opCB->ctx, opCB->flow, opCB);
+    // peer disconnected - stop callbacks and free ressources
+    } else {
+        if (config_log_level >= 1) {
+            printf("peer disconnected\n");
+        }
+        opCB->on_readable = NULL;
+        opCB->on_writable = NULL;
+        opCB->on_all_written = NULL;
+        neat_set_operations(opCB->ctx, opCB->flow, opCB);
+        free(ef->buffer);
+        free(ef);
+        neat_free_flow(opCB->flow);
+    }
+    return NEAT_OK;
+}
+
+static neat_error_code on_all_written(struct neat_flow_operations *opCB)
+{
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    opCB->on_readable = on_readable;
+    opCB->on_writable = NULL;
+    opCB->on_all_written = NULL;
+    neat_set_operations(opCB->ctx, opCB->flow, opCB);
+    return NEAT_OK;
+}
+
+static neat_error_code on_writable(struct neat_flow_operations *opCB)
+{
+    neat_error_code code;
+    struct echo_flow *ef = opCB->userData;
+
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    // set callbacks
+    opCB->on_readable = NULL;
+    opCB->on_writable = NULL;
+    opCB->on_all_written = on_all_written;
+    neat_set_operations(opCB->ctx, opCB->flow, opCB);
+
+    /*
+    if (ef->stream_id != -1) {
+        code = neat_write_ex(opCB->ctx, opCB->flow, ef->buffer, ef->bytes, ef->stream_id);
+    } else {
+    */
+        code = neat_write(opCB->ctx, opCB->flow, ef->buffer, ef->bytes);
+    // }
+    if (code != NEAT_OK) {
+        fprintf(stderr, "%s - neat_write error: %d\n", __func__, (int)code);
+        return on_error(opCB);
+    }
+
+    if (config_log_level >= 1) {
+        if (ef->stream_id != -1) {
+            printf("sent data - %d bytes to stream %d\n", ef->bytes, ef->stream_id);
+        } else {
+            printf("sent data - %d bytes\n", ef->bytes);
+        }
+    }
+
+    return NEAT_OK;
+}
+
+
+static neat_error_code on_connected(struct neat_flow_operations *opCB)
+{
+    struct echo_flow *ef = NULL;
+
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    if (config_log_level >= 1) {
+        printf("peer connected\n");
+    }
+
+    // TODO: neat_get_stream_count()
+    // TODO: Allocate a buffer for each no. of streams
+    // TODO: Ensure on_writable/on_readable is only called for streams that isn't blocked?
+
+    if ((opCB->userData = calloc(1, sizeof(struct echo_flow))) == NULL) {
+        fprintf(stderr, "%s - could not allocate echo_flow\n", __func__);
+        exit(EXIT_FAILURE);
+    }
+
+    ef = opCB->userData;
+
+    if ((ef->buffer = malloc(config_buffer_size)) == NULL) {
+        fprintf(stderr, "%s - could not allocate buffer\n", __func__);
+        exit(EXIT_FAILURE);
+    }
+
+    opCB->on_readable = on_readable;
+    opCB->on_writable = NULL;
+    opCB->on_all_written = NULL;
+    neat_set_operations(opCB->ctx, opCB->flow, opCB);
+    return NEAT_OK;
+}
+
+int main(int argc, char *argv[])
+{
+    uint64_t prop;
+    int arg, result;
+    char *arg_property = config_property;
+    char *arg_property_ptr = NULL;
+    char arg_property_delimiter[] = ",;";
+    static struct neat_ctx *ctx = NULL;
+    static struct neat_flow *flow = NULL;
+    static struct neat_flow_operations ops;
+
+    memset(&ops, 0, sizeof(ops));
+
+    result = EXIT_SUCCESS;
+
+    while ((arg = getopt(argc, argv, "P:S:v:")) != -1) {
+        switch(arg) {
+        case 'P':
+            arg_property = optarg;
+            if (config_log_level >= 1) {
+                printf("option - properties: %s\n", arg_property);
+            }
+            break;
+        case 'S':
+            config_buffer_size = atoi(optarg);
+            if (config_log_level >= 1) {
+                printf("option - buffer size: %d\n", config_buffer_size);
+            }
+            break;
+        case 'v':
+            config_log_level = atoi(optarg);
+            if (config_log_level >= 1) {
+                printf("option - log level: %d\n", config_log_level);
+            }
+            break;
+        default:
+            print_usage();
+            goto cleanup;
+            break;
+        }
+    }
+
+    if (optind != argc) {
+        fprintf(stderr, "%s - argument error\n", __func__);
+        print_usage();
+        goto cleanup;
+    }
+
+    if ((ctx = neat_init_ctx()) == NULL) {
+        fprintf(stderr, "%s - neat_init_ctx failed\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    // new neat flow
+    if ((flow = neat_new_flow(ctx)) == NULL) {
+        fprintf(stderr, "%s - neat_new_flow failed\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    // set properties (TCP only etc..)
+    if (neat_get_property(ctx, flow, &prop)) {
+        fprintf(stderr, "%s - neat_get_property failed\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    // read property arguments
+    arg_property_ptr = strtok(arg_property, arg_property_delimiter);
+
+    while (arg_property_ptr != NULL) {
+        if (config_log_level >= 1) {
+            printf("setting property: %s\n", arg_property_ptr);
+        }
+
+        if (strcmp(arg_property_ptr,"NEAT_PROPERTY_OPTIONAL_SECURITY") == 0) {
+            prop |= NEAT_PROPERTY_TCP_REQUIRED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_REQUIRED_SECURITY") == 0) {
+            prop |= NEAT_PROPERTY_REQUIRED_SECURITY;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_MESSAGE") == 0) {
+            prop |= NEAT_PROPERTY_MESSAGE;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_IPV4_REQUIRED") == 0) {
+            prop |= NEAT_PROPERTY_IPV4_REQUIRED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_IPV4_BANNED") == 0) {
+            prop |= NEAT_PROPERTY_IPV4_BANNED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_IPV6_REQUIRED") == 0) {
+            prop |= NEAT_PROPERTY_IPV6_REQUIRED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_IPV6_BANNED") == 0) {
+            prop |= NEAT_PROPERTY_IPV6_BANNED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_SCTP_REQUIRED") == 0) {
+            prop |= NEAT_PROPERTY_SCTP_REQUIRED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_SCTP_BANNED") == 0) {
+            prop |= NEAT_PROPERTY_SCTP_BANNED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_TCP_REQUIRED") == 0) {
+            prop |= NEAT_PROPERTY_TCP_REQUIRED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_TCP_BANNED") == 0) {
+            prop |= NEAT_PROPERTY_TCP_BANNED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_UDP_REQUIRED") == 0) {
+            prop |= NEAT_PROPERTY_UDP_REQUIRED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_UDP_BANNED") == 0) {
+            prop |= NEAT_PROPERTY_UDP_BANNED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_UDPLITE_REQUIRED") == 0) {
+            prop |= NEAT_PROPERTY_UDPLITE_REQUIRED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_UDPLITE_BANNED") == 0) {
+            prop |= NEAT_PROPERTY_UDPLITE_BANNED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_CONGESTION_CONTROL_REQUIRED") == 0) {
+            prop |= NEAT_PROPERTY_CONGESTION_CONTROL_REQUIRED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_CONGESTION_CONTROL_BANNED") == 0) {
+            prop |= NEAT_PROPERTY_CONGESTION_CONTROL_BANNED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_RETRANSMISSIONS_REQUIRED") == 0) {
+            prop |= NEAT_PROPERTY_RETRANSMISSIONS_REQUIRED;
+        } else if (strcmp(arg_property_ptr,"NEAT_PROPERTY_RETRANSMISSIONS_BANNED") == 0) {
+            prop |= NEAT_PROPERTY_RETRANSMISSIONS_BANNED;
+        } else {
+            printf("error - unknown property: %s\n", arg_property_ptr);
+            print_usage();
+            goto cleanup;
+        }
+
+       // get next property
+       arg_property_ptr = strtok(NULL, arg_property_delimiter);
+    }
+
+    // set properties
+    if (neat_set_property(ctx, flow, prop)) {
+        fprintf(stderr, "%s - neat_set_property failed\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    // set callbacks
+    ops.on_connected = on_connected;
+    ops.on_error = on_error;
+
+    if (neat_set_operations(ctx, flow, &ops)) {
+        fprintf(stderr, "%s - neat_set_operations failed\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    // wait for on_connected or on_error to be invoked
+    if (neat_accept(ctx, flow, "*", 8080)) {
+        fprintf(stderr, "%s - neat_accept failed\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    neat_start_event_loop(ctx, NEAT_RUN_DEFAULT);
+
+    // cleanup
+cleanup:
+    if (ctx != NULL) {
+        neat_free_ctx(ctx);
+    }
+    exit(result);
+}

--- a/neat.h
+++ b/neat.h
@@ -90,6 +90,8 @@ neat_error_code neat_get_stats(struct neat_flow *flow, char **neat_stats);
 
 neat_error_code neat_open(struct neat_ctx *ctx, struct neat_flow *flow,
                           const char *name, uint16_t port);
+neat_error_code neat_open_multistream(struct neat_ctx *ctx, struct neat_flow *flow,
+                          const char *name, uint16_t port, int count);
 neat_error_code neat_read(struct neat_ctx *ctx, struct neat_flow *flow,
                           unsigned char *buffer, uint32_t amt, uint32_t *actualAmt);
 neat_error_code neat_write(struct neat_ctx *ctx, struct neat_flow *flow,

--- a/neat_core.c
+++ b/neat_core.c
@@ -1149,20 +1149,15 @@ static void do_accept(neat_ctx *ctx, neat_flow *flow)
 #if defined(IPPROTO_SCTP) && defined(SCTP_STATUS)
         case NEAT_STACK_SCTP:
             optlen = sizeof(status);
-            // status.sstat_assoc_id = SCTP_FUTURE_ASSOC;
-            status.sstat_assoc_id = 0;
-            status.sstat_instrms = 1; /* setting a default value in case the
-                                       * getsockopt call fails.
-                                       */
-
             rc = getsockopt(newFlow->fd, IPPROTO_SCTP, SCTP_STATUS, &status, &optlen);
             if (rc < 0) {
                 neat_log(NEAT_LOG_DEBUG, "Call to getsockopt(SCTP_STATUS) failed");
-                perror("getsockopt");
+                newFlow->stream_count = 1;
+            } else {
+                newFlow->stream_count = status.sstat_instrms;
             }
 
             // number of outbound streams == number of inbound streams
-            newFlow->stream_count = status.sstat_instrms;
             neat_log(NEAT_LOG_DEBUG, "inbound streams: %d\n", newFlow->stream_count);
             break;
 #endif

--- a/neat_core.c
+++ b/neat_core.c
@@ -1728,7 +1728,7 @@ neat_write_to_lower_layer(struct neat_ctx *ctx, struct neat_flow *flow,
             memset(sndinfo, 0, sizeof(struct sctp_sndinfo));
 
             if (stream_id)
-                sndinfo->snd_sid = 1;
+                sndinfo->snd_sid = stream_id;
 
 #if defined(SCTP_EOR)
             if ((flow->isSCTPExplicitEOR) && (len == amt)) {
@@ -1746,7 +1746,7 @@ neat_write_to_lower_layer(struct neat_ctx *ctx, struct neat_flow *flow,
             memset(sndrcvinfo, 0, sizeof(struct sctp_sndrcvinfo));
 
             if (stream_id)
-                sndrcvinfo->sinfo_stream = 1;
+                sndrcvinfo->sinfo_stream = stream_id;
 #if defined(SCTP_EOR)
             if ((flow->isSCTPExplicitEOR) && (len == amt)) {
                 sndrcvinfo->sinfo_flags |= SCTP_EOR;

--- a/neat_core.c
+++ b/neat_core.c
@@ -1132,9 +1132,9 @@ static void do_accept(neat_ctx *ctx, neat_flow *flow)
         }
     }
 
-    switch (newFlow->sockProtocol) {
+    switch (newFlow->sockStack) {
 #ifdef IPPROTO_SCTP
-        case IPPROTO_SCTP:
+        case NEAT_STACK_SCTP:
             optlen = sizeof(status);
             // status.sstat_assoc_id = SCTP_FUTURE_ASSOC;
             status.sstat_assoc_id = 0;
@@ -1932,7 +1932,7 @@ neat_connect(struct he_cb_ctx *he_ctx, uv_poll_cb callback_fx)
     }
 
 #ifdef IPPROTO_SCTP
-    if (he_ctx->candidate->ai_protocol == IPPROTO_SCTP) {
+    if (he_ctx->candidate->ai_stack == NEAT_STACK_SCTP) {
         struct sctp_initmsg init;
         memset(&init, 0, sizeof(init));
         init.sinit_num_ostreams = he_ctx->flow->stream_count;

--- a/neat_core.c
+++ b/neat_core.c
@@ -695,7 +695,7 @@ static int io_readable(neat_ctx *ctx, neat_flow *flow,
             return READ_WITH_ERROR;
         }
 
-#ifdef CMSG_FIRSTHDR
+#if (defined(SCTP_RCVINFO) || defined (SCTP_SNDRCV))
         for (cmsg = CMSG_FIRSTHDR(&msghdr); cmsg != NULL; cmsg = CMSG_NXTHDR(&msghdr, cmsg)) {
             if (cmsg->cmsg_len == 0) {
                 neat_log(NEAT_LOG_DEBUG, "Error in ancilliary data from recvmsg");
@@ -719,7 +719,7 @@ static int io_readable(neat_ctx *ctx, neat_flow *flow,
             }
 #endif // defined(IPPROTP_SCTP)
         }
-#endif // defined(CMSG_FIRSTHDR)
+#endif // (defined(SCTP_RCVINFO) || defined (SCTP_SNDRCV))
 
         flags = msghdr.msg_flags; // For notification handling
 #else // !defined(USRSCTP_SUPPORT)

--- a/neat_core.c
+++ b/neat_core.c
@@ -1045,6 +1045,12 @@ static void do_accept(neat_ctx *ctx, neat_flow *flow)
 
     switch (newFlow->sockStack) {
     case NEAT_STACK_SCTP:
+        newFlow->stream_count = 1;
+        if (allocate_send_buffers(newFlow) != NEAT_OK) {
+            io_error(ctx, newFlow, NEAT_INVALID_STREAM, NEAT_ERROR_IO);
+            return;
+        }
+
 #if defined(USRSCTP_SUPPORT)
         newFlow->sock = newFlow->acceptusrsctpfx(ctx, newFlow, flow->sock);
         if (!newFlow->sock) {

--- a/neat_core.c
+++ b/neat_core.c
@@ -695,6 +695,7 @@ static int io_readable(neat_ctx *ctx, neat_flow *flow,
             return READ_WITH_ERROR;
         }
 
+#ifdef CMSG_FIRSTHDR
         for (cmsg = CMSG_FIRSTHDR(&msghdr); cmsg != NULL; cmsg = CMSG_NXTHDR(&msghdr, cmsg)) {
             if (cmsg->cmsg_len == 0) {
                 neat_log(NEAT_LOG_DEBUG, "Error in ancilliary data from recvmsg");
@@ -718,6 +719,7 @@ static int io_readable(neat_ctx *ctx, neat_flow *flow,
             }
 #endif // defined(IPPROTP_SCTP)
         }
+#endif // defined(CMSG_FIRSTHDR)
 
         flags = msghdr.msg_flags; // For notification handling
 #else // !defined(USRSCTP_SUPPORT)

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -118,6 +118,7 @@ struct neat_flow
     int sockType;
     uint16_t stream_count;
     int sockStack;
+    uint16_t stream_count;
     struct neat_resolver_results *resolver_results;
     const struct sockaddr *sockAddr; // raw unowned pointer into resolver_results
     struct neat_ctx *ctx; // raw convenience pointer

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -137,6 +137,9 @@ struct neat_flow
     size_t readBufferAllocation;  // size of buffered allocation
     int readBufferMsgComplete;    // it contains a complete user message
 
+    // Multi-stream data
+    uint32_t streamCount;
+
     neat_read_impl readfx;
     neat_write_impl writefx;
     neat_accept_impl acceptfx;

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -116,7 +116,6 @@ struct neat_flow
     uint64_t propertyUsed;
     uint8_t family;
     int sockType;
-    uint16_t stream_count;
     int sockStack;
     uint16_t stream_count;
     struct neat_resolver_results *resolver_results;

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -137,9 +137,6 @@ struct neat_flow
     size_t readBufferAllocation;  // size of buffered allocation
     int readBufferMsgComplete;    // it contains a complete user message
 
-    // Multi-stream data
-    uint32_t streamCount;
-
     neat_read_impl readfx;
     neat_write_impl writefx;
     neat_accept_impl acceptfx;


### PR DESCRIPTION
This PR adds support for multistreaming over SCTP.

* For now, I have assumed that the number of streams are symmetric in both directions.
* Down the line I think we should consider storing an `on_writable` callback for each stream, instead of forcing applications to use the same callback for all streams.

I have added a separate server/client example for multistreaming. We may consider integrating this with the existing server_echo and client respectively in the future.

@tuexen: I suppose you should take a look at this PR. In particular, I have had difficulties finding a documented way of getting the association id for a given socket/fd. [This](https://github.com/NEAT-project/neat/compare/oystedal/multistream?diff=unified&expand=1&name=oystedal%2Fmultistream#diff-4ec7caa7f7478f502be1c62255bbb75fR1151) is how I've done it so far, which appears to work.