### PR TITLE
Stop event loop on errors in context

### DIFF
--- a/docs/neat_start_event_loop.md
+++ b/docs/neat_start_event_loop.md
@@ -5,7 +5,7 @@ Starts the internal event loop within NEAT.
 ### Syntax
 
 ```c
-void neat_start_event_loop(struct neat_ctx *ctx, neat_run_mode run_mode);
+neat_error_code neat_start_event_loop(struct neat_ctx *ctx, neat_run_mode run_mode);
 ```
 
 ### Parameters
@@ -16,7 +16,9 @@ May be one of either `NEAT_RUN_DEFAULT`, `NEAT_RUN_ONCE`, or `NEAT_RUN_NOWAIT`.
 
 ### Return values
 
-None.
+- Returns `NEAT_OK` if the NEAT executed with no error.
+- Returns an error value if the internal event loop in NEAT was stopped due to
+  an error.
 
 ### Remarks
 

--- a/neat.h
+++ b/neat.h
@@ -25,13 +25,14 @@ typedef enum {
 struct neat_ctx; // global
 struct neat_flow; // one per connection
 
+typedef uint64_t neat_error_code;
+
 NEAT_EXTERN struct neat_ctx *neat_init_ctx();
-NEAT_EXTERN void neat_start_event_loop(struct neat_ctx *nc, neat_run_mode run_mode);
+NEAT_EXTERN neat_error_code neat_start_event_loop(struct neat_ctx *nc, neat_run_mode run_mode);
 NEAT_EXTERN void neat_stop_event_loop(struct neat_ctx *nc);
 NEAT_EXTERN int neat_get_backend_fd(struct neat_ctx *nc);
 NEAT_EXTERN void neat_free_ctx(struct neat_ctx *nc);
 
-typedef uint64_t neat_error_code;
 struct neat_flow_operations;
 typedef neat_error_code (*neat_flow_operations_fx)(struct neat_flow_operations *);
 

--- a/neat_addr.c
+++ b/neat_addr.c
@@ -62,7 +62,7 @@ uint8_t neat_addr_cmp_ip6_addr(struct in6_addr *aAddr,
 }
 
 //Add/remove/update a source address based on information received from OS
-void neat_addr_update_src_list(struct neat_ctx *nc,
+neat_error_code neat_addr_update_src_list(struct neat_ctx *nc,
         struct sockaddr_storage *src_addr, uint32_t if_idx,
         uint8_t newaddr, uint8_t pref_length, uint32_t ifa_pref, uint32_t ifa_valid)
 {
@@ -120,7 +120,7 @@ void neat_addr_update_src_list(struct neat_ctx *nc,
             neat_run_event_cb(nc, NEAT_UPDATEADDR, nsrc_addr);
         }
 
-        return;
+        return NEAT_ERROR_OK;
     }
 
     //No match found, so create a new address, add it to list and announce it to
@@ -130,7 +130,7 @@ void neat_addr_update_src_list(struct neat_ctx *nc,
     if (nsrc_addr == NULL) {
         neat_log(NEAT_LOG_ERROR, "%s: Could not allocate memory for %s", __func__, addr_str);
         //TODO: Trigger a refresh of available addresses
-        return;
+        return NEAT_ERROR_OUT_OF_MEMORY;
     }
 
     nsrc_addr->family = src_addr->ss_family;
@@ -148,6 +148,7 @@ void neat_addr_update_src_list(struct neat_ctx *nc,
     ++nc->src_addr_cnt;
     neat_addr_print_src_addrs(nc);
     neat_run_event_cb(nc, NEAT_NEWADDR, nsrc_addr);
+    return NEAT_ERROR_OK;
 }
 
 void neat_addr_lifetime_timeout_cb(uv_timer_t *handle)

--- a/neat_addr.h
+++ b/neat_addr.h
@@ -42,7 +42,7 @@ struct neat_addr {
 };
 
 //Add/remove addresses from src. address list
-void neat_addr_update_src_list(struct neat_ctx *nc,
+neat_error_code neat_addr_update_src_list(struct neat_ctx *nc,
         struct sockaddr_storage *src_addr, uint32_t if_idx,
         uint8_t newaddr, uint8_t pref_length, uint32_t ifa_pref, uint32_t ifa_valid);
 

--- a/neat_bsd.c
+++ b/neat_bsd.c
@@ -311,6 +311,9 @@ struct neat_ctx *neat_bsd_init_ctx(struct neat_ctx *ctx)
         neat_bsd_cleanup(ctx);
         return NULL;
     }
-    neat_bsd_get_addresses(ctx);
+    if (neat_bsd_get_addresses(ctx) != NEAT_OK) {
+        neat_log(NEAT_LOG_ERROR, "%s: cannot get src addresses", __func__);
+        return NULL;
+    }
     return ctx;
 }

--- a/neat_bsd.c
+++ b/neat_bsd.c
@@ -189,6 +189,7 @@ static void neat_bsd_route_recv(uv_udp_t *handle,
     time_t now;
     struct in6_addrlifetime *lifetime;
     uint32_t preferred_lifetime, valid_lifetime;
+    neat_error_code rc;
 
     ctx = (struct neat_ctx *)handle->data;
     ifa = (struct ifa_msghdr *)buf->base;
@@ -233,14 +234,16 @@ static void neat_bsd_route_recv(uv_udp_t *handle,
             valid_lifetime = 0;
         }
     }
-    return
-      neat_addr_update_src_list(ctx,
-                                (struct sockaddr_storage *)rti_info[RTAX_IFA],
-                                ifa->ifam_index,
-                                ifa->ifam_type == RTM_NEWADDR ? 1 : 0,
-                                0,
-                                preferred_lifetime,
-                                valid_lifetime);
+
+    rc = neat_addr_update_src_list(ctx,
+                                   (struct sockaddr_storage *)rti_info[RTAX_IFA],
+                                   ifa->ifam_index,
+                                   ifa->ifam_type == RTM_NEWADDR ? 1 : 0,
+                                   0,
+                                   preferred_lifetime,
+                                   valid_lifetime);
+
+    neat_ctx_fail_on_error(ctx, rc);
 }
 
 static void neat_bsd_cleanup(struct neat_ctx *ctx)

--- a/neat_core.c
+++ b/neat_core.c
@@ -136,6 +136,8 @@ struct neat_ctx *neat_init_ctx()
         return NULL;
     }
 
