### PR TITLE
Implementation of optional argument handling

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -209,7 +209,7 @@ on_writable(struct neat_flow_operations *opCB)
         fprintf(stderr, "%s()\n", __func__);
     }
 
-    code = neat_write(opCB->ctx, opCB->flow, stdin_buffer.buffer, stdin_buffer.buffer_filled);
+    code = neat_write(opCB->ctx, opCB->flow, stdin_buffer.buffer, stdin_buffer.buffer_filled, NULL, 0);
     if (code != NEAT_OK) {
         fprintf(stderr, "%s - neat_write - error: %d\n", __func__, (int)code);
         return on_error(opCB);

--- a/examples/client_http_get.c
+++ b/examples/client_http_get.c
@@ -55,7 +55,7 @@ static neat_error_code
 on_writable(struct neat_flow_operations *opCB)
 {
     neat_error_code code;
-    code = neat_write(opCB->ctx, opCB->flow, (const unsigned char *)request, strlen(request));
+    code = neat_write(opCB->ctx, opCB->flow, (const unsigned char *)request, strlen(request), NULL, 0);
     if (code != NEAT_OK) {
         return on_error(opCB);
     }

--- a/examples/client_multi.c
+++ b/examples/client_multi.c
@@ -172,6 +172,7 @@ on_writable(struct neat_flow_operations *opCB)
     static int message_number = 0;
     static int last_message_number = 0;
     neat_error_code code;
+    struct neat_tlv options[1];
     unsigned char buf[64];
     int len;
 
@@ -184,7 +185,15 @@ on_writable(struct neat_flow_operations *opCB)
             if (message_number > last_message_number) {
                 break;
             }
-            code = neat_write_ex(opCB->ctx, opCB->flow, stdin_buffer.buffer, stdin_buffer.buffer_filled, 0);
+
+            options[0].tag           = NEAT_TAG_STREAM_ID;
+            options[0].type          = NEAT_TYPE_INTEGER;
+            options[0].value.integer = 0;
+
+            code = neat_write(opCB->ctx, opCB->flow,
+                              stdin_buffer.buffer, stdin_buffer.buffer_filled,
+                              options, 1);
+
             if (code != NEAT_OK) {
                 fprintf(stderr, "%s - neat_write_ex - error: %d\n", __func__, (int)code);
                 return on_error(opCB);
@@ -205,7 +214,11 @@ on_writable(struct neat_flow_operations *opCB)
 
             len = snprintf((char*)buf, 64, "Sent message number %d\n", message_number);
 
-            code = neat_write_ex(opCB->ctx, opCB->flow, buf, len, 1);
+            options[0].tag           = NEAT_TAG_STREAM_ID;
+            options[0].type          = NEAT_TYPE_INTEGER;
+            options[0].value.integer = 1;
+            code = neat_write(opCB->ctx, opCB->flow, buf, len, options, 1);
+
             if (code != NEAT_OK) {
                 fprintf(stderr, "%s - neat_write_ex - error: %d\n", __func__, (int)code);
                 return on_error(opCB);

--- a/examples/server_chargen.c
+++ b/examples/server_chargen.c
@@ -135,7 +135,7 @@ on_writable(struct neat_flow_operations *opCB)
     opCB->on_all_written = on_all_written;
     neat_set_operations(opCB->ctx, opCB->flow, opCB);
 
-    code = neat_write(opCB->ctx, opCB->flow, buffer, BUFFERSIZE);
+    code = neat_write(opCB->ctx, opCB->flow, buffer, BUFFERSIZE, NULL, 0);
     if (code != NEAT_OK) {
         fprintf(stderr, "%s - neat_write error: %d\n", __func__, (int)code);
         return on_error(opCB);

--- a/examples/server_daytime.c
+++ b/examples/server_daytime.c
@@ -126,7 +126,7 @@ on_writable(struct neat_flow_operations *opCB)
     time_now = time(NULL);
     time_string = ctime(&time_now);
     // and send it
-    code = neat_write(opCB->ctx, opCB->flow, (const unsigned char *) time_string, strlen(time_string));
+    code = neat_write(opCB->ctx, opCB->flow, (const unsigned char *) time_string, strlen(time_string), NULL, 0);
     if (code != NEAT_OK) {
         fprintf(stderr, "%s - neat_write failed - code: %d\n", __func__, (int)code);
         return on_error(opCB);

--- a/examples/server_echo.c
+++ b/examples/server_echo.c
@@ -142,7 +142,7 @@ on_writable(struct neat_flow_operations *opCB)
     opCB->on_all_written = on_all_written;
     neat_set_operations(opCB->ctx, opCB->flow, opCB);
 
-    code = neat_write(opCB->ctx, opCB->flow, ef->buffer, ef->bytes);
+    code = neat_write(opCB->ctx, opCB->flow, ef->buffer, ef->bytes, NULL, 0);
     if (code != NEAT_OK) {
         fprintf(stderr, "%s - neat_write error: %d\n", __func__, (int)code);
         return on_error(opCB);

--- a/examples/server_echo_multi.c
+++ b/examples/server_echo_multi.c
@@ -151,7 +151,7 @@ on_writable(struct neat_flow_operations *opCB)
         code = neat_write_ex(opCB->ctx, opCB->flow, ef->buffer, ef->bytes, ef->stream_id);
     } else {
     */
-        code = neat_write(opCB->ctx, opCB->flow, ef->buffer, ef->bytes);
+        code = neat_write(opCB->ctx, opCB->flow, ef->buffer, ef->bytes, NULL, 0);
     // }
     if (code != NEAT_OK) {
         fprintf(stderr, "%s - neat_write error: %d\n", __func__, (int)code);

--- a/examples/server_echo_multi.c
+++ b/examples/server_echo_multi.c
@@ -15,8 +15,8 @@
 **********************************************************************/
 
 static uint32_t config_buffer_size = 512;
-static uint16_t config_log_level = 1;
-static char config_property[] = "NEAT_PROPERTY_TCP_REQUIRED,NEAT_PROPERTY_IPV4_REQUIRED";
+static uint16_t config_log_level   = 1;
+static char     config_property[]  = "NEAT_PROPERTY_TCP_REQUIRED,NEAT_PROPERTY_IPV4_REQUIRED";
 
 static neat_error_code on_writable(struct neat_flow_operations *opCB);
 
@@ -38,8 +38,8 @@ print_usage()
 
 struct echo_flow {
     unsigned char *buffer;
-    uint32_t bytes;
-    int stream_id;
+    uint32_t       bytes;
+    int            stream_id;
 };
 
 /*
@@ -62,7 +62,7 @@ static neat_error_code
 on_readable(struct neat_flow_operations *opCB)
 {
     // data is available to read
-    neat_error_code code;
+    neat_error_code   code;
     struct echo_flow *ef = opCB->userData;
 
     if (config_log_level >= 2) {
@@ -96,8 +96,8 @@ on_readable(struct neat_flow_operations *opCB)
         ef->stream_id = opCB->stream_id;
 
         // echo data
-        opCB->on_readable = NULL;
-        opCB->on_writable = on_writable;
+        opCB->on_readable    = NULL;
+        opCB->on_writable    = on_writable;
         opCB->on_all_written = NULL;
         neat_set_operations(opCB->ctx, opCB->flow, opCB);
     // peer disconnected - stop callbacks and free ressources
@@ -105,8 +105,8 @@ on_readable(struct neat_flow_operations *opCB)
         if (config_log_level >= 1) {
             printf("peer disconnected\n");
         }
-        opCB->on_readable = NULL;
-        opCB->on_writable = NULL;
+        opCB->on_readable    = NULL;
+        opCB->on_writable    = NULL;
         opCB->on_all_written = NULL;
         neat_set_operations(opCB->ctx, opCB->flow, opCB);
         free(ef->buffer);
@@ -123,8 +123,8 @@ on_all_written(struct neat_flow_operations *opCB)
         fprintf(stderr, "%s()\n", __func__);
     }
 
-    opCB->on_readable = on_readable;
-    opCB->on_writable = NULL;
+    opCB->on_readable    = on_readable;
+    opCB->on_writable    = NULL;
     opCB->on_all_written = NULL;
     neat_set_operations(opCB->ctx, opCB->flow, opCB);
     return NEAT_OK;
@@ -133,7 +133,8 @@ on_all_written(struct neat_flow_operations *opCB)
 static neat_error_code
 on_writable(struct neat_flow_operations *opCB)
 {
-    neat_error_code code;
+    neat_error_code   code;
+    struct neat_tlv   options[1];
     struct echo_flow *ef = opCB->userData;
 
     if (config_log_level >= 2) {
@@ -141,18 +142,16 @@ on_writable(struct neat_flow_operations *opCB)
     }
 
     // set callbacks
-    opCB->on_readable = NULL;
-    opCB->on_writable = NULL;
+    opCB->on_readable    = NULL;
+    opCB->on_writable    = NULL;
     opCB->on_all_written = on_all_written;
     neat_set_operations(opCB->ctx, opCB->flow, opCB);
 
-    /*
-    if (ef->stream_id != -1) {
-        code = neat_write_ex(opCB->ctx, opCB->flow, ef->buffer, ef->bytes, ef->stream_id);
-    } else {
-    */
-        code = neat_write(opCB->ctx, opCB->flow, ef->buffer, ef->bytes, NULL, 0);
-    // }
+    options[0].tag           = NEAT_TAG_STREAM_ID;
+    options[0].type          = NEAT_TYPE_INTEGER;
+    options[0].value.integer = opCB->stream_id; // Return on the same stream
+
+    code = neat_write(opCB->ctx, opCB->flow, ef->buffer, ef->bytes, options, 1);
     if (code != NEAT_OK) {
         fprintf(stderr, "%s - neat_write error: %d\n", __func__, (int)code);
         return on_error(opCB);
@@ -198,8 +197,8 @@ on_connected(struct neat_flow_operations *opCB)
         exit(EXIT_FAILURE);
     }
 
-    opCB->on_readable = on_readable;
-    opCB->on_writable = NULL;
+    opCB->on_readable    = on_readable;
+    opCB->on_writable    = NULL;
     opCB->on_all_written = NULL;
     neat_set_operations(opCB->ctx, opCB->flow, opCB);
     return NEAT_OK;
@@ -209,11 +208,12 @@ int
 main(int argc, char *argv[])
 {
     uint64_t prop;
-    int arg, result;
-    char *arg_property = config_property;
-    char *arg_property_ptr = NULL;
-    char arg_property_delimiter[] = ",;";
-    static struct neat_ctx *ctx = NULL;
+    int      arg, result;
+    char    *arg_property             = config_property;
+    char    *arg_property_ptr         = NULL;
+    char     arg_property_delimiter[] = ",;";
+
+    static struct neat_ctx *ctx   = NULL;
     static struct neat_flow *flow = NULL;
     static struct neat_flow_operations ops;
 
@@ -339,7 +339,7 @@ main(int argc, char *argv[])
 
     // set callbacks
     ops.on_connected = on_connected;
-    ops.on_error = on_error;
+    ops.on_error     = on_error;
 
     if (neat_set_operations(ctx, flow, &ops)) {
         fprintf(stderr, "%s - neat_set_operations failed\n", __func__);

--- a/examples/tneat.c
+++ b/examples/tneat.c
@@ -195,7 +195,7 @@ on_writable(struct neat_flow_operations *opCB)
         }
     }
 
-    code = neat_write(opCB->ctx, opCB->flow, tnf->snd.buffer, config_snd_buffer_size);
+    code = neat_write(opCB->ctx, opCB->flow, tnf->snd.buffer, config_snd_buffer_size, NULL, 0);
 
     if (done) {
         opCB->on_writable = NULL;

--- a/neat.h
+++ b/neat.h
@@ -65,6 +65,29 @@ struct neat_flow_operations
   struct neat_flow *flow;
 };
 
+enum neat_tlv_type {
+    NEAT_TYPE_INTEGER = 0,
+    NEAT_TYPE_FLOAT,
+    NEAT_TYPE_STRING,
+};
+typedef enum neat_tlv_type neat_tlv_type;
+
+enum neat_tlv_tag {
+    NEAT_TAG_STREAM_ID = 0,
+};
+typedef enum neat_tlv_tag neat_tlv_tag;
+
+struct neat_tlv {
+    neat_tlv_tag  tag;
+    neat_tlv_type type;
+
+    union {
+        int   integer;
+        char *string;
+        float real;
+    } value;
+};
+
 // Flags to use for neat_flow_init()
 #define NEAT_PRESERVE_MSG_BOUNDARIES (1 << 0)
 #define NEAT_USE_SECURE_INTERFACE (1 << 1)
@@ -95,10 +118,8 @@ neat_error_code neat_open_multistream(struct neat_ctx *ctx, struct neat_flow *fl
 neat_error_code neat_read(struct neat_ctx *ctx, struct neat_flow *flow,
                           unsigned char *buffer, uint32_t amt, uint32_t *actualAmt);
 neat_error_code neat_write(struct neat_ctx *ctx, struct neat_flow *flow,
-                           const unsigned char *buffer, uint32_t amt);
-neat_error_code neat_write_ex(struct neat_ctx *ctx, struct neat_flow *flow,
-                              const unsigned char *buffer, uint32_t amt,
-                              int stream_id);
+                           const unsigned char *buffer, uint32_t amt,
+                           struct neat_tlv optional[], unsigned int opt_count);
 neat_error_code neat_get_property(struct neat_ctx *ctx, struct neat_flow *flow,
                                   uint64_t *outMask);
 neat_error_code neat_set_property(struct neat_ctx *ctx, struct neat_flow *flow,

--- a/neat_core.c
+++ b/neat_core.c
@@ -2415,18 +2415,14 @@ neat_listen_via_usrsctp(struct neat_ctx *ctx, struct neat_flow *flow)
 // this function needs to accept all the data (buffering if necessary)
 neat_error_code
 neat_write(struct neat_ctx *ctx, struct neat_flow *flow,
-           const unsigned char *buffer, uint32_t amt)
+           const unsigned char *buffer, uint32_t amt,
+           struct neat_tlv optional[], unsigned int opt_count)
 {
+    int stream_id = 0;
+
     neat_log(NEAT_LOG_DEBUG, "%s", __func__);
 
-    return flow->writefx(ctx, flow, buffer, amt, 0);
-}
 
-neat_error_code
-neat_write_ex(struct neat_ctx *ctx, struct neat_flow *flow,
-              const unsigned char *buffer, uint32_t amt, int stream_id)
-{
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
 
     return flow->writefx(ctx, flow, buffer, amt, stream_id);
 }

--- a/neat_core.c
+++ b/neat_core.c
@@ -2422,7 +2422,27 @@ neat_write(struct neat_ctx *ctx, struct neat_flow *flow,
 
     neat_log(NEAT_LOG_DEBUG, "%s", __func__);
 
+    if (optional != NULL && opt_count > 0) {
+        for (unsigned int i = 0; i < opt_count; ++i) {
+            switch (optional[i].tag) {
+            case NEAT_TAG_STREAM_ID:
+                if (optional[i].type != NEAT_TYPE_INTEGER)
+                    neat_log(NEAT_LOG_DEBUG,
+                             "Optional argument \"%s\" passed to function %s: "
+                             "Expected integer, specified as something else. "
+                             "Ignoring.", "stream", __func__);
+                else
+                    stream_id = optional[i].value.integer;
 
+                break;
+            default:
+                neat_log(NEAT_LOG_DEBUG,
+                         "Optional argument \"%s\" passed to function %s: "
+                         "Unknown optional argument."
+                         "Ignoring.", "stream", __func__);
+            };
+        }
+    }
 
     return flow->writefx(ctx, flow, buffer, amt, stream_id);
 }


### PR DESCRIPTION
As decided at the plenary.

Optional arguments are specified with a tag ID, a type, and a value. For now, supported types are ints, floats, and strings.

I plan to write a set of macros to make the code inside the functions that receive the optional arguments less cumbersome, and possibly also some macros that makes passing an optional argument more concise.