### PR TITLE
Resolver rework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ LIST(APPEND neat_sources
     neat_property_helpers.c
     neat_resolver.c
     neat_resolver_conf.c
+    neat_resolver_helpers.c
 )
 
 # OS DEPENDENT

--- a/neat_addr.c
+++ b/neat_addr.c
@@ -126,8 +126,8 @@ void neat_addr_update_src_list(struct neat_ctx *nc,
 
     LIST_INSERT_HEAD(&(nc->src_addrs), nsrc_addr, next_addr);
     ++nc->src_addr_cnt;
-    neat_run_event_cb(nc, NEAT_NEWADDR, nsrc_addr);
     neat_addr_print_src_addrs(nc);
+    neat_run_event_cb(nc, NEAT_NEWADDR, nsrc_addr);
 }
 
 void neat_addr_lifetime_timeout_cb(uv_timer_t *handle)

--- a/neat_core.c
+++ b/neat_core.c
@@ -2045,7 +2045,7 @@ neat_connect(struct he_cb_ctx *he_ctx, uv_poll_cb callback_fx)
     
     retval = connect(he_ctx->fd, (struct sockaddr *) &(he_ctx->candidate->dst_addr), slen);    
     if (retval && errno != EINPROGRESS) {
-        neat_log(NEAT_LOG_DEBUG, "%s: Connect failed for fd %d connect retval %d", __func__, he_ctx->fd, retval);
+        neat_log(NEAT_LOG_DEBUG, "%s: Connect failed for fd %d connect error (%d): %s", __func__, he_ctx->fd, errno, strerror(errno));
         return -2;
     }
 

--- a/neat_core.c
+++ b/neat_core.c
@@ -2260,9 +2260,9 @@ neat_connect_via_usrsctp(struct he_cb_ctx *he_ctx)
 
     neat_log(NEAT_LOG_DEBUG, "%s", __func__);
 
-    protocol = neat_stack_to_protocol(neat_base_stack(he_ctx->candidate->ai_stack));
+    protocol = neat_stack_to_protocol(neat_base_stack(he_ctx->ai_stack));
     if (protocol == 0) {
-        neat_log(NEAT_LOG_ERROR, "Stack %d not supported", he_ctx->candidate->ai_stack);
+        neat_log(NEAT_LOG_ERROR, "Stack %d not supported", he_ctx->ai_stack);
         return -1;
     }
 

--- a/neat_core.c
+++ b/neat_core.c
@@ -1469,7 +1469,7 @@ accept_resolve_cb(struct neat_resolver_results *results,
     //variables should be determined by something else, like which listen socket
     //data arrives on
     flow->sockType = SOCK_STREAM;
-    flow->sockStack = NEAT_STACK_STCP;
+    flow->sockStack = NEAT_STACK_TCP;
     flow->resolver_results = results;
     flow->sockAddr = (struct sockaddr *) &(results->lh_first->dst_addr);
 

--- a/neat_core.c
+++ b/neat_core.c
@@ -1403,8 +1403,8 @@ neat_set_primary_dest(struct neat_ctx *ctx, struct neat_flow *flow, const char *
             return NEAT_ERROR_BAD_ARGUMENT;
         }
 
-            neat_getaddrinfo(ctx->resolver, AF_UNSPEC, name, flow->port,
-                             set_primary_dest_resolve_cb, flow);
+            neat_resolve(ctx->resolver, AF_UNSPEC, name, flow->port,
+                         set_primary_dest_resolve_cb, flow);
 
             return NEAT_ERROR_OK;
     }
@@ -1489,8 +1489,8 @@ neat_error_code neat_accept(struct neat_ctx *ctx, struct neat_flow *flow,
     if (!ctx->resolver)
         ctx->resolver = neat_resolver_init(ctx, "/etc/resolv.conf");
 
-    neat_getaddrinfo(ctx->resolver, AF_INET, flow->name, flow->port,
-                     accept_resolve_cb, flow);
+    neat_resolve(ctx->resolver, AF_INET, flow->name, flow->port,
+                 accept_resolve_cb, flow);
     return NEAT_OK;
 }
 

--- a/neat_core.c
+++ b/neat_core.c
@@ -162,11 +162,11 @@ void neat_free_ctx(struct neat_ctx *nc)
 {
     neat_log(NEAT_LOG_DEBUG, "%s", __func__);
 
-    neat_core_cleanup(nc);
-
     if (nc->resolver) {
         neat_resolver_release(nc->resolver);
     }
+
+    neat_core_cleanup(nc);
 
     if (nc->event_cbs)
         free(nc->event_cbs);

--- a/neat_core.c
+++ b/neat_core.c
@@ -1402,7 +1402,7 @@ neat_set_primary_dest(struct neat_ctx *ctx, struct neat_flow *flow, const char *
         }
 
             neat_getaddrinfo(ctx->resolver, AF_UNSPEC, name, flow->port,
-                             set_primary_dest_resolve_cb);
+                             set_primary_dest_resolve_cb, flow);
 
             return NEAT_ERROR_OK;
     }
@@ -1485,10 +1485,8 @@ neat_error_code neat_accept(struct neat_ctx *ctx, struct neat_flow *flow,
     if (!ctx->resolver)
         ctx->resolver = neat_resolver_init(ctx, "/etc/resolv.conf");
 
-    ctx->resolver->userData1 = (void *)flow;
-
     neat_getaddrinfo(ctx->resolver, AF_INET, flow->name, flow->port,
-                     accept_resolve_cb);
+                     accept_resolve_cb, flow);
     return NEAT_OK;
 }
 

--- a/neat_core.c
+++ b/neat_core.c
@@ -1401,8 +1401,8 @@ neat_set_primary_dest(struct neat_ctx *ctx, struct neat_flow *flow, const char *
             return NEAT_ERROR_BAD_ARGUMENT;
         }
 
-            ctx->resolver->handle_resolve = set_primary_dest_resolve_cb;
-            neat_getaddrinfo(ctx->resolver, AF_UNSPEC, name, flow->port);
+            neat_getaddrinfo(ctx->resolver, AF_UNSPEC, name, flow->port,
+                             set_primary_dest_resolve_cb);
 
             return NEAT_ERROR_OK;
     }
@@ -1483,16 +1483,12 @@ neat_error_code neat_accept(struct neat_ctx *ctx, struct neat_flow *flow,
     assert(flow->handle != NULL);
 
     if (!ctx->resolver)
-        ctx->resolver = neat_resolver_init(ctx, "/etc/resolv.conf",
-                                           accept_resolve_cb, NULL);
-    else if (ctx->resolver->handle_resolve != accept_resolve_cb)
-        // TODO: Race condition if this is updated before the callback for
-        // set_primary_addr is called
-        ctx->resolver->handle_resolve = accept_resolve_cb;
+        ctx->resolver = neat_resolver_init(ctx, "/etc/resolv.conf");
 
     ctx->resolver->userData1 = (void *)flow;
 
-    neat_getaddrinfo(ctx->resolver, AF_INET, flow->name, flow->port);
+    neat_getaddrinfo(ctx->resolver, AF_INET, flow->name, flow->port,
+                     accept_resolve_cb);
     return NEAT_OK;
 }
 