+    nc->error = NEAT_OK;
+
     uv_loop_init(nc->loop);
     LIST_INIT(&(nc->src_addrs));
     LIST_INIT(&(nc->flows));
@@ -187,6 +189,20 @@ int neat_get_backend_fd(struct neat_ctx *nc)
     neat_log(NEAT_LOG_DEBUG, "%s", __func__);
 
     return uv_backend_fd(nc->loop);
+}
+
+/*
+ * Terminate a NEAT context upon error.
+ * Errors are reported back to the user through neat_start_event_loop.
+ */
+void
+neat_ctx_fail_on_error(struct neat_ctx *nc, neat_error_code error)
+{
+    if (error == NEAT_OK)
+        return;
+
+    nc->error = error;
+    neat_stop_event_loop(nc);
 }
 
 static void neat_walk_cb(uv_handle_t *handle, void *arg)

--- a/neat_core.c
+++ b/neat_core.c
@@ -169,12 +169,14 @@ struct neat_ctx *neat_init_ctx()
 
 //Start the internal NEAT event loop
 //TODO: Add support for embedding libuv loops in other event loops
-void neat_start_event_loop(struct neat_ctx *nc, neat_run_mode run_mode)
+neat_error_code
+neat_start_event_loop(struct neat_ctx *nc, neat_run_mode run_mode)
 {
     neat_log(NEAT_LOG_DEBUG, "%s", __func__);
 
     uv_run(nc->loop, (uv_run_mode) run_mode);
     uv_loop_close(nc->loop);
+    return nc->error;
 }
 
 void neat_stop_event_loop(struct neat_ctx *nc)

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -68,11 +68,15 @@ struct neat_ctx
     // PvD
     struct neat_pvd* pvd;
 
+    neat_error_code error;
+
     // resolver
     NEAT_INTERNAL_CTX;
     NEAT_INTERNAL_OS;
     NEAT_INTERNAL_USRSCTP
 };
+
+void neat_ctx_fail_on_error(struct neat_ctx *nc, neat_error_code error);
 
 struct neat_he_candidate;
 struct neat_pollable_socket;

--- a/neat_linux.c
+++ b/neat_linux.c
@@ -51,7 +51,7 @@ static int neat_linux_parse_nlattr(const struct nlattr *attr, void *data)
 //Function which parses the netlink message (*ADDR) we have received and extract
 //relevant information, which is parsed to OS-independent
 //neat_addr_update_src_list
