### PR TITLE
Fix closing and shutdown

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -289,7 +289,7 @@ on_close(struct neat_flow_operations *opCB)
     ops.on_writable = NULL;
     ops.on_error = NULL;
     neat_set_operations(ctx, flow, &ops);
-    neat_free_flow(opCB->flow);
+
     neat_stop_event_loop(opCB->ctx);
 
     return NEAT_OK;

--- a/examples/client_http_get.c
+++ b/examples/client_http_get.c
@@ -108,7 +108,6 @@ on_close(struct neat_flow_operations *opCB)
     opCB->on_writable = NULL;
     opCB->on_error = NULL;
     neat_set_operations(opCB->ctx, opCB->flow, opCB);
-    neat_free_flow(opCB->flow);
 
     // stop event loop if all flows are closed
     flows_active--;

--- a/examples/client_https_get.c
+++ b/examples/client_https_get.c
@@ -140,9 +140,6 @@ int main(int argc, char *argv[])
     }
 
 cleanup:
-    if (flow != NULL) {
-        neat_free_flow(flow);
-    }
     if (ctx != NULL) {
         neat_free_ctx(ctx);
     }

--- a/examples/peer.c
+++ b/examples/peer.c
@@ -488,7 +488,7 @@ on_readable(struct neat_flow_operations *opCB)
         neat_set_operations(opCB->ctx, opCB->flow, opCB);
         free(pf->buffer);
         free(pf);
-        neat_free_flow(opCB->flow);
+        neat_close(opCB->ctx, opCB->flow);
     }
     return NEAT_OK;
 }

--- a/examples/server_chargen.c
+++ b/examples/server_chargen.c
@@ -102,7 +102,7 @@ static neat_error_code on_readable(struct neat_flow_operations *opCB)
         opCB->on_writable = NULL;
         opCB->on_all_written = NULL;
         neat_set_operations(opCB->ctx, opCB->flow, opCB);
-        neat_free_flow(opCB->flow);
+        neat_close(opCB->ctx, opCB->flow);
     }
 
     return NEAT_OK;

--- a/examples/server_daytime.c
+++ b/examples/server_daytime.c
@@ -102,7 +102,7 @@ on_readable(struct neat_flow_operations *opCB)
         opCB->on_writable = NULL;
         opCB->on_all_written = NULL;
         neat_set_operations(opCB->ctx, opCB->flow, opCB);
-        neat_free_flow(opCB->flow);
+        neat_close(opCB->ctx, opCB->flow);
     }
     return NEAT_OK;
 }
@@ -256,9 +256,6 @@ cleanup:
     if (arg_property)
         free(arg_property);
 
-    if (flow != NULL) {
-        neat_free_flow(flow);
-    }
     if (ctx != NULL) {
         neat_free_ctx(ctx);
     }

--- a/examples/server_discard.c
+++ b/examples/server_discard.c
@@ -104,7 +104,7 @@ on_readable(struct neat_flow_operations *opCB)
         }
         opCB->on_readable = NULL;
         neat_set_operations(opCB->ctx, opCB->flow, opCB);
-        neat_free_flow(opCB->flow);
+        neat_close(opCB->ctx, opCB->flow);
     }
     return NEAT_OK;
 }

--- a/examples/server_echo.c
+++ b/examples/server_echo.c
@@ -132,7 +132,7 @@ on_readable(struct neat_flow_operations *opCB)
         neat_set_operations(opCB->ctx, opCB->flow, opCB);
         free(ef->buffer);
         free(ef);
-        neat_free_flow(opCB->flow);
+        neat_close(opCB->ctx, opCB->flow);
     }
     return NEAT_OK;
 }

--- a/examples/tneat.c
+++ b/examples/tneat.c
@@ -361,7 +361,6 @@ on_close(struct neat_flow_operations *opCB)
     free(tnf);
 
     neat_set_operations(opCB->ctx, opCB->flow, opCB);
-    neat_free_flow(opCB->flow);
 
     fprintf(stderr, "%s - flow closed OK!\n", __func__);
 

--- a/neat.h
+++ b/neat.h
@@ -123,7 +123,6 @@ struct neat_flow_security {
 };
 
 NEAT_EXTERN struct neat_flow *neat_new_flow(struct neat_ctx *ctx);
-NEAT_EXTERN void neat_free_flow(struct neat_flow *flow);
 
 NEAT_EXTERN neat_error_code neat_set_operations(struct neat_ctx *ctx, struct neat_flow *flow,
                                     struct neat_flow_operations *ops);

