### PR TITLE
Only ban UDP and UDPLite by default

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -29,7 +29,7 @@ static uint32_t config_snd_buffer_size = 128;
 static uint16_t config_log_level = 1;
 static uint16_t config_json_stats = 0;
 static char *config_primary_dest_addr = NULL;
-static char config_property[] = "NEAT_PROPERTY_TCP_REQUIRED,NEAT_PROPERTY_IPV4_REQUIRED";
+static char config_property[] = "NEAT_PROPERTY_UDP_BANNED,NEAT_PROPERTY_UDPLITE_BANNED";
 
 struct std_buffer {
     unsigned char *buffer;

--- a/examples/server_chargen.c
+++ b/examples/server_chargen.c
@@ -14,7 +14,7 @@
 
 **********************************************************************/
 
-static char config_property[] = "NEAT_PROPERTY_TCP_REQUIRED,NEAT_PROPERTY_IPV4_REQUIRED";
+static char config_property[] = "NEAT_PROPERTY_UDP_BANNED,NEAT_PROPERTY_UDPLITE_BANNED";
 static uint16_t config_log_level = 1;
 static uint16_t chargen_offset = 0;
 

--- a/examples/server_daytime.c
+++ b/examples/server_daytime.c
@@ -15,7 +15,7 @@
 
 **********************************************************************/
 
-static char config_property[] = "NEAT_PROPERTY_TCP_REQUIRED,NEAT_PROPERTY_IPV4_REQUIRED";
+static char config_property[] = "NEAT_PROPERTY_UDP_BANNED,NEAT_PROPERTY_UDPLITE_BANNED";
 static uint16_t config_log_level = 1;
 
 #define BUFFERSIZE 32

--- a/examples/server_discard.c
+++ b/examples/server_discard.c
@@ -16,7 +16,7 @@
 
 static uint32_t config_buffer_size = 128;
 static uint16_t config_log_level = 1;
-static char config_property[] = "NEAT_PROPERTY_TCP_REQUIRED,NEAT_PROPERTY_IPV4_REQUIRED";
+static char config_property[] = "NEAT_PROPERTY_UDP_BANNED,NEAT_PROPERTY_UDPLITE_BANNED";
 
 static unsigned char *buffer = NULL;
 static uint32_t buffer_filled = 0;

--- a/examples/server_echo.c
+++ b/examples/server_echo.c
@@ -16,7 +16,7 @@
 
 static uint32_t config_buffer_size = 512;
 static uint16_t config_log_level = 1;
-static char config_property[] = "NEAT_PROPERTY_TCP_REQUIRED,NEAT_PROPERTY_IPV4_REQUIRED";
+static char config_property[] = "NEAT_PROPERTY_UDP_BANNED,NEAT_PROPERTY_UDPLITE_BANNED";
 
 static neat_error_code on_writable(struct neat_flow_operations *opCB);
 

--- a/examples/tneat.c
+++ b/examples/tneat.c
@@ -31,7 +31,7 @@ static uint16_t config_active = 0;
 static uint16_t config_chargen_offset = 0;
 static uint16_t config_port = 8080;
 static uint16_t config_log_level = 1;
-static char config_property[] = "NEAT_PROPERTY_TCP_REQUIRED,NEAT_PROPERTY_IPV4_REQUIRED";
+static char config_property[] = "NEAT_PROPERTY_UDP_BANNED,NEAT_PROPERTY_UDPLITE_BANNED";
 static uint8_t done = 0;
 
 /*


### PR DESCRIPTION
Changed the default property from "TCP over IPv4 only" to "all except UDP and UDPLite"