-static void neat_linux_handle_addr(struct neat_ctx *nc,
+static neat_error_code neat_linux_handle_addr(struct neat_ctx *nc,
                                    struct nlmsghdr *nl_hdr)
 {
     struct ifaddrmsg *ifm = (struct ifaddrmsg*) mnl_nlmsg_get_payload(nl_hdr);
@@ -67,7 +67,7 @@ static void neat_linux_handle_addr(struct neat_ctx *nc,
     uint32_t ifa_pref = 0, ifa_valid = 0;
 
     if (ifm->ifa_scope == RT_SCOPE_LINK)
-        return;
+        return NEAT_ERROR_OK;
 
     memset(attr_table, 0, sizeof(attr_table));
     memset(&src_addr, 0, sizeof(src_addr));
@@ -76,7 +76,7 @@ static void neat_linux_handle_addr(struct neat_ctx *nc,
                 neat_linux_parse_nlattr, &tb_storage) != MNL_CB_OK) {
         neat_log(NEAT_LOG_ERROR, "Failed to parse nlattr for msg of type %d",
                 __func__, nl_hdr->nlmsg_type);
-        return;
+        return NEAT_ERROR_OK;
     }
 
     //v4 and v6 has to be handled differently, both due to address size and
@@ -97,8 +97,9 @@ static void neat_linux_handle_addr(struct neat_ctx *nc,
 
     //TODO: Should this function be a callback instead? Will we have multiple
     //addresses handlers/types of context?
-    neat_addr_update_src_list(nc, &src_addr, ifm->ifa_index,
-            nl_hdr->nlmsg_type == RTM_NEWADDR, ifm->ifa_prefixlen, ifa_pref, ifa_valid);
+    return neat_addr_update_src_list(nc, &src_addr, ifm->ifa_index,
+                                     nl_hdr->nlmsg_type == RTM_NEWADDR,
+                                     ifm->ifa_prefixlen, ifa_pref, ifa_valid);
 }
 
 //libuv datagram socket alloc function, un-interesting
@@ -195,29 +196,29 @@ struct neat_ctx *neat_linux_init_ctx(struct neat_ctx *nc)
     return nc;
 }
 
-/* Get the Linux TCP_INFO and copy the relevant fields into the neat-specific 
+/* Get the Linux TCP_INFO and copy the relevant fields into the neat-specific
  * TCP_INFO struct. Return pointer to the struct with the copied data */
 void linux_get_tcp_info(neat_flow *flow, struct neat_tcp_info *neat_tcp_info)
 {
-    int tcp_info_length; 
+    int tcp_info_length;
     struct tcp_info tcpi;
-   
+
     neat_log(NEAT_LOG_DEBUG, "%s", __func__);
-    
+
     tcp_info_length = sizeof(struct tcp_info);
     getsockopt(flow->socket->fd, SOL_TCP, TCP_INFO, (void *)&tcpi, (socklen_t *)&tcp_info_length );
-    
+
     /* Copy relevant fields between structs */
 
-    neat_tcp_info->retransmits = tcpi.tcpi_retransmits; 
-    neat_tcp_info->tcpi_pmtu = tcpi.tcpi_pmtu; 
+    neat_tcp_info->retransmits = tcpi.tcpi_retransmits;
+    neat_tcp_info->tcpi_pmtu = tcpi.tcpi_pmtu;
     neat_tcp_info->tcpi_rcv_ssthresh = tcpi.tcpi_rcv_ssthresh;
     neat_tcp_info->tcpi_rtt = tcpi.tcpi_rtt;
     neat_tcp_info->tcpi_rttvar = tcpi.tcpi_rttvar;
     neat_tcp_info->tcpi_snd_ssthresh = tcpi.tcpi_snd_ssthresh;
     neat_tcp_info->tcpi_snd_cwnd = tcpi.tcpi_snd_cwnd;
     neat_tcp_info->tcpi_advmss = tcpi.tcpi_advmss;
-    neat_tcp_info->tcpi_reordering = tcpi.tcpi_reordering;    
+    neat_tcp_info->tcpi_reordering = tcpi.tcpi_reordering;
     neat_tcp_info->tcpi_rcv_rtt = tcpi.tcpi_rcv_rtt;
     neat_tcp_info->tcpi_rcv_space = tcpi.tcpi_rcv_space;
     neat_tcp_info->tcpi_total_retrans = tcpi.tcpi_total_retrans;

--- a/neat_linux.c
+++ b/neat_linux.c
@@ -126,7 +126,7 @@ static void neat_linux_nl_recv(uv_udp_t *handle, ssize_t nread,
     while (mnl_nlmsg_ok(nl_hdr, numbytes)) {
         if (nl_hdr->nlmsg_type == RTM_NEWADDR ||
             nl_hdr->nlmsg_type == RTM_DELADDR)
-            neat_linux_handle_addr(nc, nl_hdr);
+            neat_ctx_fail_on_error(nc, neat_linux_handle_addr(nc, nl_hdr));
 
         nl_hdr = mnl_nlmsg_next(nl_hdr, &numbytes);
     }


### PR DESCRIPTION
This PR is an amendment to #142.

The new function `neat_fail_ctx_on_error` stops the event loop and stores the error value in `ctx`. This error value is returned to the user by `neat_start_event_loop`. This is for cases where the error is not tied to any flow in particular.

The source address code on Linux and BSD has been updated to use this mechanism when `neat_addr_update_src_list` fails.

@tuexen and @kristrev, could you take a look at these changes?