--- a/neat_core.c
+++ b/neat_core.c
@@ -72,6 +72,8 @@ static void neat_sctp_init_events(struct socket *sock);
 static void neat_sctp_init_events(int sock);
 #endif
 
+static void neat_free_flow(struct neat_flow *flow);
+
 static neat_flow * do_accept(neat_ctx *ctx, neat_flow *flow, struct neat_pollable_socket *socket);
 neat_flow * neat_find_flow(neat_ctx *, struct sockaddr *, struct sockaddr *);
 

--- a/neat_core.c
+++ b/neat_core.c
@@ -3720,10 +3720,13 @@ neat_close_via_kernel(struct neat_ctx *ctx, struct neat_flow *flow)
 {
     neat_log(NEAT_LOG_DEBUG, "%s", __func__);
     if (flow->socket->fd != -1) {
-        neat_log(NEAT_LOG_DEBUG, "%s: Close fd %d", __func__, flow->socket->fd);
         // we might want a fx callback here to split between
         // kernel and userspace.. same for connect read and write
-        close(flow->socket->fd);
+
+        if (flow->socket->fd != 0) {
+            neat_log(NEAT_LOG_DEBUG, "%s: Close fd %d", __func__, flow->socket->fd);
+            close(flow->socket->fd);
+        }
 
         // KAH: AFAIK the socket API provides no way of knowing any
         // further status of the close op for TCP.

--- a/neat_core.c
+++ b/neat_core.c
@@ -4475,16 +4475,10 @@ void neat_notify_network_status_changed(neat_flow *flow, neat_error_code code)
 // CLOSE, D1.2 sect. 3.2.4
 neat_error_code neat_close(struct neat_ctx *ctx, struct neat_flow *flow)
 {
-    // KAH: free_cb actually does the closefx() call
-
-    // This code is copied from neat_free_flow
-    // TODO consider a refactor...
-    if (flow->isPolling)
+    if (flow->isPolling && uv_is_active((uv_handle_t*)flow->socket->handle))
         uv_poll_stop(flow->socket->handle);
 
-    if ((flow->socket->handle != NULL) &&
-        (flow->socket->handle->type != UV_UNKNOWN_HANDLE))
-        uv_close((uv_handle_t *)(flow->socket->handle), free_cb);
+    neat_free_flow(flow);
 
     return NEAT_OK;
 }

--- a/neat_core.c
+++ b/neat_core.c
@@ -233,7 +233,7 @@ static void neat_core_cleanup(struct neat_ctx *nc)
 //TODO: Consider adding callback, like for resolver
 void neat_free_ctx(struct neat_ctx *nc)
 {
-    struct neat_flow *f, *prev = NULL;
+    struct neat_flow *f;
     neat_log(NEAT_LOG_DEBUG, "%s", __func__);
 
     if (nc->resolver) {
@@ -242,17 +242,7 @@ void neat_free_ctx(struct neat_ctx *nc)
 
     while (!LIST_EMPTY(&nc->flows)) {
         f = LIST_FIRST(&nc->flows);
-
-        /*
-         * If this assert triggers, it means that a call to neat_free_flow did
-         * not remove the flow pointed to by f from the list of flows. The
-         * assert is present because clang-analyzer somehow doesn't see the fact
-         * that the list is changed in synchronous_free().
-         */
-        assert(f != prev);
-
         neat_free_flow(f);
-        prev = f;
     }
 
     neat_core_cleanup(nc);

--- a/neat_core.c
+++ b/neat_core.c
@@ -468,6 +468,7 @@ static void synchronous_free(neat_flow *flow)
 
 static void free_cb(uv_handle_t *handle)
 {
+    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
     struct neat_pollable_socket *pollable_socket = handle->data;
     synchronous_free(pollable_socket->flow);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 LIST(APPEND neat_test_programs
     neat_resolver_example.c
     test_echo.c
+    test_close.c
 )
 
 LIST(APPEND neat_test_scripts

--- a/tests/test_close.c
+++ b/tests/test_close.c
@@ -1,0 +1,264 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <assert.h>
+#include "../neat.h"
+
+/**********************************************************************
+ * Stripped down version of http_client_get used for testing various
+ * ways users could free or shut down flows and contexts.
+ **********************************************************************/
+
+typedef struct {
+    int on_connected;
+    int on_readable;
+    int on_writable;
+    int on_error;
+    int on_close;
+} close_t;
+
+static int config_rcv_buffer_size = 65536;
+static const char *request_tail = "HTTP/1.0\r\nUser-agent: libneat\r\nConnection: close\r\n\r\n";
+static char *config_property = "{\
+    \"transport\": [\
+        {\
+            \"value\": \"SCTP\",\
+            \"precedence\": 1\
+        },\
+        {\
+            \"value\": \"TCP\",\
+            \"precedence\": 1\
+        }\
+    ]\
+}";\
+
+static neat_error_code on_close(struct neat_flow_operations *ops);
+
+#define ON_ERROR_CLOSE_COUNT 2
+static neat_error_code
+on_error(struct neat_flow_operations *ops)
+{
+    close_t *cls = ops->userData;
+
+    fprintf(stderr, "%s\n", __func__);
+
+    if (cls->on_error == 1)
+        neat_close(ops->ctx, ops->flow);
+
+    neat_stop_event_loop(ops->ctx);
+
+    // TODO: This leads to an abort in libuv after calling neat_set_ops
+    // in on_close.
+#if 1
+    if (cls->on_error == 2)
+        neat_close(ops->ctx, ops->flow);
+#endif
+
+    return NEAT_OK;
+}
+
+#define ON_READABLE_CLOSE_COUNT 2
+static neat_error_code
+on_readable(struct neat_flow_operations *ops)
+{
+    close_t *cls = ops->userData;
+
+    unsigned char buffer[config_rcv_buffer_size];
+    uint32_t bytes_read = 0;
+    neat_error_code code;
+
+    if (cls->on_readable == 1)
+        neat_close(ops->ctx, ops->flow);
+
+    fprintf(stderr, "%s - reading from flow\n", __func__);
+    code = neat_read(ops->ctx, ops->flow, buffer, config_rcv_buffer_size, &bytes_read, NULL, 0);
+    if (code == NEAT_ERROR_WOULD_BLOCK) {
+        return 0;
+    }
+
+    assert(code == NEAT_OK);
+
+    if (!bytes_read) { // eof
+        fprintf(stderr, "%s - neat_read() got 0 bytes - connection closed\n", __func__);
+        fflush(stdout);
+        neat_close(ops->ctx, ops->flow);
+    } else if (bytes_read > 0) {
+        fprintf(stderr, "%s - received %d bytes\n", __func__, bytes_read);
+        fwrite(buffer, sizeof(char), bytes_read, stdout);
+    }
+
+    if (cls->on_readable == 2)
+        neat_close(ops->ctx, ops->flow);
+
+    return 0;
+}
+
+#define ON_WRITABLE_CLOSE_COUNT 3
+static neat_error_code
+on_writable(struct neat_flow_operations *ops)
+{
+    close_t *cls = ops->userData;
+
+    neat_error_code code;
+    fprintf(stderr, "%s - writing to flow\n", __func__);
+
+    if (cls->on_writable == 1)
+        neat_close(ops->ctx, ops->flow);
+
+    code = neat_write(ops->ctx, ops->flow, (const unsigned char *)request_tail, strlen(request_tail), NULL, 0);
+    if (code != NEAT_OK) {
+        return on_error(ops);
+    }
+
+    if (cls->on_writable == 2)
+        neat_close(ops->ctx, ops->flow);
+
+    ops->on_writable = NULL;
+    neat_set_operations(ops->ctx, ops->flow, ops);
+
+    if (cls->on_writable == 3)
+        neat_close(ops->ctx, ops->flow);
+
+    return 0;
+}
+
+#define ON_CONNECTED_CLOSE_COUNT 2
+static neat_error_code
+on_connected(struct neat_flow_operations *ops)
+{
+    close_t *cls = ops->userData;
+
+    // now we can start writing
+    fprintf(stderr, "%s - connection established\n", __func__);
+
+    if (cls->on_connected == 1)
+        neat_close(ops->ctx, ops->flow);
+
+    ops->on_readable = on_readable;
+    ops->on_writable = on_writable;
+    neat_set_operations(ops->ctx, ops->flow, ops);
+
+    if (cls->on_connected == 2)
+        neat_close(ops->ctx, ops->flow);
+
+    return 0;
+}
+
+#define ON_CLOSE_CLOSE_COUNT 3
+static neat_error_code
+on_close(struct neat_flow_operations *ops)
+{
+    close_t *cls = ops->userData;
+
+    fprintf(stderr, "%s - flow closed OK!\n", __func__);
+
+    if (cls->on_close == 1)
+        neat_close(ops->ctx, ops->flow);
+
+    // cleanup
+    ops->on_close = NULL;
+    ops->on_readable = NULL;
+    ops->on_writable = NULL;
+    ops->on_error = NULL;
+    neat_set_operations(ops->ctx, ops->flow, ops);
+
+    if (cls->on_close == 2)
+        neat_close(ops->ctx, ops->flow);
+
+    // stop event loop if all flows are closed
+    neat_stop_event_loop(ops->ctx);
+
+    if (cls->on_close == 3)
+        neat_close(ops->ctx, ops->flow);
+
+    return NEAT_OK;
+}
+
+int
+run_case(const char* name, close_t *close_spec)
+{
+    struct neat_ctx *ctx = NULL;
+    struct neat_flow *flow = NULL;
+    struct neat_flow_operations ops;
+    int result = 0;
+    result = EXIT_SUCCESS;
+
+    memset(&ops, 0, sizeof(ops));
+
+    if ((ctx = neat_init_ctx()) == NULL) {
+        fprintf(stderr, "could not initialize context\n");
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    if ((flow = neat_new_flow(ctx)) == NULL) {
+        fprintf(stderr, "could not create new flow\n");
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    neat_set_property(ctx, flow, config_property);
+
+    ops.userData = close_spec;
+
+    ops.on_connected = on_connected;
+    ops.on_error = on_error;
+    ops.on_close = on_close;
+
+    neat_set_operations(ctx, flow, &ops);
+
+    // wait for on_connected or on_error to be invoked
+    if (neat_open(ctx, flow, name, 80, NULL, 0) != NEAT_OK) {
+        fprintf(stderr, "Could not open flow\n");
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    neat_start_event_loop(ctx, NEAT_RUN_DEFAULT);
+
+cleanup:
+    if (ctx != NULL) {
+        neat_free_ctx(ctx);
+    }
+    return result;
+}
+
+int
+main(int argc, char *argv[])
+{
+    close_t cls;
+    memset(&cls, 0, sizeof(cls));
+
+    for (int i = 1; i <= ON_CONNECTED_CLOSE_COUNT; ++i) {
+        cls.on_connected = i;
+        run_case("bsd10.fh-muenster.de", &cls);
+    }
+    cls.on_connected = 0;
+
+    for (int i = 1; i <= ON_READABLE_CLOSE_COUNT; ++i) {
+        cls.on_readable = i;
+        run_case("bsd10.fh-muenster.de", &cls);
+    }
+    cls.on_readable = 0;
+
+    for (int i = 1; i <= ON_WRITABLE_CLOSE_COUNT; ++i) {
+        cls.on_writable = i;
+        run_case("bsd10.fh-muenster.de", &cls);
+    }
+    cls.on_writable = 0;
+
+    for (int i = 1; i <= ON_CLOSE_CLOSE_COUNT; ++i) {
+        cls.on_close = i;
+        run_case("bsd10.fh-muenster.de", &cls);
+    }
+    cls.on_close = 0;
+
+    for (int i = 1; i <= ON_ERROR_CLOSE_COUNT; ++i) {
+        cls.on_error = i;
+        run_case("not.resolvable.neat", &cls);
+    }
+    cls.on_error = 0;
+
+    return 0;
+}


### PR DESCRIPTION
Fixes #164. Hopefully.

Yet another round of fixes to the free/shutdown code.

`neat_free_flow` is now gone from the public API. It is instead called from `neat_close`, which essentially did the same as `neat_free_flow`.

Flows are now freed first in `neat_free_ctx` so that the shutdown happens in a sensible order.

The list of flows in a context is now updated in `neat_free_flow` instead of `synchronous_free` so that freeing all flows upon shutdown happens in a sane manner. This way we don't get stuck in an infinite loop if a flow cannot immediately be freed during shutdown.

The handles belonging to flows are now closed prior to calling `uv_walk`. During `uv_walk`, every handle that still isn't closed is closed with no callback, which will cause memory leaks for the handles that were attached to flows. Any future updates should make sure that flows are still closed before `uv_walk`.

Handles belonging to HE candidates are only freed if the same handle is not used by the flow.

Some minor and trivial changes.

And finally, a test which mimics the HTTP client, closing the flow at odd times.

I haven't tested the updated examples in detail, but I couldn't find any errors that I couldn't reproduce in the master branch.