### PR TITLE
he_resolve_cb: return error on NULL results or NULL lh_first

### DIFF
--- a/neat_he.c
+++ b/neat_he.c
@@ -100,7 +100,7 @@ static void free_he_handle_cb(uv_handle_t *handle)
 
 static neat_error_code
 he_resolve_cb(struct neat_resolver_results *results,
-              uint8_t code,
+              uint8_t code, // actually a 'neat_resolver_code'
               void *user_data)
 {
     neat_protocol_stack_type stacks[NEAT_STACK_MAX_NUM]; /* We only support SCTP, TCP, UDP, and UDPLite */
@@ -118,7 +118,9 @@ he_resolve_cb(struct neat_resolver_results *results,
 
     nr_of_stacks = neat_property_translate_protocols(flow->propertyMask, stacks);
 
-    assert (results->lh_first);
+    if (!results || !results->lh_first) {
+      return NEAT_ERROR_DNS;
+    }
     assert (!flow->resolver_results);
 
     he_print_results(results);


### PR DESCRIPTION
... instead of using a bad assert.

Fixes #135