### PR TITLE
Fix: Initialized ptr with NULL, in order to fix compiler warnings.

### DIFF
--- a/neat_resolver.c
+++ b/neat_resolver.c
@@ -227,7 +227,7 @@ static uint32_t neat_resolver_literal_populate_results(struct neat_resolver_requ
     neat_log(NEAT_LOG_DEBUG, "%s", __func__);
 
     char *tmp = strdup(request->domain_name);
-    char *ptr;
+    char *ptr = NULL;
     char *address_name = strtok_r((char *)tmp, ",", &ptr);
     while (address_name != NULL) {
         if (request->family == AF_INET) {

--- a/neat_resolver_helpers.c
+++ b/neat_resolver_helpers.c
@@ -53,7 +53,7 @@ neat_resolver_helpers_check_for_literal(uint8_t *family,
     } else {
         // More than one destination address provided
         char *tmp = strdup(node);
-        char *ptr;
+        char *ptr = NULL;
         char *address_name = strtok_r((char *)tmp, ",", &ptr);
         while (address_name != NULL) {
             v4_literal = inet_pton(AF_INET, address_name, &dummy_addr);


### PR DESCRIPTION
Initialized ptr with NULL, in order to fix compiler warnings on possibly uninitialized variable "ptr". Otherwise, when compiling with -Werror, building fails on Ubuntu Xenial.