### PR TITLE
neat_resolver_handle: make the callback use neat_error_code

### DIFF
--- a/neat_core.c
+++ b/neat_core.c
@@ -1506,7 +1506,7 @@ neat_change_timeout(neat_ctx *mgr, neat_flow *flow, unsigned int seconds)
 #endif // defined(TCP_USER_TIMEOUT)
 }
 
-static void
+static neat_error_code
 set_primary_dest_resolve_cb(struct neat_resolver_results *results,
                             uint8_t code,
                             void *user_data)
@@ -1528,7 +1528,7 @@ set_primary_dest_resolve_cb(struct neat_resolver_results *results,
 
     if (code != NEAT_RESOLVER_OK) {
         neat_io_error(ctx, flow, code);
-        return;
+        return NEAT_ERROR_DNS;
     }
 
     assert(results->lh_first);
@@ -1567,6 +1567,7 @@ set_primary_dest_resolve_cb(struct neat_resolver_results *results,
     } else {
         neat_log(NEAT_LOG_DEBUG, "Updated primary destination address to: %s", dest_addr);
     }
+    return NEAT_ERROR_OK;
 }
 
 neat_error_code
@@ -1601,7 +1602,7 @@ neat_request_capacity(struct neat_ctx *ctx, struct neat_flow *flow, int rate, in
     return NEAT_ERROR_UNABLE;
 }
 
-static void
+static neat_error_code
 accept_resolve_cb(struct neat_resolver_results *results,
                   uint8_t code,
                   void *user_data)
@@ -1617,7 +1618,7 @@ accept_resolve_cb(struct neat_resolver_results *results,
 
     if (code != NEAT_RESOLVER_OK) {
         neat_io_error(ctx, flow, code);
-        return;
+        return NEAT_ERROR_DNS;
     }
 
     assert (results->lh_first);
@@ -1763,7 +1764,7 @@ accept_resolve_cb(struct neat_resolver_results *results,
 
     if (socket_count == 0) {
         neat_io_error(ctx, flow, NEAT_ERROR_IO);
-        return;
+        return NEAT_ERROR_IO;
     }
 
 #ifdef USRSCTP_SUPPORT
@@ -1800,6 +1801,7 @@ accept_resolve_cb(struct neat_resolver_results *results,
     }
 #endif // if defined(__FreeBSD__)
 #endif // ifdef else USRSCTP_SUPPORT
+    return NEAT_ERROR_OK;
 }
 
 neat_error_code neat_accept(struct neat_ctx *ctx, struct neat_flow *flow,

--- a/neat_he.c
+++ b/neat_he.c
@@ -98,7 +98,7 @@ static void free_he_handle_cb(uv_handle_t *handle)
     free(handle);
 }
 
-static void
+static neat_error_code
 he_resolve_cb(struct neat_resolver_results *results,
               uint8_t code,
               void *user_data)
@@ -180,6 +180,7 @@ he_resolve_cb(struct neat_resolver_results *results,
     }
 
     free(resolver_data);
+    return NEAT_ERROR_OK;
 }
 
 neat_error_code neat_he_lookup(neat_ctx *ctx, neat_flow *flow, uv_poll_cb callback_fx)

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -248,9 +248,9 @@ LIST_HEAD(neat_resolver_servers, neat_resolver_server);
 
 //Arguments are result struct (must be freed by user), neat_resolver_code and
 //user_data passed to getaddrinfo
-typedef void (*neat_resolver_handle_t)(struct neat_resolver_results *,
-                                       uint8_t,
-                                       void *);
+typedef neat_error_code (*neat_resolver_handle_t)(struct neat_resolver_results *,
+                                                  uint8_t,
+                                                  void *);
 typedef void (*neat_resolver_cleanup_t)(struct neat_resolver *resolver);
 
 enum neat_resolver_code {

--- a/tests/neat_resolver_example.c
+++ b/tests/neat_resolver_example.c
@@ -18,9 +18,9 @@
 static uint8_t expected_replies;
 static uint8_t num_replies;
 
-static void resolver_handle(struct neat_resolver_results *results,
-                            uint8_t neat_code,
-                            void *user_data)
+static neat_error_code resolver_handle(struct neat_resolver_results *results,
+                                       uint8_t neat_code,
+                                       void *user_data)
 {
     char src_str[INET6_ADDRSTRLEN], dst_str[INET6_ADDRSTRLEN];
     struct neat_resolver_res *result;
@@ -33,7 +33,7 @@ static void resolver_handle(struct neat_resolver_results *results,
 
         if (num_replies == expected_replies)
             neat_stop_event_loop(resolver->nc);
-        return;
+        return NEAT_ERROR_DNS;
     }
 
     LIST_FOREACH(result, results, next_res) {
@@ -64,6 +64,8 @@ static void resolver_handle(struct neat_resolver_results *results,
     //neat_resolver_release(resolver);
     if (num_replies == expected_replies)
         neat_stop_event_loop(resolver->nc);
+
+    return NEAT_ERROR_OK;
 }
 
 static void resolver_cleanup(struct neat_resolver *resolver)


### PR DESCRIPTION
... in preparation for properly returning error on malloc fails etc.