### PR TITLE
Add tracking of neat_flow into the neat_ctx

### DIFF
--- a/neat_core.c
+++ b/neat_core.c
@@ -304,15 +304,9 @@ static void free_cb(uv_handle_t *handle)
         free(e->handle);
         free(e);
     }
-    /*
-    while(!LIST_EMPTY(&(flow->he_cb_ctx_list))) {
-        count++;
-        struct he_cb_ctx *e = LIST_FIRST(&(flow->he_cb_ctx_list));
-        LIST_REMOVE(e, next_he_ctx);
-        free(e->handle);
-        free(e);
-    }
-    */
+
+	LIST_REMOVE(flow, next_flow);
+
     free(flow->readBuffer);
     free(flow->handle);
     free(flow);
@@ -372,9 +366,6 @@ void neat_free_flow(neat_flow *flow)
     if ((flow->handle != NULL) &&
         (flow->handle->type != UV_UNKNOWN_HANDLE))
         uv_close((uv_handle_t *)(flow->handle), free_cb);
-
-	LIST_REMOVE(flow, next_flow);
-	free(flow);
 }
 
 neat_error_code neat_get_property(neat_ctx *mgr, struct neat_flow *flow,

--- a/neat_core.c
+++ b/neat_core.c
@@ -177,7 +177,6 @@ void neat_free_ctx(struct neat_ctx *nc)
 
     while (!LIST_EMPTY(&nc->flows)) {
         struct neat_flow *f = LIST_FIRST(&nc->flows);
-        LIST_REMOVE(f, next_flow);
         neat_free_flow(f);
     }
 
@@ -373,6 +372,9 @@ void neat_free_flow(neat_flow *flow)
     if ((flow->handle != NULL) &&
         (flow->handle->type != UV_UNKNOWN_HANDLE))
         uv_close((uv_handle_t *)(flow->handle), free_cb);
+
+	LIST_REMOVE(flow, next_flow);
+	free(flow);
 }
 
 neat_error_code neat_get_property(neat_ctx *mgr, struct neat_flow *flow,

--- a/neat_core.c
+++ b/neat_core.c
@@ -78,6 +78,7 @@ struct neat_ctx *neat_init_ctx()
 
     uv_loop_init(nc->loop);
     LIST_INIT(&(nc->src_addrs));
+    LIST_INIT(&(nc->flows));
 
     uv_timer_init(nc->loop, &(nc->addr_lifetime_handle));
     nc->addr_lifetime_handle.data = nc;
@@ -173,6 +174,13 @@ void neat_free_ctx(struct neat_ctx *nc)
         free(nc->event_cbs);
 
     free(nc->loop);
+
+    while (!LIST_EMPTY(&nc->flows)) {
+        struct neat_flow *f = LIST_FIRST(&nc->flows);
+        LIST_REMOVE(f, next_flow);
+        neat_free_flow(f);
+    }
+
     free(nc);
     neat_log_close();
 }
@@ -2493,6 +2501,9 @@ neat_flow *neat_new_flow(neat_ctx *mgr)
     rv->sock = NULL;
     rv->acceptusrsctpfx = neat_accept_via_usrsctp;
 #endif
+
+    LIST_INSERT_HEAD(&mgr->flows, rv, next_flow);
+
     return rv;
 }
 

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -48,11 +48,15 @@ struct neat_cib
     uint8_t dummy;
 };
 
-struct neat_ctx {
+LIST_HEAD(neat_flow_list_head, neat_flow);
+
+struct neat_ctx
+{
     uv_loop_t *loop;
     struct neat_resolver *resolver;
     struct neat_pib pib;
     struct neat_cib cib;
+    struct neat_flow_list_head flows;
     uv_timer_t addr_lifetime_handle;
 
     // resolver
@@ -162,6 +166,7 @@ struct neat_flow
 
     //List with all non-freed HE contexts.
     LIST_HEAD(he_cb_ctxs, he_cb_ctx) he_cb_ctx_list;
+    LIST_ENTRY(neat_flow) next_flow;
 };
 
 typedef struct neat_flow neat_flow;


### PR DESCRIPTION
Track neat_flow objects in the neat_ctx using a simple list from
queue.h. All flows are free'd in neat_free_ctx now, this should help the
memory management in the code be much clearer.