### PR TITLE
Initial UDP Client Support

### DIFF
--- a/neat_addr.c
+++ b/neat_addr.c
@@ -178,3 +178,40 @@ void neat_addr_free_src_list(struct neat_ctx *nc)
     }
 
 }
+
+/*
+ * https://gist.github.com/kazuho/45eae4f92257daceb73e
+ * Copyright (c) 2014 Kazuho Oku
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+uint8_t sockaddr_cmp(struct sockaddr *x, struct sockaddr *y)
+{
+#define CMP(a, b) if (a != b) return a < b ? -1 : 1
+
+    CMP(x->sa_family, y->sa_family);
+
+    if (x->sa_family == AF_INET) {
+        struct sockaddr_in *xin = (void*)x, *yin = (void*)y;
+        CMP(ntohs(xin->sin_port), ntohs(yin->sin_port));
+        CMP(ntohl(xin->sin_addr.s_addr), ntohl(yin->sin_addr.s_addr));
+    } else if (x->sa_family == AF_INET6) {
+        struct sockaddr_in6 *xin6 = (void*)x, *yin6 = (void*)y;
+        CMP(ntohs(xin6->sin6_port), ntohs(yin6->sin6_port));
+        CMP(xin6->sin6_flowinfo, yin6->sin6_flowinfo);
+        CMP(xin6->sin6_scope_id, yin6->sin6_scope_id);
+        return memcmp(xin6->sin6_addr.s6_addr, yin6->sin6_addr.s6_addr, sizeof(xin6->sin6_addr.s6_addr));
+    }
+
+#undef CMP
+    return 0;
+}

--- a/neat_addr.h
+++ b/neat_addr.h
@@ -48,6 +48,8 @@ void neat_addr_update_src_list(struct neat_ctx *nc,
 uint8_t neat_addr_cmp_ip6_addr(struct in6_addr *aAddr,
                                struct in6_addr *aAddr2);
 
+uint8_t sockaddr_cmp(struct sockaddr *, struct sockaddr *);
+
 void neat_addr_lifetime_timeout_cb(uv_timer_t *handle);
 
 //Free the list of source addresses

--- a/neat_core.c
+++ b/neat_core.c
@@ -1925,6 +1925,8 @@ neat_connect(struct he_cb_ctx *he_ctx, uv_poll_cb callback_fx)
         neat_log(NEAT_LOG_ERROR, "Failed to create he socket");
         return -1;
     }
+	setsockopt(he_ctx->fd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int));
+	setsockopt(he_ctx->fd, SOL_SOCKET, SO_REUSEPORT, &enable, sizeof(int));
 
     if (he_ctx->candidate->ai_family == AF_INET) {
         inet_ntop(AF_INET, &(((struct sockaddr_in *) &(he_ctx->candidate->src_addr))->sin_addr), addrsrcbuf, INET6_ADDRSTRLEN);
@@ -1980,6 +1982,9 @@ neat_connect(struct he_cb_ctx *he_ctx, uv_poll_cb callback_fx)
         neat_sctp_init_events(he_ctx->fd);
 #endif
             break;
+        case NEAT_STACK_UDP:
+
+			recvfrom(he_ctx->fd, NULL, 0, MSG_PEEK, NULL, 0);
         default:
             break;
     }

--- a/neat_core.c
+++ b/neat_core.c
@@ -2678,3 +2678,17 @@ neat_error_code neat_abort(struct neat_ctx *ctx, struct neat_flow *flow)
 
     return NEAT_OK;
 }
+
+neat_flow *
+neat_find_flow(neat_ctx *ctx, int sockProto, 
+       struct sockaddr *src, struct sockaddr *dst)
+{
+    neat_flow *flow;
+    LIST_FOREACH(flow, &ctx->flows, next_flow) {
+        if ((sockaddr_cmp(flow->dstAddr, dst) != 0) && 
+               (sockaddr_cmp(flow->srcAddr, src) != 0)) {
+                       return flow;
+        }
+    }
+    return NULL;
+}

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -124,6 +124,8 @@ struct neat_flow
     uint16_t stream_count;
     struct neat_resolver_results *resolver_results;
     const struct sockaddr *sockAddr; // raw unowned pointer into resolver_results
+	struct sockaddr *srcAddr;
+	struct sockaddr *dstAddr;
     struct neat_ctx *ctx; // raw convenience pointer
     uv_poll_t *handle;
 


### PR DESCRIPTION
Enables creation of a neat_flow with UDP_REQURIED property set that is able to speak to an outside udp server( nc -lu). 