--- a/neat_core.c
+++ b/neat_core.c
@@ -1933,7 +1933,7 @@ int neat_base_stack(neat_protocol_stack_type stack)
 static int
 neat_connect(struct he_cb_ctx *he_ctx, uv_poll_cb callback_fx)
 {
-    int enable = 1;
+    int enable = 1, retval;
     socklen_t len = 0;
     int size = 0, protocol;
 #ifdef __linux__
@@ -2042,10 +2042,13 @@ neat_connect(struct he_cb_ctx *he_ctx, uv_poll_cb callback_fx)
 #endif
 
     uv_poll_init(he_ctx->nc->loop, he_ctx->handle, he_ctx->fd); // makes fd nb as side effect
-    if ((he_ctx->fd == -1) ||
-        (connect(he_ctx->fd, (struct sockaddr *) &(he_ctx->candidate->dst_addr), slen) && (errno != EINPROGRESS))) {
-        neat_log(NEAT_LOG_DEBUG, "%s: Connect failed for fd %d", __func__, he_ctx->fd);
-        return -2;
+    if ((he_ctx->fd == -1)) {
+        retval = connect(he_ctx->fd, (struct sockaddr *) &(he_ctx->candidate->dst_addr), slen);
+        
+        if (retval && errno != EINPROGRESS) {
+            neat_log(NEAT_LOG_DEBUG, "%s: Connect failed for fd %d %d", __func__, he_ctx->fd, retval);
+            return -2;
+        }
     }
     uv_poll_start(he_ctx->handle, UV_WRITABLE, callback_fx);
 #if defined(USRSCTP_SUPPORT)

--- a/neat_core.c
+++ b/neat_core.c
@@ -129,6 +129,12 @@ static void neat_walk_cb(uv_handle_t *handle, void *arg)
 {
     neat_log(NEAT_LOG_DEBUG, "%s", __func__);
 
+    //HACK: Can't stop the IDLE handle used by resolver. Should probably do
+    //something more advanced in case we use other idle handles
+    if (handle->type == UV_IDLE) {
+        return;
+    }
+
     if (!uv_is_closing(handle))
         uv_close(handle, NULL);
 }
@@ -138,6 +144,7 @@ static void neat_close_loop(struct neat_ctx *nc)
     neat_log(NEAT_LOG_DEBUG, "%s", __func__);
 
     uv_walk(nc->loop, neat_walk_cb, nc);
+
     //Let all close handles run
     uv_run(nc->loop, UV_RUN_DEFAULT);
     uv_loop_close(nc->loop);

--- a/neat_core.c
+++ b/neat_core.c
@@ -2042,14 +2042,13 @@ neat_connect(struct he_cb_ctx *he_ctx, uv_poll_cb callback_fx)
 #endif
 
     uv_poll_init(he_ctx->nc->loop, he_ctx->handle, he_ctx->fd); // makes fd nb as side effect
-    if (he_ctx->fd == -1) {
-        retval = connect(he_ctx->fd, (struct sockaddr *) &(he_ctx->candidate->dst_addr), slen);
-        
-        if (retval && errno != EINPROGRESS) {
-            neat_log(NEAT_LOG_DEBUG, "%s: Connect failed for fd %d %d", __func__, he_ctx->fd, retval);
-            return -2;
-        }
+    
+    retval = connect(he_ctx->fd, (struct sockaddr *) &(he_ctx->candidate->dst_addr), slen);    
+    if (retval && errno != EINPROGRESS) {
+        neat_log(NEAT_LOG_DEBUG, "%s: Connect failed for fd %d connect retval %d", __func__, he_ctx->fd, retval);
+        return -2;
     }
+
     uv_poll_start(he_ctx->handle, UV_WRITABLE, callback_fx);
 #if defined(USRSCTP_SUPPORT)
     }

--- a/neat_core.c
+++ b/neat_core.c
@@ -1469,7 +1469,7 @@ accept_resolve_cb(struct neat_resolver_results *results,
     //variables should be determined by something else, like which listen socket
     //data arrives on
     flow->sockType = SOCK_STREAM;
-    flow->sockStack = NEAT_STACK_TCP;
+    flow->sockStack = NEAT_STACK_STCP;
     flow->resolver_results = results;
     flow->sockAddr = (struct sockaddr *) &(results->lh_first->dst_addr);
 

--- a/neat_core.c
+++ b/neat_core.c
@@ -1324,10 +1324,12 @@ neat_change_timeout(neat_ctx *mgr, neat_flow *flow, int seconds)
 }
 
 static void
-set_primary_dest_resolve_cb(struct neat_resolver *resolver, struct neat_resolver_results *results, uint8_t code)
+set_primary_dest_resolve_cb(struct neat_resolver_results *results,
+                            uint8_t code,
+                            void *user_data)
 {
     int rc;
-    neat_flow *flow = (neat_flow *)resolver->userData1;
+    neat_flow *flow = user_data;
     struct neat_ctx *ctx = flow->ctx;
     char dest_addr[NI_MAXHOST];
 
@@ -1417,9 +1419,11 @@ neat_request_capacity(struct neat_ctx *ctx, struct neat_flow *flow, int rate, in
 }
 
 static void
-accept_resolve_cb(struct neat_resolver *resolver, struct neat_resolver_results *results, uint8_t code)
+accept_resolve_cb(struct neat_resolver_results *results,
+                  uint8_t code,
+                  void *user_data)
 {
-    neat_flow *flow = (neat_flow *)resolver->userData1;
+    neat_flow *flow = user_data;
     struct neat_ctx *ctx = flow->ctx;
     neat_log(NEAT_LOG_DEBUG, "%s", __func__);
 

--- a/neat_core.c
+++ b/neat_core.c
@@ -27,6 +27,7 @@
 #include "neat_queue.h"
 #include "neat_property_helpers.h"
 #include "neat_stat.h"
+#include "neat_resolver_helpers.h"
 
 #if defined(USRSCTP_SUPPORT)
     #include "neat_usrsctp_internal.h"
@@ -1423,7 +1424,7 @@ neat_set_primary_dest(struct neat_ctx *ctx, struct neat_flow *flow, const char *
     neat_log(NEAT_LOG_DEBUG, "%s", __func__);
 
     if (neat_base_stack(flow->sockStack) == NEAT_STACK_SCTP) {
-        literal = neat_resolver_check_for_literal(&family, name);
+        literal = neat_resolver_helpers_check_for_literal(&family, name);
 
         if (literal != 1) {
             neat_log(NEAT_LOG_ERROR, "%s: provided name '%s' is not an address literal.\n",

--- a/neat_core.c
+++ b/neat_core.c
@@ -166,7 +166,6 @@ void neat_free_ctx(struct neat_ctx *nc)
 
     if (nc->resolver) {
         neat_resolver_release(nc->resolver);
-        free(nc->resolver);
     }
 
     if (nc->event_cbs)

--- a/neat_core.c
+++ b/neat_core.c
@@ -2042,7 +2042,7 @@ neat_connect(struct he_cb_ctx *he_ctx, uv_poll_cb callback_fx)
 #endif
 
     uv_poll_init(he_ctx->nc->loop, he_ctx->handle, he_ctx->fd); // makes fd nb as side effect
-    if ((he_ctx->fd == -1)) {
+    if (he_ctx->fd == -1) {
         retval = connect(he_ctx->fd, (struct sockaddr *) &(he_ctx->candidate->dst_addr), slen);
         
         if (retval && errno != EINPROGRESS) {

--- a/neat_core.c
+++ b/neat_core.c
@@ -1946,14 +1946,13 @@ neat_connect(struct he_cb_ctx *he_ctx, uv_poll_cb callback_fx)
     neat_log(NEAT_LOG_DEBUG, "%s", __func__);
 
 #if defined(USRSCTP_SUPPORT)
-    if (neat_base_stack(he_ctx->candidate->ai_stack) == NEAT_STACK_SCTP) {
+    if (neat_base_stack(he_ctx->ai_stack) == NEAT_STACK_SCTP) {
         neat_connect_via_usrsctp(he_ctx);
     } else {
 #endif
-    //protocol = neat_stack_to_protocol(neat_base_stack(he_ctx->candidate->ai_stack));
-    protocol = IPPROTO_TCP;
+    protocol = neat_stack_to_protocol(neat_base_stack(he_ctx->ai_stack));
     if (protocol == 0) {
-        //neat_log(NEAT_LOG_ERROR, "Stack %d not supported", he_ctx->candidate->ai_stack);
+        neat_log(NEAT_LOG_ERROR, "Stack %d not supported", he_ctx->ai_stack);
         return -1;
     }
     if ((he_ctx->fd = socket(he_ctx->candidate->ai_family, he_ctx->ai_socktype, protocol)) < 0) {
@@ -2030,7 +2029,7 @@ neat_connect(struct he_cb_ctx *he_ctx, uv_poll_cb callback_fx)
 #endif
 
 #if defined(IPPROTO_SCTP) && defined(SCTP_INITMSG)
-    if (he_ctx->candidate->ai_stack == NEAT_STACK_SCTP) {
+    if (he_ctx->ai_stack == NEAT_STACK_SCTP) {
         struct sctp_initmsg init;
         memset(&init, 0, sizeof(init));
         init.sinit_num_ostreams = he_ctx->flow->stream_count;

--- a/neat_core.c
+++ b/neat_core.c
@@ -2267,7 +2267,7 @@ neat_connect_via_usrsctp(struct he_cb_ctx *he_ctx)
         return -1;
     }
 
-    he_ctx->sock = usrsctp_socket(he_ctx->candidate->ai_family, he_ctx->candidate->ai_socktype, protocol, NULL, NULL, 0, NULL);
+    he_ctx->sock = usrsctp_socket(he_ctx->candidate->ai_family, he_ctx->ai_socktype, protocol, NULL, NULL, 0, NULL);
     if (he_ctx->sock) {
         usrsctp_set_non_blocking(he_ctx->sock, 1);
         len = (socklen_t)sizeof(int);
@@ -2311,8 +2311,8 @@ neat_connect_via_usrsctp(struct he_cb_ctx *he_ctx)
         if (flow->hefirstConnect) {
             flow->hefirstConnect = 0;
             flow->family = he_ctx->candidate->ai_family;
-            flow->sockType = he_ctx->candidate->ai_socktype;
-            flow->sockStack = he_ctx->candidate->ai_stack;
+            flow->sockType = he_ctx->ai_socktype;
+            flow->sockStack = he_ctx->ai_stack;
             flow->everConnected = 1;
             flow->sock = he_ctx->sock;
             flow->fd = -1;

--- a/neat_he.c
+++ b/neat_he.c
@@ -34,7 +34,6 @@ static void he_print_results(struct neat_resolver_results *results)
                 break;
         }
 
-        //printf("port: %u\n", result->dst_port);
         getnameinfo((struct sockaddr *)&result->src_addr, result->src_addr_len,
                     addr_name_src, sizeof(addr_name_src),
                     serv_name_src, sizeof(serv_name_src),

--- a/neat_he.c
+++ b/neat_he.c
@@ -216,8 +216,7 @@ neat_error_code neat_he_lookup(neat_ctx *ctx, neat_flow *flow, uv_poll_cb callba
     /* FIXME: derivation of the socket type is wrong.
      * FIXME: Make use of the array of protocols
      */
-    neat_getaddrinfo(ctx->resolver, family, flow->name, flow->port,
-            stacks, nr_of_stacks);
+    neat_getaddrinfo(ctx->resolver, family, flow->name, flow->port);
 
     return NEAT_OK;
 }

--- a/neat_he.c
+++ b/neat_he.c
@@ -217,7 +217,7 @@ neat_error_code neat_he_lookup(neat_ctx *ctx, neat_flow *flow, uv_poll_cb callba
      * FIXME: Make use of the array of protocols
      */
     neat_getaddrinfo(ctx->resolver, family, flow->name, flow->port,
-                     he_resolve_cb);
+                     he_resolve_cb, flow);
 
     return NEAT_OK;
 }

--- a/neat_he.c
+++ b/neat_he.c
@@ -115,9 +115,12 @@ static void free_he_handle_cb(uv_handle_t *handle)
 }
 
 static void
-he_resolve_cb(struct neat_resolver *resolver, struct neat_resolver_results *results, uint8_t code)
+he_resolve_cb(struct neat_resolver_results *results,
+              uint8_t code,
+              void *user_data)
 {
-    neat_flow *flow = (neat_flow *)resolver->userData1;
+#if 0
+    neat_flow *flow = user_data;
     neat_log(NEAT_LOG_DEBUG, "%s", __func__);
 
     if (code == NEAT_RESOLVER_TIMEOUT)  {
@@ -174,6 +177,7 @@ he_resolve_cb(struct neat_resolver *resolver, struct neat_resolver_results *resu
     if (flow->heConnectAttemptCount == 0) {
         io_error(resolver->nc, flow, NEAT_INVALID_STREAM, NEAT_ERROR_IO);
     }
+#endif
 }
 
 neat_error_code neat_he_lookup(neat_ctx *ctx, neat_flow *flow, uv_poll_cb callback_fx)
@@ -210,8 +214,8 @@ neat_error_code neat_he_lookup(neat_ctx *ctx, neat_flow *flow, uv_poll_cb callba
         ctx->resolver = neat_resolver_init(ctx, "/etc/resolv.conf");
     }
 
-    ctx->resolver->userData1 = (void *)flow; // TODO: This doesn't allow multiple sockets
-    ctx->resolver->userData2 = callback_fx;
+    /*ctx->resolver->userData1 = (void *)flow; // TODO: This doesn't allow multiple sockets
+    ctx->resolver->userData2 = callback_fx;*/
 
     /* FIXME: derivation of the socket type is wrong.
      * FIXME: Make use of the array of protocols

--- a/neat_he.c
+++ b/neat_he.c
@@ -207,16 +207,17 @@ neat_error_code neat_he_lookup(neat_ctx *ctx, neat_flow *flow, uv_poll_cb callba
         return NEAT_ERROR_UNABLE;
 
     if (!ctx->resolver) {
-        ctx->resolver = neat_resolver_init(ctx, "/etc/resolv.conf",
-                                           he_resolve_cb, NULL);
+        ctx->resolver = neat_resolver_init(ctx, "/etc/resolv.conf");
     }
+
     ctx->resolver->userData1 = (void *)flow; // TODO: This doesn't allow multiple sockets
     ctx->resolver->userData2 = callback_fx;
 
     /* FIXME: derivation of the socket type is wrong.
      * FIXME: Make use of the array of protocols
      */
-    neat_getaddrinfo(ctx->resolver, family, flow->name, flow->port);
+    neat_getaddrinfo(ctx->resolver, family, flow->name, flow->port,
+                     he_resolve_cb);
 
     return NEAT_OK;
 }

--- a/neat_he.c
+++ b/neat_he.c
@@ -224,9 +224,6 @@ neat_error_code neat_he_lookup(neat_ctx *ctx, neat_flow *flow, uv_poll_cb callba
         ctx->resolver = neat_resolver_init(ctx, "/etc/resolv.conf");
     }
 
-    /*ctx->resolver->userData1 = (void *)flow; // TODO: This doesn't allow multiple sockets
-    ctx->resolver->userData2 = callback_fx;*/
-
     /* FIXME: derivation of the socket type is wrong.
      * FIXME: Make use of the array of protocols
      */

--- a/neat_he.c
+++ b/neat_he.c
@@ -217,8 +217,10 @@ neat_error_code neat_he_lookup(neat_ctx *ctx, neat_flow *flow, uv_poll_cb callba
     nr_of_stacks = neat_property_translate_protocols(flow->propertyMask,
             stacks);
 
-    if (nr_of_stacks == 0)
+    if (nr_of_stacks == 0) {
+        free(resolver_data);
         return NEAT_ERROR_UNABLE;
+    }
 
     if (!ctx->resolver) {
         ctx->resolver = neat_resolver_init(ctx, "/etc/resolv.conf");

--- a/neat_he.c
+++ b/neat_he.c
@@ -23,7 +23,7 @@ static void he_print_results(struct neat_resolver_results *results)
     neat_log(NEAT_LOG_INFO, "Happy-Eyeballs results:");
 
     LIST_FOREACH(result, results, next_res) {
-        switch (result->ai_stack) {
+        /*switch (result->ai_stack) {
             case NEAT_STACK_UDP:
                 snprintf(proto, 16, "UDP");
                 break;
@@ -39,7 +39,7 @@ static void he_print_results(struct neat_resolver_results *results)
             default:
                 snprintf(proto, 16, "stack%d", result->ai_stack);
                 break;
-        }
+        }*/
         switch (result->ai_family) {
             case AF_INET:
                 snprintf(family, 16, "IPv4");

--- a/neat_he.c
+++ b/neat_he.c
@@ -33,6 +33,8 @@ static void he_print_results(struct neat_resolver_results *results)
                 snprintf(family, 16, "family%d", result->ai_family);
                 break;
         }
+
+        //printf("port: %u\n", result->dst_port);
         getnameinfo((struct sockaddr *)&result->src_addr, result->src_addr_len,
                     addr_name_src, sizeof(addr_name_src),
                     serv_name_src, sizeof(serv_name_src),

--- a/neat_he.c
+++ b/neat_he.c
@@ -229,8 +229,8 @@ neat_error_code neat_he_lookup(neat_ctx *ctx, neat_flow *flow, uv_poll_cb callba
      */
     resolver_data->flow = flow;
     resolver_data->callback_fx = callback_fx;
-    neat_getaddrinfo(ctx->resolver, family, flow->name, flow->port,
-                     he_resolve_cb, resolver_data);
+    neat_resolve(ctx->resolver, family, flow->name, flow->port,
+                 he_resolve_cb, resolver_data);
 
     return NEAT_OK;
 }

--- a/neat_he.h
+++ b/neat_he.h
@@ -1,0 +1,14 @@
+#ifndef NEAT_HE_H
+#define NEAT_HE_H
+
+#include <uv.h>
+
+struct neat_flow;
+
+struct neat_he_resolver_data
+{
+    struct neat_flow *flow;
+    uv_poll_cb callback_fx;
+};
+
+#endif

--- a/neat_he.h
+++ b/neat_he.h
@@ -4,9 +4,11 @@
 #include <uv.h>
 
 struct neat_flow;
+struct neat_ctx;
 
 struct neat_he_resolver_data
 {
+    struct neat_ctx *ctx;
     struct neat_flow *flow;
     uv_poll_cb callback_fx;
 };

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -251,6 +251,8 @@ struct he_cb_ctx {
     size_t readSize;
     size_t writeLimit;
     unsigned int isSCTPExplicitEOR : 1;
+    int32_t ai_socktype;
+    int32_t ai_stack;
 
     LIST_ENTRY(he_cb_ctx) next_he_ctx;
 };

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -250,9 +250,7 @@ struct he_cb_ctx {
 //Intilize resolver. Sets up internal callbacks etc.
 //Resolve is required, cleanup is not
 struct neat_resolver *neat_resolver_init(struct neat_ctx *nc,
-                                         const char *resolv_conf_path,
-                                         neat_resolver_handle_t handle_resolve,
-                                         neat_resolver_cleanup_t cleanup);
+                                         const char *resolv_conf_path);
 
 //Release all memory occupied by a resolver. Resolver can't be used again
 void neat_resolver_release(struct neat_resolver *resolver);
@@ -262,8 +260,11 @@ void neat_resolver_free_results(struct neat_resolver_results *results);
 
 //Start to resolve a domain name (or literal). Accepts a list of protocols, will
 //set socktype based on protocol
-uint8_t neat_getaddrinfo(struct neat_resolver *resolver, uint8_t family,
-        const char *node, uint16_t port);
+uint8_t neat_getaddrinfo(struct neat_resolver *resolver,
+                         uint8_t family,
+                         const char *node,
+                         uint16_t port,
+                         neat_resolver_handle_t handle_resolve);
 //Check if node is an IP literal or not. Returns -1 on failure, 0 if not
 //literal, 1 if literal
 int8_t neat_resolver_check_for_literal(uint8_t *family, const char *node);

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -274,9 +274,6 @@ uint8_t neat_resolve(struct neat_resolver *resolver,
                          uint16_t port,
                          neat_resolver_handle_t handle_resolve,
                          void *user_data);
-//Check if node is an IP literal or not. Returns -1 on failure, 0 if not
-//literal, 1 if literal
-int8_t neat_resolver_check_for_literal(uint8_t *family, const char *node);
 
 //Update timeouts (in ms) for DNS resolving. T1 is total timeout, T2 is how long
 //to wait after first reply from DNS server. Initial values are 30s and 1s.

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -355,16 +355,6 @@ struct neat_resolver {
     uv_timer_t timeout_handle;
     uv_fs_event_t resolv_conf_handle;
 
-    //Result is the resolved addresses, code is one of the neat_resolver_codes.
-    //Ownsership of results is transfered to application, so it is the
-    //applications responsibility to free memory
-    //void (*handle_resolve)(struct neat_resolver*, struct neat_resolver_results *, uint8_t);
-    neat_resolver_handle_t handle_resolve;
-
-    //Users must be notified when it is safe to free or reset resolver memory.
-    //It has to be done ansync due to libuv cleanup order
-    neat_resolver_cleanup_t cleanup;
-
     //DNS request queue, using TAILQ
     struct neat_resolver_request_queue request_queue;
     struct neat_resolver_request_queue dead_request_queue;

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -186,6 +186,7 @@ struct neat_resolver_server;
 LIST_HEAD(neat_resolver_results, neat_resolver_res);
 LIST_HEAD(neat_resolver_servers, neat_resolver_server);
 
+//TODO: First argument will be changed, maybe change it to the data pointer?
 typedef void (*neat_resolver_handle_t)(struct neat_resolver*, struct neat_resolver_results *, uint8_t);
 typedef void (*neat_resolver_cleanup_t)(struct neat_resolver *resolver);
 

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -263,7 +263,7 @@ void neat_resolver_free_results(struct neat_resolver_results *results);
 
 //Start to resolve a domain name (or literal). Accepts a list of protocols, will
 //set socktype based on protocol
-uint8_t neat_getaddrinfo(struct neat_resolver *resolver,
+uint8_t neat_resolve(struct neat_resolver *resolver,
                          uint8_t family,
                          const char *node,
                          uint16_t port,

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -186,8 +186,11 @@ struct neat_resolver_server;
 LIST_HEAD(neat_resolver_results, neat_resolver_res);
 LIST_HEAD(neat_resolver_servers, neat_resolver_server);
 
-//TODO: First argument will be changed, maybe change it to the data pointer?
-typedef void (*neat_resolver_handle_t)(struct neat_resolver*, struct neat_resolver_results *, uint8_t);
+//Arguments are result struct (must be freed by user), neat_resolver_code and
+//user_data passed to getaddrinfo
+typedef void (*neat_resolver_handle_t)(struct neat_resolver_results *,
+                                       uint8_t,
+                                       void *);
 typedef void (*neat_resolver_cleanup_t)(struct neat_resolver *resolver);
 
 enum neat_resolver_code {
@@ -318,7 +321,6 @@ struct neat_resolver {
     //The resolver will wrap the context, so that we can easily have many
     //resolvers
     struct neat_ctx *nc;
-    void *userData1;
     uv_poll_cb userData2;
 
     //These values are just passed on to neat_resolver_res

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -313,6 +313,7 @@ struct neat_event_cb {
     LIST_ENTRY(neat_event_cb) next_cb;
 };
 
+TAILQ_HEAD(neat_resolver_request_queue, neat_resolver_request);
 struct neat_resolver {
     //The resolver will wrap the context, so that we can easily have many
     //resolvers
@@ -339,7 +340,6 @@ struct neat_resolver {
     //total DNS timeout
     uint8_t name_resolved_timeout;
     uint8_t __pad2;
-    char domain_name[MAX_DOMAIN_LENGTH];
 
     //The reason we need two of these is that as of now, a neat_event_cb
     //struct can only be part of one list. This is a future optimization, if we
@@ -367,6 +367,9 @@ struct neat_resolver {
     //Users must be notified when it is safe to free or reset resolver memory.
     //It has to be done ansync due to libuv cleanup order
     neat_resolver_cleanup_t cleanup;
+
+    //DNS request queue, using TAILQ
+    struct neat_resolver_request_queue request_queue;
 };
 
 neat_error_code neat_he_lookup(neat_ctx *ctx, neat_flow *flow, uv_poll_cb callback_fx);

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -254,8 +254,6 @@ struct neat_resolver *neat_resolver_init(struct neat_ctx *nc,
                                          neat_resolver_handle_t handle_resolve,
                                          neat_resolver_cleanup_t cleanup);
 
-//Reset resolver, it is ready for use right after this is called
-void neat_resolver_reset(struct neat_resolver *resolver);
 //Release all memory occupied by a resolver. Resolver can't be used again
 void neat_resolver_release(struct neat_resolver *resolver);
 
@@ -370,6 +368,7 @@ struct neat_resolver {
 
     //DNS request queue, using TAILQ
     struct neat_resolver_request_queue request_queue;
+    struct neat_resolver_request_queue dead_request_queue;
 };
 
 neat_error_code neat_he_lookup(neat_ctx *ctx, neat_flow *flow, uv_poll_cb callback_fx);

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -228,8 +228,6 @@ struct neat_resolver_server {
 //Struct passed to resolver callback, mirrors what we get back from getaddrinfo
 struct neat_resolver_res {
     int32_t ai_family;
-    int32_t ai_socktype; //TODO: Remove
-    int32_t ai_stack; //TODO: Remove
     uint32_t if_idx;
     struct sockaddr_storage src_addr;
     socklen_t src_addr_len;

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -217,8 +217,8 @@ struct neat_resolver_server {
 //Struct passed to resolver callback, mirrors what we get back from getaddrinfo
 struct neat_resolver_res {
     int32_t ai_family;
-    int32_t ai_socktype;
-    int32_t ai_stack;
+    int32_t ai_socktype; //TODO: Remove
+    int32_t ai_stack; //TODO: Remove
     uint32_t if_idx;
     struct sockaddr_storage src_addr;
     socklen_t src_addr_len;

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -329,11 +329,7 @@ struct neat_resolver {
     uint16_t dns_t1;
     //DNS timeout after at least one domain has been resolved
     uint16_t dns_t2;
-    uint16_t dst_port;
-    uint16_t __pad;
 
-    //Domain name and family to look up
-    uint8_t family;
     //Will be set to 1 if we are going to free resolver in idle
     //TODO: Will most likely be changed to a state variable
     uint8_t free_resolver;

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -311,7 +311,7 @@ struct neat_event_cb {
     LIST_ENTRY(neat_event_cb) next_cb;
 };
 
-LIST_HEAD(neat_resolver_request_queue, neat_resolver_request);
+TAILQ_HEAD(neat_resolver_request_queue, neat_resolver_request);
 struct neat_resolver {
     //The resolver will wrap the context, so that we can easily have many
     //resolvers

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -264,7 +264,8 @@ uint8_t neat_getaddrinfo(struct neat_resolver *resolver,
                          uint8_t family,
                          const char *node,
                          uint16_t port,
-                         neat_resolver_handle_t handle_resolve);
+                         neat_resolver_handle_t handle_resolve,
+                         void *user_data);
 //Check if node is an IP literal or not. Returns -1 on failure, 0 if not
 //literal, 1 if literal
 int8_t neat_resolver_check_for_literal(uint8_t *family, const char *node);

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -321,7 +321,6 @@ struct neat_resolver {
     //The resolver will wrap the context, so that we can easily have many
     //resolvers
     struct neat_ctx *nc;
-    uv_poll_cb userData2;
 
     //These values are just passed on to neat_resolver_res
     //TODO: Remove this, will be set on result

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -265,8 +265,7 @@ void neat_resolver_free_results(struct neat_resolver_results *results);
 //Start to resolve a domain name (or literal). Accepts a list of protocols, will
 //set socktype based on protocol
 uint8_t neat_getaddrinfo(struct neat_resolver *resolver, uint8_t family,
-        const char *node, uint16_t port, neat_protocol_stack_type ai_stack[],
-        uint8_t stack_count);
+        const char *node, uint16_t port);
 //Check if node is an IP literal or not. Returns -1 on failure, 0 if not
 //literal, 1 if literal
 int8_t neat_resolver_check_for_literal(uint8_t *family, const char *node);

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -337,7 +337,7 @@ struct neat_resolver {
     //Flag used to signal if we have resolved name and timeout has switched from
     //total DNS timeout
     uint8_t name_resolved_timeout;
-    uint8_t __pad2;
+    uint8_t fs_event_closed;
 
     //The reason we need two of these is that as of now, a neat_event_cb
     //struct can only be part of one list. This is a future optimization, if we

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -311,7 +311,7 @@ struct neat_event_cb {
     LIST_ENTRY(neat_event_cb) next_cb;
 };
 
-TAILQ_HEAD(neat_resolver_request_queue, neat_resolver_request);
+LIST_HEAD(neat_resolver_request_queue, neat_resolver_request);
 struct neat_resolver {
     //The resolver will wrap the context, so that we can easily have many
     //resolvers

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -32,6 +32,7 @@
 
 struct neat_event_cb;
 struct neat_addr;
+struct neat_resolver;
 
 //TODO: One drawback with using LIST from queue.h, is that a callback can only
 //be member of one list. Decide if this is critical and improve if needed
@@ -179,7 +180,6 @@ struct neat_interface_stats {
 typedef struct neat_interface_stats neat_interface_stats;
 
 //NEAT resolver public data structures/functions
-struct neat_resolver;
 struct neat_resolver_res;
 struct neat_resolver_server;
 
@@ -314,50 +314,6 @@ struct neat_event_cb {
     void (*event_cb)(struct neat_ctx *nc, void *p_ptr, void *data);
     void *data;
     LIST_ENTRY(neat_event_cb) next_cb;
-};
-
-TAILQ_HEAD(neat_resolver_request_queue, neat_resolver_request);
-struct neat_resolver {
-    //The resolver will wrap the context, so that we can easily have many
-    //resolvers
-    struct neat_ctx *nc;
-
-    //These values are just passed on to neat_resolver_res
-    //TODO: Remove this, will be set on result
-    neat_protocol_stack_type ai_stack[NEAT_STACK_MAX_NUM];
-    //DNS timeout before any domain has been resolved
-    uint16_t dns_t1;
-    //DNS timeout after at least one domain has been resolved
-    uint16_t dns_t2;
-
-    //Will be set to 1 if we are going to free resolver in idle
-    //TODO: Will most likely be changed to a state variable
-    uint8_t free_resolver;
-    //Flag used to signal if we have resolved name and timeout has switched from
-    //total DNS timeout
-    uint8_t name_resolved_timeout;
-    uint8_t fs_event_closed;
-
-    //The reason we need two of these is that as of now, a neat_event_cb
-    //struct can only be part of one list. This is a future optimization, if we
-    //decide that it is a problem
-    struct neat_event_cb newaddr_cb;
-    struct neat_event_cb deladdr_cb;
-
-    //Keep track of all DNS servers seen until now
-    struct neat_resolver_servers server_list;
-
-    //List of all active resolver pairs
-    struct neat_resolver_pairs resolver_pairs;
-    //Need to defer free until libuv has clean up memory
-    struct neat_resolver_pairs resolver_pairs_del;
-    uv_idle_t idle_handle;
-    uv_timer_t timeout_handle;
-    uv_fs_event_t resolv_conf_handle;
-
-    //DNS request queue, using TAILQ
-    struct neat_resolver_request_queue request_queue;
-    struct neat_resolver_request_queue dead_request_queue;
 };
 
 neat_error_code neat_he_lookup(neat_ctx *ctx, neat_flow *flow, uv_poll_cb callback_fx);

--- a/neat_resolver.c
+++ b/neat_resolver.c
@@ -972,7 +972,8 @@ uint8_t neat_getaddrinfo(struct neat_resolver *resolver,
                          uint8_t family,
                          const char *node,
                          uint16_t port,
-                         neat_resolver_handle_t handle_resolve)
+                         neat_resolver_handle_t handle_resolve,
+                         void *user_data)
 {
     struct neat_resolver_request *request;
     int8_t is_literal = 0;
@@ -996,6 +997,7 @@ uint8_t neat_getaddrinfo(struct neat_resolver *resolver,
     request->family = family;
     request->dst_port = htons(port);
     request->resolver = resolver;
+    request->data = user_data;
 
     uv_timer_init(resolver->nc->loop, &(request->timeout_handle));
     request->timeout_handle.data = request;

--- a/neat_resolver.c
+++ b/neat_resolver.c
@@ -228,7 +228,6 @@ static uint32_t neat_resolver_literal_populate_results(struct neat_resolver_requ
         u.dst_addr4 = (struct sockaddr_in*) &dst_addr;
         memset(u.dst_addr4, 0, sizeof(struct sockaddr_in));
         u.dst_addr4->sin_family = AF_INET;
-        u.dst_addr4->sin_port = request->dst_port;
 #ifdef HAVE_SIN_LEN
         u.dst_addr4->sin_len = sizeof(struct sockaddr_in);
 #endif
@@ -237,7 +236,6 @@ static uint32_t neat_resolver_literal_populate_results(struct neat_resolver_requ
         u.dst_addr6 = (struct sockaddr_in6*) &dst_addr;
         memset(u.dst_addr6, 0, sizeof(struct sockaddr_in6));
         u.dst_addr6->sin6_family = AF_INET6;
-        u.dst_addr6->sin6_port = request->dst_port;
 #ifdef HAVE_SIN6_LEN
         u.dst_addr6->sin6_len = sizeof(struct sockaddr_in6);
 #endif
@@ -259,7 +257,8 @@ static uint32_t neat_resolver_literal_populate_results(struct neat_resolver_requ
         if (nsrc_addr->family == AF_INET6 && !nsrc_addr->u.v6.ifa_pref)
             continue;
 
-        num_resolved_addrs += neat_resolver_helpers_fill_results(result_list,
+        num_resolved_addrs += neat_resolver_helpers_fill_results(request,
+                                                                 result_list,
                                                                  nsrc_addr,
                                                                  dst_addr);
     }
@@ -295,7 +294,8 @@ static uint32_t neat_resolver_populate_results(struct neat_resolver_request *req
                 break;
 
             //TODO: Consider connecting pairs to request instead of resolver
-            num_resolved_addrs += neat_resolver_helpers_fill_results(result_list,
+            num_resolved_addrs += neat_resolver_helpers_fill_results(request,
+                                                                     result_list,
                                                                      pair_itr->src_addr,
                                                                      pair_itr->resolved_addr[i]);
         }

--- a/neat_resolver.c
+++ b/neat_resolver.c
@@ -1111,8 +1111,10 @@ static void neat_resolver_cleanup(struct neat_resolver *resolver)
     neat_remove_event_cb(resolver->nc, NEAT_NEWADDR, &(resolver->newaddr_cb));
     neat_remove_event_cb(resolver->nc, NEAT_DELADDR, &(resolver->deladdr_cb));
     uv_fs_event_stop(&(resolver->resolv_conf_handle));
-    uv_close((uv_handle_t*) &(resolver->resolv_conf_handle),
-             neat_resolver_conf_close_cb);
+
+    if (!uv_is_closing((const uv_handle_t*) &(resolver->resolv_conf_handle)))
+        uv_close((uv_handle_t*) &(resolver->resolv_conf_handle),
+                neat_resolver_conf_close_cb);
 
     //Remove all entries in the server table
     LIST_FOREACH_SAFE(server, &(resolver->server_list), next_server, server_next) {

--- a/neat_resolver.c
+++ b/neat_resolver.c
@@ -22,6 +22,7 @@
 #include "neat_addr.h"
 #include "neat_resolver.h"
 #include "neat_resolver_conf.h"
+#include "neat_resolver_helpers.h"
 
 static uint8_t neat_resolver_create_pairs(struct neat_addr *src_addr,
                                           struct neat_resolver_request *request);
@@ -177,60 +178,6 @@ static void neat_resolver_idle_cb(uv_idle_t *handle)
     uv_close((uv_handle_t*) handle, neat_resolver_idle_close_cb);
 }
 
-static uint8_t neat_resolver_addr_internal(struct sockaddr_storage *addr)
-{
-    struct sockaddr_in *addr4 = NULL;
-    struct sockaddr_in6 *addr6 = NULL;
-    uint32_t haddr4 = 0;
-
-    if (addr->ss_family == AF_INET6) {
-        addr6 = (struct sockaddr_in6*) addr;
-        return (addr6->sin6_addr.s6_addr[0] & 0xfe) != 0xfc;
-    }
-
-    addr4 = (struct sockaddr_in*) addr;
-    haddr4 = ntohl(addr4->sin_addr.s_addr);
-
-    if ((haddr4 & IANA_A_MASK) == IANA_A_NW ||
-        (haddr4 & IANA_B_MASK) == IANA_B_NW ||
-        (haddr4 & IANA_C_MASK) == IANA_C_NW)
-        return 1;
-    else
-        return 0;
-}
-
-//Create all results for one match
-static uint8_t neat_resolver_fill_results(
-        struct neat_resolver_results *result_list,
-        struct neat_addr *src_addr,
-        struct sockaddr_storage dst_addr)
-{
-    socklen_t addrlen;
-    struct neat_resolver_res *result;
-    uint8_t num_addr_added = 0;
-
-    result = calloc(sizeof(struct neat_resolver_res), 1);
-
-    if (result == NULL)
-        return 0;
-
-    addrlen = src_addr->family == AF_INET ?
-        sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6);
-
-    result->ai_family = src_addr->family;
-    result->if_idx = src_addr->if_idx;
-    result->src_addr = src_addr->u.generic.addr;
-    result->src_addr_len = addrlen;
-    result->dst_addr = dst_addr;
-    result->dst_addr_len = addrlen;
-    result->internal = neat_resolver_addr_internal(&dst_addr);
-    
-    LIST_INSERT_HEAD(result_list, result, next_res);
-    num_addr_added++;
-
-    return num_addr_added;
-}
-
 static void neat_resolver_request_cleanup(struct neat_resolver_request *request)
 {
     struct neat_resolver_src_dst_addr *resolver_pair, *resolver_itr;
@@ -312,8 +259,9 @@ static uint32_t neat_resolver_literal_populate_results(struct neat_resolver_requ
         if (nsrc_addr->family == AF_INET6 && !nsrc_addr->u.v6.ifa_pref)
             continue;
 
-        num_resolved_addrs += neat_resolver_fill_results(result_list, nsrc_addr,
-                                                         dst_addr);
+        num_resolved_addrs += neat_resolver_helpers_fill_results(result_list,
+                                                                 nsrc_addr,
+                                                                 dst_addr);
     }
 
     return num_resolved_addrs;
@@ -347,9 +295,9 @@ static uint32_t neat_resolver_populate_results(struct neat_resolver_request *req
                 break;
 
             //TODO: Consider connecting pairs to request instead of resolver
-            num_resolved_addrs += neat_resolver_fill_results(result_list,
-                                                             pair_itr->src_addr,
-                                                             pair_itr->resolved_addr[i]);
+            num_resolved_addrs += neat_resolver_helpers_fill_results(result_list,
+                                                                     pair_itr->src_addr,
+                                                                     pair_itr->resolved_addr[i]);
         }
 
         pair_itr = pair_itr->next_pair.le_next;
@@ -481,83 +429,6 @@ static void neat_resolver_mark_pair_del(struct neat_resolver *resolver,
         uv_idle_start(&(resolver->idle_handle), neat_resolver_idle_cb);
 }
 
-static uint8_t neat_resolver_check_duplicate(
-        struct neat_resolver_src_dst_addr *pair, const char *resolved_addr_str)
-{
-    //Accepts a src_dst_pair and an address, convert this address to struct
-    //in{6}_addr, then check all pairs if this IP has seen before for same
-    //(index, source)
-    struct neat_addr *src_addr = pair->src_addr;
-    struct sockaddr_in *src_addr_4 = NULL, *cmp_addr_4 = NULL;
-    struct sockaddr_in6 *src_addr_6 = NULL, *cmp_addr_6 = NULL;
-    union {
-        struct in_addr resolved_addr_4;
-        struct in6_addr resolved_addr_6;
-    } u;
-    struct neat_resolver_src_dst_addr *itr;
-    uint8_t addr_equal = 0;
-    int32_t i;
-
-    if (src_addr->family == AF_INET) {
-        src_addr_4 = &(src_addr->u.v4.addr4);
-        i = inet_pton(AF_INET, resolved_addr_str,
-                (void *) &u.resolved_addr_4);
-    } else {
-        src_addr_6 = &(src_addr->u.v6.addr6);
-        i = inet_pton(AF_INET6, resolved_addr_str,
-                (void *) &u.resolved_addr_6);
-    }
-
-    //the calleee also does pton, so that failure will currently be handled
-    //elsewhere
-    //TODO: SO UGLY!!!!!!!!!!!!!
-    if (i <= 0)
-        return 0;
-
-    for (itr = pair->request->resolver_pairs.lh_first; itr != NULL;
-            itr = itr->next_pair.le_next) {
-
-        //Must match index
-        if (src_addr->if_idx != itr->src_addr->if_idx ||
-            src_addr->family != itr->src_addr->family)
-            continue;
-
-        if (src_addr->family == AF_INET) {
-            cmp_addr_4 = &(itr->src_addr->u.v4.addr4);
-            addr_equal = (cmp_addr_4->sin_addr.s_addr ==
-                          src_addr_4->sin_addr.s_addr);
-        } else {
-            cmp_addr_6 = &(itr->src_addr->u.v6.addr6);
-            addr_equal = neat_addr_cmp_ip6_addr(&(cmp_addr_6->sin6_addr),
-                                                &(src_addr_6->sin6_addr));
-        }
-
-        if (!addr_equal)
-            continue;
-
-        //Check all resolved addresses
-        for (i = 0; i < MAX_NUM_RESOLVED; i++) {
-            if (!itr->resolved_addr[i].ss_family)
-                break;
-
-            if (src_addr->family == AF_INET) {
-                cmp_addr_4 = (struct sockaddr_in*) &(itr->resolved_addr[i]);
-                addr_equal = (u.resolved_addr_4.s_addr ==
-                              cmp_addr_4->sin_addr.s_addr);
-            } else {
-                cmp_addr_6 = (struct sockaddr_in6*) &(itr->resolved_addr[i]);
-                addr_equal = neat_addr_cmp_ip6_addr(&(cmp_addr_6->sin6_addr),
-                                                    &(u.resolved_addr_6));
-            }
-
-            if (addr_equal)
-                return 1;
-        }
-    }
-
-    return 0;
-}
-
 //Receive and parse a DNS reply
 //TODO: Refactor and make large parts helper function?
 static void neat_resolver_dns_recv_cb(uv_udp_t* handle, ssize_t nread,
@@ -616,7 +487,7 @@ static void neat_resolver_dns_recv_cb(uv_udp_t* handle, ssize_t nread,
         if (pair->src_addr->family == AF_INET) {
             ldns_rdf2buffer_str_a(host_addr, rdf_result);
 
-            if (neat_resolver_check_duplicate(pair,
+            if (neat_resolver_helpers_check_duplicate(pair,
                     (const char *) ldns_buffer_begin(host_addr))) {
                 ldns_buffer_free(host_addr);
                 continue;
@@ -635,7 +506,7 @@ static void neat_resolver_dns_recv_cb(uv_udp_t* handle, ssize_t nread,
             }
         } else {
             ldns_rdf2buffer_str_aaaa(host_addr, rdf_result);
-            if (neat_resolver_check_duplicate(pair,
+            if (neat_resolver_helpers_check_duplicate(pair,
                     (const char *) ldns_buffer_begin(host_addr))) {
                 ldns_buffer_free(host_addr);
                 continue;
@@ -896,42 +767,6 @@ static void neat_resolver_delete_pairs(struct neat_resolver_request *request,
     }
 }
 
-//Check if node is an IP literal or not. Returns -1 on failure, 0 if not
-//literal, 1 if literal
-int8_t neat_resolver_check_for_literal(uint8_t *family, const char *node)
-{
-    struct in6_addr dummy_addr;
-    int32_t v4_literal = 0, v6_literal = 0;
-
-    if (*family != AF_UNSPEC && *family != AF_INET && *family != AF_INET6) {
-        neat_log(NEAT_LOG_ERROR, "%s - Unsupported address family", __func__);
-        return -1;
-    }
-
-    //The only time inet_pton fails is if the system lacks v4/v6 support. This
-    //should rather be handled with an ifdef + check at compile time
-    v4_literal = inet_pton(AF_INET, node, &dummy_addr);
-    v6_literal = inet_pton(AF_INET6, node, &dummy_addr);
-
-    //These are the two possible error cases:
-    //if family is v4 and address is v6 (or opposite), then user has made a
-    //mistake and must be notifed
-    if ((*family == AF_INET && v6_literal) ||
-        (*family == AF_INET6 && v4_literal)) {
-        neat_log(NEAT_LOG_ERROR, "%s - Mismatch between family and literal", __func__);
-        return -1;
-    }
-
-    if (*family == AF_UNSPEC) {
-        if (v4_literal)
-            *family = AF_INET;
-        if (v6_literal)
-            *family = AF_INET6;
-    }
-
-    return v4_literal | v6_literal;
-}
-
 //This one will (at least for now) be used to start the first quest. Lets see
 //how much we can recycle when we start processing queue
 static void neat_start_request(struct neat_resolver *resolver,
@@ -1016,7 +851,8 @@ uint8_t neat_resolve(struct neat_resolver *resolver,
     //HACK: This is just a hack for testing, will be set based on argument later!
     request->resolve_cb = handle_resolve;
 
-    is_literal = neat_resolver_check_for_literal(&(request->family), node);
+    is_literal = neat_resolver_helpers_check_for_literal(&(request->family),
+                                                         node);
 
     if (is_literal < 0)
         return RETVAL_FAILURE;

--- a/neat_resolver.c
+++ b/neat_resolver.c
@@ -37,7 +37,7 @@ static void neat_resolver_handle_newaddr(struct neat_ctx *nc,
                                          void *data)
 {
     struct neat_resolver *resolver = p_ptr;
-    struct neat_resolver_request *request = resolver->request_queue.tqh_first;
+    struct neat_resolver_request *request_itr;
     struct neat_addr *src_addr = data;
 
     if (resolver->family && resolver->family != src_addr->family)
@@ -47,12 +47,12 @@ static void neat_resolver_handle_newaddr(struct neat_ctx *nc,
     if (src_addr->family == AF_INET6 && !src_addr->u.v6.ifa_pref)
         return;
 
-    //TODO: This will be a loop through all requests
-    if (!request)
-        return;
+    request_itr = resolver->request_queue.tqh_first;
 
-    //TODO: Figure out what to do here
-    neat_resolver_create_pairs(src_addr, request);
+    while (request_itr != NULL) {
+        neat_resolver_create_pairs(src_addr, request_itr);
+        request_itr = request_itr->next_req.tqe_next;
+    }
 }
 
 static void neat_resolver_handle_deladdr(struct neat_ctx *nic,

--- a/neat_resolver.c
+++ b/neat_resolver.c
@@ -974,12 +974,12 @@ static void neat_start_request(struct neat_resolver *resolver,
 
 //Public NEAT resolver functions
 //getaddrinfo starts a query for the provided service
-uint8_t neat_getaddrinfo(struct neat_resolver *resolver,
-                         uint8_t family,
-                         const char *node,
-                         uint16_t port,
-                         neat_resolver_handle_t handle_resolve,
-                         void *user_data)
+uint8_t neat_resolve(struct neat_resolver *resolver,
+                     uint8_t family,
+                     const char *node,
+                     uint16_t port,
+                     neat_resolver_handle_t handle_resolve,
+                     void *user_data)
 {
     struct neat_resolver_request *request;
     int8_t is_literal = 0;

--- a/neat_resolver.c
+++ b/neat_resolver.c
@@ -829,28 +829,6 @@ int8_t neat_resolver_check_for_literal(uint8_t *family, const char *node)
     return v4_literal | v6_literal;
 }
 
-static uint8_t neat_validate_protocols(neat_protocol_stack_type stacks[], uint8_t stack_count)
-{
-    uint8_t i;
-
-    if (stack_count > NEAT_STACK_MAX_NUM)
-        return RETVAL_FAILURE;
-
-    for (i = 0; i < stack_count; i++) {
-        switch (stacks[i]) {
-        case NEAT_STACK_UDP:
-        case NEAT_STACK_UDPLITE:
-        case NEAT_STACK_TCP:
-        case NEAT_STACK_SCTP:
-            continue;
-        default:
-            return RETVAL_FAILURE;
-        }
-    }
-
-    return RETVAL_SUCCESS;
-}
-
 //This one will (at least for now) be used to start the first quest. Lets see
 //how much we can recycle when we start processing queue
 static void neat_start_request(struct neat_resolver *resolver,
@@ -899,9 +877,7 @@ static void neat_start_request(struct neat_resolver *resolver,
 uint8_t neat_getaddrinfo(struct neat_resolver *resolver,
                          uint8_t family,
                          const char *node,
-                         uint16_t port,
-                         neat_protocol_stack_type ai_stack[],
-                         uint8_t stack_count)
+                         uint16_t port)
 {
     struct neat_resolver_request *request;
     uint8_t do_request = 0;
@@ -914,11 +890,6 @@ uint8_t neat_getaddrinfo(struct neat_resolver *resolver,
 
     if (family && family != AF_INET && family != AF_INET6 && family != AF_UNSPEC) {
         neat_log(NEAT_LOG_ERROR, "%s - Invalid family specified", __func__);
-        return RETVAL_FAILURE;
-    }
-
-    if (neat_validate_protocols(ai_stack, stack_count)) {
-        neat_log(NEAT_LOG_ERROR, "%s - Error in desired protocol list", __func__);
         return RETVAL_FAILURE;
     }
 

--- a/neat_resolver.c
+++ b/neat_resolver.c
@@ -968,12 +968,16 @@ neat_resolver_init(struct neat_ctx *nc,
                    neat_resolver_handle_t handle_resolve,
                    neat_resolver_cleanup_t cleanup)
 {
-    struct neat_resolver *resolver = calloc(sizeof(struct neat_resolver), 1);
 
-    if (!handle_resolve || !resolver) {
-        free(resolver);
+    struct neat_resolver *resolver;
+    
+    if (!handle_resolve)
         return NULL;
-    }
+
+    resolver = calloc(sizeof(struct neat_resolver), 1);
+
+    if (!resolver)
+        return NULL;
 
     TAILQ_INIT(&(resolver->request_queue));
 

--- a/neat_resolver.c
+++ b/neat_resolver.c
@@ -126,6 +126,7 @@ static void neat_resolver_flush_pairs_del(struct neat_resolver *resolver)
             continue;
 
         LIST_REMOVE(resolver_pair, next_pair);
+        //TODO: Instead of free, consider making a resolve_pair cache
         free(resolver_pair);
     }
 }
@@ -1061,7 +1062,6 @@ neat_resolver_init(struct neat_ctx *nc, const char *resolv_conf_path)
         return NULL;
     }
 
-    LIST_INIT(&(resolver->resolver_pairs));
     LIST_INIT(&(resolver->resolver_pairs_del));
 
     uv_idle_init(nc->loop, &(resolver->idle_handle));

--- a/neat_resolver.c
+++ b/neat_resolver.c
@@ -279,6 +279,8 @@ static void neat_resolver_timeout_cb(uv_timer_t *handle)
     //DNS timeout, call DNS callback with timeout error code
     if (!request->name_resolved_timeout) {
         request->resolve_cb(NULL, NULL, NEAT_RESOLVER_TIMEOUT);
+
+        //TODO: Cleanup, remove request
         return;
     }
 
@@ -286,6 +288,8 @@ static void neat_resolver_timeout_cb(uv_timer_t *handle)
     if ((result_list =
                 calloc(sizeof(struct neat_resolver_results), 1)) == NULL) {
         request->resolve_cb(NULL, NULL, NEAT_RESOLVER_ERROR);
+
+        //TODO: Cleanup, remove request
         return;
     }
 
@@ -308,7 +312,7 @@ static void neat_resolver_timeout_cb(uv_timer_t *handle)
 
             if (pair_itr->src_addr->family == AF_INET6 &&
                 !pair_itr->src_addr->u.v6.ifa_pref)
-                return;
+                break;
 
             //TODO: Consider connecting pairs to request instead of resolver
             num_resolved_addrs += neat_resolver_fill_results(result_list,
@@ -324,6 +328,8 @@ static void neat_resolver_timeout_cb(uv_timer_t *handle)
         request->resolve_cb(NULL, NULL, NEAT_RESOLVER_ERROR);
     } else
         request->resolve_cb(NULL, result_list, NEAT_RESOLVER_OK);
+
+    //TODO: Cleanup, remove request
 }
 
 //Called when a DNS request has been (i.e., passed to socket). We will send the

--- a/neat_resolver.h
+++ b/neat_resolver.h
@@ -6,6 +6,7 @@
 
 #include "neat_internal.h"
 #include "neat_queue.h"
+#include "neat_addr.h"
 
 //Timeout for complete DNS query
 #define DNS_TIMEOUT             30000

--- a/neat_resolver.h
+++ b/neat_resolver.h
@@ -69,7 +69,7 @@ struct neat_resolver_request {
 
     char domain_name[MAX_DOMAIN_LENGTH];
 
-    neat_resolver_handle_t *cb; //Callback that will be called when resolving is done
+    neat_resolver_handle_t resolve_cb; //Callback that will be called when resolving is done
 
     //These values are just passed on to neat_resolver_res
     //TODO: Remove this, will be set on result

--- a/neat_resolver.h
+++ b/neat_resolver.h
@@ -84,6 +84,7 @@ struct neat_resolver_request {
     void *data; //User data
 
     TAILQ_ENTRY(neat_resolver_request) next_req;
+    TAILQ_ENTRY(neat_resolver_request) next_dead_req;
 };
 
 #endif

--- a/neat_resolver.h
+++ b/neat_resolver.h
@@ -67,7 +67,7 @@ struct neat_resolver_src_dst_addr {
 struct neat_resolver_request {
     uint16_t dst_port;
     uint8_t family;
-    uint8_t __pad;
+    uint8_t name_resolved_timeout;
 
     char domain_name[MAX_DOMAIN_LENGTH];
 
@@ -76,6 +76,9 @@ struct neat_resolver_request {
 
     //Callback that will be called when resolving is done
     neat_resolver_handle_t resolve_cb; 
+
+    //Timeout handle owned by this request
+    uv_timer_t timeout_handle;
 
     void *data; //User data
 

--- a/neat_resolver.h
+++ b/neat_resolver.h
@@ -83,8 +83,8 @@ struct neat_resolver_request {
 
     void *data; //User data
 
-    LIST_ENTRY(neat_resolver_request) next_req;
-    LIST_ENTRY(neat_resolver_request) next_dead_req;
+    TAILQ_ENTRY(neat_resolver_request) next_req;
+    TAILQ_ENTRY(neat_resolver_request) next_dead_req;
 };
 
 #endif

--- a/neat_resolver.h
+++ b/neat_resolver.h
@@ -34,12 +34,14 @@ static char* const INET6_DNS_SERVERS [] = {"2001:4860:4860::8888", "2001:4860:48
 
 struct neat_addr;
 struct neat_resolver;
+struct neat_resolver_request;
 
 //Represent one source/dst address used for DNS lookups. We could save space by
 //recycling handle, but this structure will make it easier to support
 //fragmentation of DNS requests (way down the line)
 struct neat_resolver_src_dst_addr {
-    struct neat_resolver *resolver;
+    struct neat_resolver *resolver; //TODO: Remove?
+    struct neat_resolver_request *request;
     struct neat_addr *src_addr;
     //TODO: Dynamically allocate?
     struct neat_addr dst_addr;
@@ -69,12 +71,11 @@ struct neat_resolver_request {
 
     char domain_name[MAX_DOMAIN_LENGTH];
 
-    neat_resolver_handle_t resolve_cb; //Callback that will be called when resolving is done
+    //The resolver pairs related to this request
+    struct neat_resolver_pairs resolver_pairs;
 
-    //These values are just passed on to neat_resolver_res
-    //TODO: Remove this, will be set on result
-    //WHAT IS THIS? Causes a large number of allocs ...
-    neat_protocol_stack_type ai_stack[NEAT_STACK_MAX_NUM];
+    //Callback that will be called when resolving is done
+    neat_resolver_handle_t resolve_cb; 
 
     void *data; //User data
 

--- a/neat_resolver.h
+++ b/neat_resolver.h
@@ -17,15 +17,6 @@
 #define MAX_NUM_RESOLVED        3
 #define NO_PROTOCOL             0xFFFFFFFF
 
-//These are the private networks defined by IANA. We use them to check if we end
-//up in the private network after following redirects
-#define IANA_A_NW           0x0a000000 //10.0.0.0
-#define IANA_A_MASK         0xff000000 //255.0.0.0 (8)
-#define IANA_B_NW           0xac100000 //172.16.0.0
-#define IANA_B_MASK         0xfff00000 //255.240.0.0 (12)
-#define IANA_C_NW           0xc0a80000 //192.168.0.0
-#define IANA_C_MASK         0xffff0000 //255.255.0.0 (16)
-
 //We know these servers will not lie and will accept queries from an network
 //address. Until we have defined a syntax for IP/interface information in
 //resolv.conf (and the like), then this is as good as we can do

--- a/neat_resolver.h
+++ b/neat_resolver.h
@@ -4,6 +4,7 @@
 #include <uv.h>
 #include <ldns/ldns.h>
 
+#include "neat_internal.h"
 #include "neat_queue.h"
 
 //Timeout for complete DNS query
@@ -57,6 +58,27 @@ struct neat_resolver_src_dst_addr {
 
     //Keep track of which pairs are closed
     uint8_t closed;
+};
+
+//Struct representing one DNS request
+//TODO: Might be moved to neat_internal.h, will probably be passed to callback
+struct neat_resolver_request {
+    uint16_t dst_port;
+    uint8_t family;
+    uint8_t __pad;
+
+    char domain_name[MAX_DOMAIN_LENGTH];
+
+    neat_resolver_handle_t *cb; //Callback that will be called when resolving is done
+
+    //These values are just passed on to neat_resolver_res
+    //TODO: Remove this, will be set on result
+    //WHAT IS THIS? Causes a large number of allocs ...
+    neat_protocol_stack_type ai_stack[NEAT_STACK_MAX_NUM];
+
+    void *data; //User data
+
+    TAILQ_ENTRY(neat_resolver_request) next_req;
 };
 
 #endif

--- a/neat_resolver.h
+++ b/neat_resolver.h
@@ -81,7 +81,7 @@ struct neat_resolver_request {
     //Timeout handle owned by this request
     uv_timer_t timeout_handle;
 
-    void *data; //User data
+    void *user_data; //User data
 
     TAILQ_ENTRY(neat_resolver_request) next_req;
     TAILQ_ENTRY(neat_resolver_request) next_dead_req;

--- a/neat_resolver.h
+++ b/neat_resolver.h
@@ -40,7 +40,7 @@ struct neat_resolver_request;
 //recycling handle, but this structure will make it easier to support
 //fragmentation of DNS requests (way down the line)
 struct neat_resolver_src_dst_addr {
-    struct neat_resolver *resolver; //TODO: Remove?
+    struct neat_resolver *resolver; //TODO: Remove
     struct neat_resolver_request *request;
     struct neat_addr *src_addr;
     //TODO: Dynamically allocate?
@@ -68,6 +68,7 @@ struct neat_resolver_request {
     uint16_t dst_port;
     uint8_t family;
     uint8_t name_resolved_timeout;
+    struct neat_resolver *resolver;
 
     char domain_name[MAX_DOMAIN_LENGTH];
 

--- a/neat_resolver.h
+++ b/neat_resolver.h
@@ -83,8 +83,8 @@ struct neat_resolver_request {
 
     void *data; //User data
 
-    TAILQ_ENTRY(neat_resolver_request) next_req;
-    TAILQ_ENTRY(neat_resolver_request) next_dead_req;
+    LIST_ENTRY(neat_resolver_request) next_req;
+    LIST_ENTRY(neat_resolver_request) next_dead_req;
 };
 
 #endif

--- a/neat_resolver_helpers.c
+++ b/neat_resolver_helpers.c
@@ -1,0 +1,181 @@
+#include <stddef.h>
+#include <stdlib.h>
+#include <arpa/inet.h>
+
+#include "neat_resolver_helpers.h"
+#include "neat_log.h"
+#include "neat_internal.h"
+#include "neat_addr.h"
+#include "neat_resolver.h"
+
+uint8_t
+neat_resolver_helpers_addr_internal(struct sockaddr_storage *addr)
+{
+    struct sockaddr_in *addr4 = NULL;
+    struct sockaddr_in6 *addr6 = NULL;
+    uint32_t haddr4 = 0;
+
+    if (addr->ss_family == AF_INET6) {
+        addr6 = (struct sockaddr_in6*) addr;
+        return (addr6->sin6_addr.s6_addr[0] & 0xfe) != 0xfc;
+    }
+
+    addr4 = (struct sockaddr_in*) addr;
+    haddr4 = ntohl(addr4->sin_addr.s_addr);
+
+    if ((haddr4 & IANA_A_MASK) == IANA_A_NW ||
+        (haddr4 & IANA_B_MASK) == IANA_B_NW ||
+        (haddr4 & IANA_C_MASK) == IANA_C_NW)
+        return 1;
+    else
+        return 0;
+}
+
+//Check if node is an IP literal or not. Returns -1 on failure, 0 if not
+//literal, 1 if literal
+int8_t 
+neat_resolver_helpers_check_for_literal(uint8_t *family,
+                                        const char *node)
+{
+    struct in6_addr dummy_addr;
+    int32_t v4_literal = 0, v6_literal = 0;
+
+    if (*family != AF_UNSPEC && *family != AF_INET && *family != AF_INET6) {
+        neat_log(NEAT_LOG_ERROR, "%s - Unsupported address family", __func__);
+        return -1;
+    }
+
+    //The only time inet_pton fails is if the system lacks v4/v6 support. This
+    //should rather be handled with an ifdef + check at compile time
+    v4_literal = inet_pton(AF_INET, node, &dummy_addr);
+    v6_literal = inet_pton(AF_INET6, node, &dummy_addr);
+
+    //These are the two possible error cases:
+    //if family is v4 and address is v6 (or opposite), then user has made a
+    //mistake and must be notifed
+    if ((*family == AF_INET && v6_literal) ||
+        (*family == AF_INET6 && v4_literal)) {
+        neat_log(NEAT_LOG_ERROR, "%s - Mismatch between family and literal", __func__);
+        return -1;
+    }
+
+    if (*family == AF_UNSPEC) {
+        if (v4_literal)
+            *family = AF_INET;
+        if (v6_literal)
+            *family = AF_INET6;
+    }
+
+    return v4_literal | v6_literal;
+}
+
+//Create all results for one match
+uint8_t
+neat_resolver_helpers_fill_results(struct neat_resolver_results *result_list,
+                                   struct neat_addr *src_addr,
+                                   struct sockaddr_storage dst_addr)
+{
+    socklen_t addrlen;
+    struct neat_resolver_res *result;
+    uint8_t num_addr_added = 0;
+
+    result = calloc(sizeof(struct neat_resolver_res), 1);
+
+    if (result == NULL)
+        return 0;
+
+    addrlen = src_addr->family == AF_INET ?
+        sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6);
+
+    result->ai_family = src_addr->family;
+    result->if_idx = src_addr->if_idx;
+    result->src_addr = src_addr->u.generic.addr;
+    result->src_addr_len = addrlen;
+    result->dst_addr = dst_addr;
+    result->dst_addr_len = addrlen;
+    result->internal = neat_resolver_helpers_addr_internal(&dst_addr);
+    
+    LIST_INSERT_HEAD(result_list, result, next_res);
+    num_addr_added++;
+
+    return num_addr_added;
+}
+
+uint8_t
+neat_resolver_helpers_check_duplicate(struct neat_resolver_src_dst_addr *pair,
+                                      const char *resolved_addr_str)
+{
+    //Accepts a src_dst_pair and an address, convert this address to struct
+    //in{6}_addr, then check all pairs if this IP has seen before for same
+    //(index, source)
+    struct neat_addr *src_addr = pair->src_addr;
+    struct sockaddr_in *src_addr_4 = NULL, *cmp_addr_4 = NULL;
+    struct sockaddr_in6 *src_addr_6 = NULL, *cmp_addr_6 = NULL;
+    union {
+        struct in_addr resolved_addr_4;
+        struct in6_addr resolved_addr_6;
+    } u;
+    struct neat_resolver_src_dst_addr *itr;
+    uint8_t addr_equal = 0;
+    int32_t i;
+
+    if (src_addr->family == AF_INET) {
+        src_addr_4 = &(src_addr->u.v4.addr4);
+        i = inet_pton(AF_INET, resolved_addr_str,
+                (void *) &u.resolved_addr_4);
+    } else {
+        src_addr_6 = &(src_addr->u.v6.addr6);
+        i = inet_pton(AF_INET6, resolved_addr_str,
+                (void *) &u.resolved_addr_6);
+    }
+
+    //the calleee also does pton, so that failure will currently be handled
+    //elsewhere
+    //TODO: SO UGLY!!!!!!!!!!!!!
+    if (i <= 0)
+        return 0;
+
+    for (itr = pair->request->resolver_pairs.lh_first; itr != NULL;
+            itr = itr->next_pair.le_next) {
+
+        //Must match index
+        if (src_addr->if_idx != itr->src_addr->if_idx ||
+            src_addr->family != itr->src_addr->family)
+            continue;
+
+        if (src_addr->family == AF_INET) {
+            cmp_addr_4 = &(itr->src_addr->u.v4.addr4);
+            addr_equal = (cmp_addr_4->sin_addr.s_addr ==
+                          src_addr_4->sin_addr.s_addr);
+        } else {
+            cmp_addr_6 = &(itr->src_addr->u.v6.addr6);
+            addr_equal = neat_addr_cmp_ip6_addr(&(cmp_addr_6->sin6_addr),
+                                                &(src_addr_6->sin6_addr));
+        }
+
+        if (!addr_equal)
+            continue;
+
+        //Check all resolved addresses
+        for (i = 0; i < MAX_NUM_RESOLVED; i++) {
+            if (!itr->resolved_addr[i].ss_family)
+                break;
+
+            if (src_addr->family == AF_INET) {
+                cmp_addr_4 = (struct sockaddr_in*) &(itr->resolved_addr[i]);
+                addr_equal = (u.resolved_addr_4.s_addr ==
+                              cmp_addr_4->sin_addr.s_addr);
+            } else {
+                cmp_addr_6 = (struct sockaddr_in6*) &(itr->resolved_addr[i]);
+                addr_equal = neat_addr_cmp_ip6_addr(&(cmp_addr_6->sin6_addr),
+                                                    &(u.resolved_addr_6));
+            }
+
+            if (addr_equal)
+                return 1;
+        }
+    }
+
+    return 0;
+}
+

--- a/neat_resolver_helpers.c
+++ b/neat_resolver_helpers.c
@@ -71,13 +71,15 @@ neat_resolver_helpers_check_for_literal(uint8_t *family,
 
 //Create all results for one match
 uint8_t
-neat_resolver_helpers_fill_results(struct neat_resolver_results *result_list,
+neat_resolver_helpers_fill_results(struct neat_resolver_request *request,
+                                   struct neat_resolver_results *result_list,
                                    struct neat_addr *src_addr,
                                    struct sockaddr_storage dst_addr)
 {
     socklen_t addrlen;
     struct neat_resolver_res *result;
     uint8_t num_addr_added = 0;
+    struct sockaddr_in *addr4;
 
     result = calloc(sizeof(struct neat_resolver_res), 1);
 
@@ -94,7 +96,12 @@ neat_resolver_helpers_fill_results(struct neat_resolver_results *result_list,
     result->dst_addr = dst_addr;
     result->dst_addr_len = addrlen;
     result->internal = neat_resolver_helpers_addr_internal(&dst_addr);
-    
+   
+    //Head of sockaddr_in and sockaddr_in6 is the same, so this is safe
+    //for setting port
+    addr4 = (struct sockaddr_in*) &(result->dst_addr);
+    addr4->sin_port = request->dst_port;
+ 
     LIST_INSERT_HEAD(result_list, result, next_res);
     num_addr_added++;
 

--- a/neat_resolver_helpers.h
+++ b/neat_resolver_helpers.h
@@ -22,6 +22,7 @@ struct sockaddr_storage;
 struct neat_resolver_results;
 struct neat_addr;
 struct neat_resolver_src_dst_addr;
+struct neat_resolver_request;
 
 uint8_t
 neat_resolver_helpers_addr_internal(struct sockaddr_storage *addr);
@@ -31,7 +32,8 @@ neat_resolver_helpers_check_for_literal(uint8_t *family,
                                         const char *node);
 
 uint8_t
-neat_resolver_helpers_fill_results(struct neat_resolver_results *result_list,
+neat_resolver_helpers_fill_results(struct neat_resolver_request *request,
+                                   struct neat_resolver_results *result_list,
                                    struct neat_addr *src_addr,
                                    struct sockaddr_storage dst_addr);
 

--- a/neat_resolver_helpers.h
+++ b/neat_resolver_helpers.h
@@ -1,0 +1,42 @@
+#ifndef NEAT_RESOLVER_HELPERS_H
+#define NEAT_RESOLVER_HELPERS_H
+
+#include <stdint.h>
+#ifdef __linux__
+    #include <netinet/in.h>
+#elif _WIN32
+    #include <inaddr.h>
+    #include <in6addr.h>
+#endif
+
+//These are the private networks defined by IANA. We use them to check if we end
+//up in the private network after following redirects
+#define IANA_A_NW           0x0a000000 //10.0.0.0
+#define IANA_A_MASK         0xff000000 //255.0.0.0 (8)
+#define IANA_B_NW           0xac100000 //172.16.0.0
+#define IANA_B_MASK         0xfff00000 //255.240.0.0 (12)
+#define IANA_C_NW           0xc0a80000 //192.168.0.0
+#define IANA_C_MASK         0xffff0000 //255.255.0.0 (16)
+
+struct sockaddr_storage;
+struct neat_resolver_results;
+struct neat_addr;
+struct neat_resolver_src_dst_addr;
+
+uint8_t
+neat_resolver_helpers_addr_internal(struct sockaddr_storage *addr);
+
+int8_t
+neat_resolver_helpers_check_for_literal(uint8_t *family,
+                                        const char *node);
+
+uint8_t
+neat_resolver_helpers_fill_results(struct neat_resolver_results *result_list,
+                                   struct neat_addr *src_addr,
+                                   struct sockaddr_storage dst_addr);
+
+uint8_t
+neat_resolver_helpers_check_duplicate(struct neat_resolver_src_dst_addr *pair,
+                                      const char *resolved_addr_str);
+
+#endif

--- a/tests/neat_resolver_example.c
+++ b/tests/neat_resolver_example.c
@@ -12,7 +12,6 @@
 // or if you have installed neat globally
 // clang -g neat_resolver_example.c -lneat
 
-
 static void resolver_handle(struct neat_resolver *resolver,
                      struct neat_resolver_results *results, uint8_t neat_code)
 {
@@ -21,7 +20,7 @@ static void resolver_handle(struct neat_resolver *resolver,
 
     if (neat_code != NEAT_RESOLVER_OK) {
         fprintf(stderr, "Resolver failed\n");
-        neat_stop_event_loop(resolver->nc);
+        //neat_stop_event_loop(resolver->nc);
         return;
     }
 
@@ -79,7 +78,7 @@ static void resolver_handle(struct neat_resolver *resolver,
 
     //Free list, it is callers responsibility
     neat_resolver_free_results(results);
-    neat_stop_event_loop(resolver->nc);
+    //neat_stop_event_loop(resolver->nc);
 }
 
 static void resolver_cleanup(struct neat_resolver *resolver)

--- a/tests/neat_resolver_example.c
+++ b/tests/neat_resolver_example.c
@@ -78,7 +78,7 @@ static void resolver_handle(struct neat_resolver *resolver,
 
     //Free list, it is callers responsibility
     neat_resolver_free_results(results);
-    neat_resolver_release(resolver);
+    //neat_resolver_release(resolver);
     //neat_stop_event_loop(resolver->nc);
 }
 

--- a/tests/neat_resolver_example.c
+++ b/tests/neat_resolver_example.c
@@ -91,7 +91,7 @@ static void resolver_cleanup(struct neat_resolver *resolver)
 static uint8_t test_resolver(struct neat_ctx *nc, struct neat_resolver *resolver,
         uint8_t family, neat_protocol_stack_type stack[], uint8_t stack_count, char *node, uint16_t port)
 {
-    if (neat_getaddrinfo(resolver, family, node, port, stack, stack_count))
+    if (neat_getaddrinfo(resolver, family, node, port))
         return 1;
 
     neat_start_event_loop(nc, NEAT_RUN_DEFAULT);

--- a/tests/neat_resolver_example.c
+++ b/tests/neat_resolver_example.c
@@ -36,6 +36,7 @@ static void resolver_handle(struct neat_resolver_results *results,
         getnameinfo((struct sockaddr *)&result->dst_addr, result->dst_addr_len,
                     dst_str, sizeof(dst_str), NULL, 0,
                     NI_NUMERICHOST);
+        /*
         switch (result->ai_stack) {
         case NEAT_STACK_UDP:
             fprintf(stderr, "UDP/");
@@ -52,7 +53,8 @@ static void resolver_handle(struct neat_resolver_results *results,
         default:
             fprintf(stderr, "stack%d/", result->ai_stack);
             break;
-        }
+        }*/
+
         switch (result->ai_family) {
         case AF_INET:
             fprintf(stderr, "IPv4");
@@ -64,6 +66,7 @@ static void resolver_handle(struct neat_resolver_results *results,
             fprintf(stderr, "family%d", result->ai_family);
             break;
         }
+        /*
         switch (result->ai_socktype) {
         case SOCK_DGRAM:
             fprintf(stderr, "[SOCK_DGRAM]");
@@ -77,7 +80,7 @@ static void resolver_handle(struct neat_resolver_results *results,
         default:
             fprintf(stderr, "[%d]", result->ai_socktype);
             break;
-        }
+        }*/
         printf(": %s -> %s\n", src_str, dst_str);
     }
 

--- a/tests/neat_resolver_example.c
+++ b/tests/neat_resolver_example.c
@@ -90,7 +90,7 @@ static void resolver_cleanup(struct neat_resolver *resolver)
 }
 
 static uint8_t test_resolver(struct neat_ctx *nc, struct neat_resolver *resolver,
-        uint8_t family, neat_protocol_stack_type stack[], uint8_t stack_count, char *node, uint16_t port)
+        uint8_t family, char *node, uint16_t port)
 {
     if (neat_getaddrinfo(resolver, family, node, port))
         return 1;
@@ -102,8 +102,6 @@ int main(int argc, char *argv[])
 {
     struct neat_ctx *nc = neat_init_ctx();
     struct neat_resolver *resolver;
-    neat_protocol_stack_type test_stack[NEAT_STACK_MAX_NUM];
-    uint8_t n;
 
     resolver = nc ? neat_resolver_init(nc, "/etc/resolv.conf", resolver_handle,
                                        resolver_cleanup) : NULL;
@@ -111,23 +109,13 @@ int main(int argc, char *argv[])
     if (nc == NULL || resolver == NULL)
         exit(EXIT_FAILURE);
 
-    memset(test_stack, 0, NEAT_STACK_MAX_NUM * sizeof(neat_protocol_stack_type));
-
     //this is set in he_lookup in the other example code
     nc->resolver = resolver;
 
     neat_resolver_update_timeouts(resolver, 5000, 500);
-    n = 0;
-    test_stack[n++] = NEAT_STACK_UDP;
-    test_stack[n++] = NEAT_STACK_TCP;
-#ifdef IPPROTO_SCTP
-    test_stack[n++] = NEAT_STACK_SCTP;
-#endif
-#ifdef IPPROTO_UDPLITE
-    test_stack[n++] = NEAT_STACK_UDPLITE;
-#endif
-    test_resolver(nc, resolver, AF_INET, test_stack, n, "www.google.com", 80);
-    test_resolver(nc, resolver, AF_INET, test_stack, n, "www.facebook.com", 80);
+
+    test_resolver(nc, resolver, AF_INET, "www.google.com", 80);
+    test_resolver(nc, resolver, AF_INET, "www.facebook.com", 80);
 
     neat_start_event_loop(nc, NEAT_RUN_DEFAULT);
 #if 0

--- a/tests/neat_resolver_example.c
+++ b/tests/neat_resolver_example.c
@@ -8,6 +8,9 @@
 // The resolver interface is internal - but this is still a good test
 #include "../neat_internal.h"
 
+//HACKHACKHACK, code is not supposed to access resolver directly
+#include "../neat_resolver.h"
+
 // clang -g neat_resolver_example.c ../build/libneatS.a -luv -lldns -lmnl
 // or if you have installed neat globally
 // clang -g neat_resolver_example.c -lneat

--- a/tests/neat_resolver_example.c
+++ b/tests/neat_resolver_example.c
@@ -101,6 +101,23 @@ static void test_single_request_v4(struct neat_ctx *nc,
     neat_start_event_loop(nc, NEAT_RUN_DEFAULT);
 }
 
+static void test_single_request_literal_v4(struct neat_ctx *nc,
+                                           struct neat_resolver *resolver)
+{
+    test_resolver(resolver, AF_INET, "127.0.0.1", 80);
+    expected_replies = 1;
+    num_replies = 0;
+    neat_start_event_loop(nc, NEAT_RUN_DEFAULT);
+    test_resolver(resolver, AF_INET, "8.8.8.8", 80);
+    expected_replies = 1;
+    num_replies = 0;
+    neat_start_event_loop(nc, NEAT_RUN_DEFAULT);
+    test_resolver(resolver, AF_INET, "8.8.4.4", 80);
+    expected_replies = 1;
+    num_replies = 0;
+    neat_start_event_loop(nc, NEAT_RUN_DEFAULT);
+}
+
 static void test_single_request_v6(struct neat_ctx *nc,
                                    struct neat_resolver *resolver)
 {
@@ -125,6 +142,20 @@ static void test_parallel_requests_v4(struct neat_ctx *nc,
     test_resolver(resolver, AF_INET, "www.facebook.com", 80);
     test_resolver(resolver, AF_INET, "www.vg.no", 80);
     expected_replies = 3;
+    num_replies = 0;
+    neat_start_event_loop(nc, NEAT_RUN_DEFAULT);
+}
+
+static void test_parallel_requests_literal_v4(struct neat_ctx *nc,
+                                              struct neat_resolver *resolver)
+{
+    test_resolver(resolver, AF_INET, "www.google.com", 80);
+    test_resolver(resolver, AF_INET, "127.0.0.1", 80);
+    test_resolver(resolver, AF_INET, "www.facebook.com", 80);
+    test_resolver(resolver, AF_INET, "8.8.8.8", 80);
+    test_resolver(resolver, AF_INET, "www.vg.no", 80);
+    test_resolver(resolver, AF_INET, "8.8.4.4", 80);
+    expected_replies = 6;
     num_replies = 0;
     neat_start_event_loop(nc, NEAT_RUN_DEFAULT);
 }
@@ -169,10 +200,12 @@ int main(int argc, char *argv[])
     neat_resolver_update_timeouts(resolver, 5000, 500);
 
     test_single_request_v4(nc, resolver);
-    test_single_request_v6(nc, resolver);
+    test_single_request_literal_v4(nc, resolver);
+    //test_single_request_v6(nc, resolver);
     test_parallel_requests_v4(nc, resolver);
-    test_parallel_requests_v6(nc, resolver);
-    test_parallel_requests_mixed(nc, resolver);
+    test_parallel_requests_literal_v4(nc, resolver);
+    //test_parallel_requests_v6(nc, resolver);
+    //test_parallel_requests_mixed(nc, resolver);
     neat_free_ctx(nc);
     exit(EXIT_SUCCESS);
 }

--- a/tests/neat_resolver_example.c
+++ b/tests/neat_resolver_example.c
@@ -12,11 +12,13 @@
 // or if you have installed neat globally
 // clang -g neat_resolver_example.c -lneat
 
-static void resolver_handle(struct neat_resolver *resolver,
-                     struct neat_resolver_results *results, uint8_t neat_code)
+static void resolver_handle(struct neat_resolver_results *results,
+                            uint8_t neat_code,
+                            void *user_data)
 {
     char src_str[INET6_ADDRSTRLEN], dst_str[INET6_ADDRSTRLEN];
     struct neat_resolver_res *result;
+    struct neat_resolver *resolver = user_data;
 
     if (neat_code != NEAT_RESOLVER_OK) {
         fprintf(stderr, "Resolver failed\n");
@@ -92,7 +94,7 @@ static void resolver_cleanup(struct neat_resolver *resolver)
 static uint8_t test_resolver(struct neat_ctx *nc, struct neat_resolver *resolver,
         uint8_t family, char *node, uint16_t port)
 {
-    if (neat_getaddrinfo(resolver, family, node, port, resolver_handle, NULL))
+    if (neat_getaddrinfo(resolver, family, node, port, resolver_handle, resolver))
         return 1;
     else
         return 0;

--- a/tests/neat_resolver_example.c
+++ b/tests/neat_resolver_example.c
@@ -97,7 +97,7 @@ static void resolver_cleanup(struct neat_resolver *resolver)
 static uint8_t test_resolver(struct neat_ctx *nc, struct neat_resolver *resolver,
         uint8_t family, char *node, uint16_t port)
 {
-    if (neat_getaddrinfo(resolver, family, node, port, resolver_handle, resolver))
+    if (neat_resolve(resolver, family, node, port, resolver_handle, resolver))
         return 1;
     else
         return 0;

--- a/tests/neat_resolver_example.c
+++ b/tests/neat_resolver_example.c
@@ -36,24 +36,6 @@ static void resolver_handle(struct neat_resolver_results *results,
         getnameinfo((struct sockaddr *)&result->dst_addr, result->dst_addr_len,
                     dst_str, sizeof(dst_str), NULL, 0,
                     NI_NUMERICHOST);
-        /*
-        switch (result->ai_stack) {
-        case NEAT_STACK_UDP:
-            fprintf(stderr, "UDP/");
-            break;
-        case NEAT_STACK_TCP:
-            fprintf(stderr, "TCP/");
-            break;
-        case NEAT_STACK_SCTP:
-            fprintf(stderr, "SCTP/");
-            break;
-        case NEAT_STACK_UDPLITE:
-            fprintf(stderr, "UDP-LITE/");
-            break;
-        default:
-            fprintf(stderr, "stack%d/", result->ai_stack);
-            break;
-        }*/
 
         switch (result->ai_family) {
         case AF_INET:
@@ -66,21 +48,7 @@ static void resolver_handle(struct neat_resolver_results *results,
             fprintf(stderr, "family%d", result->ai_family);
             break;
         }
-        /*
-        switch (result->ai_socktype) {
-        case SOCK_DGRAM:
-            fprintf(stderr, "[SOCK_DGRAM]");
-            break;
-        case SOCK_STREAM:
-            fprintf(stderr, "[SOCK_STREAM]");
-            break;
-        case SOCK_SEQPACKET:
-            fprintf(stderr, "[SOCK_SEQPACKET]");
-            break;
-        default:
-            fprintf(stderr, "[%d]", result->ai_socktype);
-            break;
-        }*/
+
         printf(": %s -> %s\n", src_str, dst_str);
     }
 

--- a/tests/neat_resolver_example.c
+++ b/tests/neat_resolver_example.c
@@ -15,6 +15,9 @@
 // or if you have installed neat globally
 // clang -g neat_resolver_example.c -lneat
 
+static uint8_t expected_replies;
+static uint8_t num_replies;
+
 static void resolver_handle(struct neat_resolver_results *results,
                             uint8_t neat_code,
                             void *user_data)
@@ -23,9 +26,13 @@ static void resolver_handle(struct neat_resolver_results *results,
     struct neat_resolver_res *result;
     struct neat_resolver *resolver = user_data;
 
+    num_replies++;
+
     if (neat_code != NEAT_RESOLVER_OK) {
         fprintf(stderr, "Resolver failed\n");
-        //neat_stop_event_loop(resolver->nc);
+
+        if (num_replies == expected_replies)
+            neat_stop_event_loop(resolver->nc);
         return;
     }
 
@@ -55,7 +62,8 @@ static void resolver_handle(struct neat_resolver_results *results,
     //Free list, it is callers responsibility
     neat_resolver_free_results(results);
     //neat_resolver_release(resolver);
-    neat_stop_event_loop(resolver->nc);
+    if (num_replies == expected_replies)
+        neat_stop_event_loop(resolver->nc);
 }
 
 static void resolver_cleanup(struct neat_resolver *resolver)
@@ -65,13 +73,85 @@ static void resolver_cleanup(struct neat_resolver *resolver)
     neat_resolver_release(resolver);
 }
 
-static uint8_t test_resolver(struct neat_ctx *nc, struct neat_resolver *resolver,
-        uint8_t family, char *node, uint16_t port)
+static uint8_t test_resolver(struct neat_resolver *resolver,
+                             uint8_t family,
+                             char *node,
+                             uint16_t port)
 {
     if (neat_resolve(resolver, family, node, port, resolver_handle, resolver))
         return 1;
     else
         return 0;
+}
+
+static void test_single_request_v4(struct neat_ctx *nc,
+                                   struct neat_resolver *resolver)
+{
+    test_resolver(resolver, AF_INET, "www.google.com", 80);
+    expected_replies = 1;
+    num_replies = 0;
+    neat_start_event_loop(nc, NEAT_RUN_DEFAULT);
+    test_resolver(resolver, AF_INET, "www.facebook.com", 80);
+    expected_replies = 1;
+    num_replies = 0;
+    neat_start_event_loop(nc, NEAT_RUN_DEFAULT);
+    test_resolver(resolver, AF_INET, "www.vg.no", 80);
+    expected_replies = 1;
+    num_replies = 0;
+    neat_start_event_loop(nc, NEAT_RUN_DEFAULT);
+}
+
+static void test_single_request_v6(struct neat_ctx *nc,
+                                   struct neat_resolver *resolver)
+{
+    test_resolver(resolver, AF_INET6, "www.google.com", 80);
+    expected_replies = 1;
+    num_replies = 0;
+    neat_start_event_loop(nc, NEAT_RUN_DEFAULT);
+    test_resolver(resolver, AF_INET6, "www.facebook.com", 80);
+    expected_replies = 1;
+    num_replies = 0;
+    neat_start_event_loop(nc, NEAT_RUN_DEFAULT);
+    test_resolver(resolver, AF_INET6, "www.vg.no", 80);
+    expected_replies = 1;
+    num_replies = 0;
+    neat_start_event_loop(nc, NEAT_RUN_DEFAULT);
+}
+
+static void test_parallel_requests_v4(struct neat_ctx *nc,
+                                   struct neat_resolver *resolver)
+{
+    test_resolver(resolver, AF_INET, "www.google.com", 80);
+    test_resolver(resolver, AF_INET, "www.facebook.com", 80);
+    test_resolver(resolver, AF_INET, "www.vg.no", 80);
+    expected_replies = 3;
+    num_replies = 0;
+    neat_start_event_loop(nc, NEAT_RUN_DEFAULT);
+}
+
+static void test_parallel_requests_v6(struct neat_ctx *nc,
+                                   struct neat_resolver *resolver)
+{
+    test_resolver(resolver, AF_INET6, "www.google.com", 80);
+    test_resolver(resolver, AF_INET6, "www.facebook.com", 80);
+    test_resolver(resolver, AF_INET6, "www.vg.no", 80);
+    expected_replies = 3;
+    num_replies = 0;
+    neat_start_event_loop(nc, NEAT_RUN_DEFAULT);
+}
+
+static void test_parallel_requests_mixed(struct neat_ctx *nc,
+                                         struct neat_resolver *resolver)
+{
+    test_resolver(resolver, AF_INET, "www.google.com", 80);
+    test_resolver(resolver, AF_INET6, "www.google.com", 80);
+    test_resolver(resolver, AF_INET, "www.facebook.com", 80);
+    test_resolver(resolver, AF_INET6, "www.facebook.com", 80);
+    test_resolver(resolver, AF_INET, "www.vg.no", 80);
+    test_resolver(resolver, AF_INET6, "www.vg.no", 80);
+    expected_replies = 6;
+    num_replies = 0;
+    neat_start_event_loop(nc, NEAT_RUN_DEFAULT);
 }
 
 int main(int argc, char *argv[])
@@ -86,55 +166,13 @@ int main(int argc, char *argv[])
 
     //this is set in he_lookup in the other example code
     nc->resolver = resolver;
-
     neat_resolver_update_timeouts(resolver, 5000, 500);
-    test_resolver(nc, resolver, AF_INET, "www.google.com", 80);
-    test_resolver(nc, resolver, AF_INET, "www.facebook.com", 80);
-    
-    neat_start_event_loop(nc, NEAT_RUN_DEFAULT);
-#if 0
-    neat_resolver_reset(resolver);
-    test_resolver(nc, resolver, AF_INET6, test_stack, n, "www.google.com", 80);
-    neat_resolver_reset(resolver);
-    test_resolver(nc, resolver, AF_INET, test_stack, n, "www.facebook.com", 80);
-    neat_resolver_reset(resolver);
-    test_resolver(nc, resolver, AF_INET6, test_stack, n, "www.facebook.com", 80);
-    neat_resolver_reset(resolver);
 
-    test_stack[0] = NEAT_STACK_TCP;
-    test_resolver(nc, resolver, AF_INET, test_stack, 1, "bsd10.fh-muenster.de", 80);
-    neat_resolver_reset(resolver);
-    test_resolver(nc, resolver, AF_INET6, test_stack, 1, "bsd10.fh-muenster.de", 80);
-    neat_resolver_reset(resolver);
-
-#ifdef IPPROTO_SCTP
-    test_stack[0] = NEAT_STACK_SCTP;
-    test_resolver(nc, resolver, AF_INET, test_stack, 1, "bsd10.fh-muenster.de", 80);
-    neat_resolver_reset(resolver);
-    test_resolver(nc, resolver, AF_INET6, test_stack, 1, "bsd10.fh-muenster.de", 80);
-    neat_resolver_reset(resolver);
-#endif
-
-    test_stack[0] = NEAT_STACK_UDP;
-    test_resolver(nc, resolver, AF_INET, test_stack, 1, "bsd10.fh-muenster.de", 80);
-    neat_resolver_reset(resolver);
-    test_resolver(nc, resolver, AF_INET6, test_stack, 1, "bsd10.fh-muenster.de", 80);
-    neat_resolver_reset(resolver);
-    test_resolver(nc, resolver, AF_UNSPEC, test_stack, 1, "bsd10.fh-muenster.de", 80);
-
-    n = 0;
-    test_stack[n++] = NEAT_STACK_TCP;
-#ifdef IPPROTO_SCTP
-    test_stack[n++] = NEAT_STACK_SCTP;
-#endif
-    neat_resolver_reset(resolver);
-    test_resolver(nc, resolver, AF_INET, test_stack, n, "bsd10.fh-muenster.de", 80);
-    neat_resolver_reset(resolver);
-    test_resolver(nc, resolver, AF_INET6, test_stack, n, "bsd10.fh-muenster.de", 80);
-    neat_resolver_reset(resolver);
-    test_resolver(nc, resolver, AF_UNSPEC, test_stack, n, "bsd10.fh-muenster.de", 80);
-#endif
-
+    test_single_request_v4(nc, resolver);
+    test_single_request_v6(nc, resolver);
+    test_parallel_requests_v4(nc, resolver);
+    test_parallel_requests_v6(nc, resolver);
+    test_parallel_requests_mixed(nc, resolver);
     neat_free_ctx(nc);
     exit(EXIT_SUCCESS);
 }

--- a/tests/neat_resolver_example.c
+++ b/tests/neat_resolver_example.c
@@ -92,7 +92,7 @@ static void resolver_cleanup(struct neat_resolver *resolver)
 static uint8_t test_resolver(struct neat_ctx *nc, struct neat_resolver *resolver,
         uint8_t family, char *node, uint16_t port)
 {
-    if (neat_getaddrinfo(resolver, family, node, port, resolver_handle))
+    if (neat_getaddrinfo(resolver, family, node, port, resolver_handle, NULL))
         return 1;
     else
         return 0;

--- a/tests/neat_resolver_example.c
+++ b/tests/neat_resolver_example.c
@@ -128,6 +128,7 @@ int main(int argc, char *argv[])
 #endif
     test_resolver(nc, resolver, AF_INET, test_stack, n, "www.google.com", 80);
     test_resolver(nc, resolver, AF_INET, test_stack, n, "www.facebook.com", 80);
+    test_resolver(nc, resolver, AF_INET, test_stack, n, "127.0.0.1", 80);
 
     neat_start_event_loop(nc, NEAT_RUN_DEFAULT);
 #if 0

--- a/tests/neat_resolver_example.c
+++ b/tests/neat_resolver_example.c
@@ -78,7 +78,7 @@ static void resolver_handle(struct neat_resolver *resolver,
 
     //Free list, it is callers responsibility
     neat_resolver_free_results(results);
-    //neat_stop_event_loop(resolver->nc);
+    neat_stop_event_loop(resolver->nc);
 }
 
 static void resolver_cleanup(struct neat_resolver *resolver)
@@ -127,6 +127,8 @@ int main(int argc, char *argv[])
     test_stack[n++] = NEAT_STACK_UDPLITE;
 #endif
     test_resolver(nc, resolver, AF_INET, test_stack, n, "www.google.com", 80);
+
+#if 0
     neat_resolver_reset(resolver);
     test_resolver(nc, resolver, AF_INET6, test_stack, n, "www.google.com", 80);
     neat_resolver_reset(resolver);
@@ -167,7 +169,8 @@ int main(int argc, char *argv[])
     test_resolver(nc, resolver, AF_INET6, test_stack, n, "bsd10.fh-muenster.de", 80);
     neat_resolver_reset(resolver);
     test_resolver(nc, resolver, AF_UNSPEC, test_stack, n, "bsd10.fh-muenster.de", 80);
-
+#endif
+    fprintf(stderr, "Heihei\n");
     neat_free_ctx(nc);
     exit(EXIT_SUCCESS);
 }

--- a/tests/neat_resolver_example.c
+++ b/tests/neat_resolver_example.c
@@ -79,7 +79,7 @@ static void resolver_handle(struct neat_resolver *resolver,
     //Free list, it is callers responsibility
     neat_resolver_free_results(results);
     //neat_resolver_release(resolver);
-    //neat_stop_event_loop(resolver->nc);
+    neat_stop_event_loop(resolver->nc);
 }
 
 static void resolver_cleanup(struct neat_resolver *resolver)
@@ -92,7 +92,7 @@ static void resolver_cleanup(struct neat_resolver *resolver)
 static uint8_t test_resolver(struct neat_ctx *nc, struct neat_resolver *resolver,
         uint8_t family, char *node, uint16_t port)
 {
-    if (neat_getaddrinfo(resolver, family, node, port))
+    if (neat_getaddrinfo(resolver, family, node, port, resolver_handle))
         return 1;
     else
         return 0;
@@ -103,8 +103,7 @@ int main(int argc, char *argv[])
     struct neat_ctx *nc = neat_init_ctx();
     struct neat_resolver *resolver;
 
-    resolver = nc ? neat_resolver_init(nc, "/etc/resolv.conf", resolver_handle,
-                                       resolver_cleanup) : NULL;
+    resolver = nc ? neat_resolver_init(nc, "/etc/resolv.conf") : NULL;
 
     if (nc == NULL || resolver == NULL)
         exit(EXIT_FAILURE);

--- a/tests/neat_resolver_example.c
+++ b/tests/neat_resolver_example.c
@@ -78,6 +78,7 @@ static void resolver_handle(struct neat_resolver *resolver,
 
     //Free list, it is callers responsibility
     neat_resolver_free_results(results);
+    //neat_resolver_release(resolver);
     neat_stop_event_loop(resolver->nc);
 }
 
@@ -170,7 +171,7 @@ int main(int argc, char *argv[])
     neat_resolver_reset(resolver);
     test_resolver(nc, resolver, AF_UNSPEC, test_stack, n, "bsd10.fh-muenster.de", 80);
 #endif
-    fprintf(stderr, "Heihei\n");
+
     neat_free_ctx(nc);
     exit(EXIT_SUCCESS);
 }

--- a/tests/neat_resolver_example.c
+++ b/tests/neat_resolver_example.c
@@ -79,7 +79,7 @@ static void resolver_handle(struct neat_resolver *resolver,
     //Free list, it is callers responsibility
     neat_resolver_free_results(results);
     //neat_resolver_release(resolver);
-    //neat_stop_event_loop(resolver->nc);
+    neat_stop_event_loop(resolver->nc);
 }
 
 static void resolver_cleanup(struct neat_resolver *resolver)
@@ -128,7 +128,6 @@ int main(int argc, char *argv[])
 #endif
     test_resolver(nc, resolver, AF_INET, test_stack, n, "www.google.com", 80);
     test_resolver(nc, resolver, AF_INET, test_stack, n, "www.facebook.com", 80);
-    test_resolver(nc, resolver, AF_INET, test_stack, n, "127.0.0.1", 80);
 
     neat_start_event_loop(nc, NEAT_RUN_DEFAULT);
 #if 0

--- a/tests/neat_resolver_example.c
+++ b/tests/neat_resolver_example.c
@@ -78,8 +78,8 @@ static void resolver_handle(struct neat_resolver *resolver,
 
     //Free list, it is callers responsibility
     neat_resolver_free_results(results);
-    //neat_resolver_release(resolver);
-    neat_stop_event_loop(resolver->nc);
+    neat_resolver_release(resolver);
+    //neat_stop_event_loop(resolver->nc);
 }
 
 static void resolver_cleanup(struct neat_resolver *resolver)
@@ -113,10 +113,9 @@ int main(int argc, char *argv[])
     nc->resolver = resolver;
 
     neat_resolver_update_timeouts(resolver, 5000, 500);
-
     test_resolver(nc, resolver, AF_INET, "www.google.com", 80);
     test_resolver(nc, resolver, AF_INET, "www.facebook.com", 80);
-
+    
     neat_start_event_loop(nc, NEAT_RUN_DEFAULT);
 #if 0
     neat_resolver_reset(resolver);

--- a/tests/neat_resolver_example.c
+++ b/tests/neat_resolver_example.c
@@ -79,7 +79,7 @@ static void resolver_handle(struct neat_resolver *resolver,
     //Free list, it is callers responsibility
     neat_resolver_free_results(results);
     //neat_resolver_release(resolver);
-    neat_stop_event_loop(resolver->nc);
+    //neat_stop_event_loop(resolver->nc);
 }
 
 static void resolver_cleanup(struct neat_resolver *resolver)
@@ -94,9 +94,8 @@ static uint8_t test_resolver(struct neat_ctx *nc, struct neat_resolver *resolver
 {
     if (neat_getaddrinfo(resolver, family, node, port))
         return 1;
-
-    neat_start_event_loop(nc, NEAT_RUN_DEFAULT);
-    return 0;
+    else
+        return 0;
 }
 
 int main(int argc, char *argv[])
@@ -128,7 +127,9 @@ int main(int argc, char *argv[])
     test_stack[n++] = NEAT_STACK_UDPLITE;
 #endif
     test_resolver(nc, resolver, AF_INET, test_stack, n, "www.google.com", 80);
+    test_resolver(nc, resolver, AF_INET, test_stack, n, "www.facebook.com", 80);
 
+    neat_start_event_loop(nc, NEAT_RUN_DEFAULT);
 #if 0
     neat_resolver_reset(resolver);
     test_resolver(nc, resolver, AF_INET6, test_stack, n, "www.google.com", 80);


### PR DESCRIPTION
The DNS resolver was one of the first pieces of code to be written and was based on incorrect assumptions and had several errors/weaknesses. This pull request contains a rework of the resolver, as agreed upon in the plenary. The main goal was to support multiple resolve requests in parallel (or at least support queuing up multiple requests), which the initial resolver did not support.

The new DNS resolver is still based around a `struct neat_resolver`. This data structure is assumed to be tied to a context and now contains a list of `struct neat_resolver_request`. When the user calls `neat_resolve()` (`getaddrinfo()` has been renamed), a request is created, added to the list and started if there are any source addresses available. In other words, there is currently no pacing. This will be future work, if we believe this should be the responsibility of the resolver and not the user.

We have added some arguments to `neat_resolve()` that `neat_getaddrinfo()` did not have. The resolve-callback is now store in request, so different callbacks can be used with the same resolver. There is also a user_data argument now, which is a pointer that is forwarded to the resolve-callback. The resolver is no longer part of the resolve-callback signature, since no user should need direct access to it.

The `cleanup()` callback is removed sine it was not used. It might be added later if we see a need for it.

Based on my tests, this code works fine and supports the features we discussed during the plenary. However, it breaks other pieces of code, namely happy eyeballs. It also does not follow the new coding style, as I had forgot to update my .vimrc. I will fix at least the last one before merge, but the functionality will be the same. How should we proceed with merging this @adventureloop @weinrank @oystedal? It does break some functionality, but one can argue that that functionality has always been broken ...

There are also some dead variables that will be removed once we update HE.