### PR TITLE
Examples improvements, neat_log documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,9 +44,11 @@ Welcome to the NEAT documentation!
     neat_get_backend_fd <neat_get_backend_fd>
     neat_get_stats <neat_get_stats>
 
+    neat_log_level <neat_log_level>
+    neat_log_file <neat_log_file>
+
 .. toctree::
     :caption: Internal
     :maxdepth: 1
 
     Coding Style <internal/codingstyle>
-

--- a/docs/neat_log_file.md
+++ b/docs/neat_log_file.md
@@ -16,7 +16,7 @@ uint8_t neat_log_file(const char* file_name)
 
 ### Examples
 ```
-neat_log_file("desaster.log");
+neat_log_file("disaster.log");
 ```
 
 ### See also

--- a/docs/neat_log_file.md
+++ b/docs/neat_log_file.md
@@ -1,0 +1,24 @@
+# neat_log_file
+Sets the name of the log file.
+
+### Syntax
+```c
+uint8_t neat_log_file(const char* file_name)
+```
+
+### Parameters
+- **file_name**: Name of the NEAT logfile. If set to `NULL`, NEAT writes the log output to `stderr`.
+
+
+### Return values
+- **RETVAL_SUCCESS**: success
+- **RETVAL_FAILURE**: failure
+
+### Examples
+```
+neat_log_file("desaster.log");
+```
+
+### See also
+
+- [neat_log_level](neat_log_level.md)

--- a/docs/neat_log_level.md
+++ b/docs/neat_log_level.md
@@ -1,0 +1,27 @@
+# neat_log_level
+Set the log-level of the NEAT library.
+
+### Syntax
+```c
+void neat_log_level(uint8_t level)
+```
+
+### Parameters
+- **level**: Log level of the log entry
+    - NEAT_LOG_OFF
+    - NEAT_LOG_ERROR
+    - NEAT_LOG_WARNING
+    - NEAT_LOG_ERROR
+    - NEAT_LOG_DEBUG
+
+### Return values
+None.
+
+### Examples
+```
+neat_log_level(NEAT_LOG_ERROR);
+```
+
+### See also
+
+- [neat_log_file](neat_log_file.md)

--- a/examples/client.c
+++ b/examples/client.c
@@ -28,7 +28,7 @@
 
 static uint32_t config_rcv_buffer_size = 256;
 static uint32_t config_snd_buffer_size = 128;
-static uint16_t config_log_level = 2;
+static uint16_t config_log_level = 1;
 static uint16_t config_json_stats = 1;
 static uint16_t config_timeout = 0;
 static uint16_t config_number_of_streams = 1207;
@@ -182,7 +182,7 @@ on_readable(struct neat_flow_operations *opCB)
     // all fine
     if (buffer_filled > 0) {
         if (config_log_level >= 1) {
-            fprintf(stderr, "%s - received %d bytes on stream %d of %d\n", __func__, buffer_filled, opCB->stream_id, opCB->flow->stream_count);
+            fprintf(stderr, "%s - received %d bytes on stream id %d (%d streams)\n", __func__, buffer_filled, opCB->stream_id, opCB->flow->stream_count);
         }
         fwrite(buffer_rcv, sizeof(char), buffer_filled, stdout);
         fflush(stdout);
@@ -445,6 +445,14 @@ main(int argc, char *argv[])
             goto cleanup;
             break;
         }
+    }
+
+    if (config_log_level == 0) {
+        neat_log_level(NEAT_LOG_ERROR);
+    } else if (config_log_level == 1){
+        neat_log_level(NEAT_LOG_WARNING);
+    } else {
+        neat_log_level(NEAT_LOG_DEBUG);
     }
 
     if (optind + 2 != argc) {

--- a/examples/client_http_get.c
+++ b/examples/client_http_get.c
@@ -137,6 +137,8 @@ main(int argc, char *argv[])
     uint32_t i = 0;
     result = EXIT_SUCCESS;
 
+    neat_log_level(NEAT_LOG_DEBUG);
+
     memset(&ops, 0, sizeof(ops));
     memset(flows, 0, sizeof(flows));
 

--- a/examples/peer.c
+++ b/examples/peer.c
@@ -20,7 +20,7 @@
 **********************************************************************/
 
 static uint32_t config_buffer_size_max = 1400;
-static uint16_t config_log_level = 0;
+static uint16_t config_log_level = 1;
 static char config_property[] = "NEAT_PROPERTY_UDP_REQUIRED";
 static uint32_t config_drop_randomly= 0;
 static uint32_t config_drop_rate= 80;

--- a/examples/server_chargen.c
+++ b/examples/server_chargen.c
@@ -216,6 +216,14 @@ main(int argc, char *argv[])
         }
     }
 
+    if (config_log_level == 0) {
+        neat_log_level(NEAT_LOG_ERROR);
+    } else if (config_log_level == 1){
+        neat_log_level(NEAT_LOG_WARNING);
+    } else {
+        neat_log_level(NEAT_LOG_DEBUG);
+    }
+
     if (optind != argc) {
         fprintf(stderr, "%s - argument error\n", __func__);
         print_usage();

--- a/examples/server_daytime.c
+++ b/examples/server_daytime.c
@@ -206,6 +206,14 @@ main(int argc, char *argv[])
         }
     }
 
+    if (config_log_level == 0) {
+        neat_log_level(NEAT_LOG_ERROR);
+    } else if (config_log_level == 1){
+        neat_log_level(NEAT_LOG_WARNING);
+    } else {
+        neat_log_level(NEAT_LOG_DEBUG);
+    }
+
     if (optind != argc) {
         fprintf(stderr, "%s - argument error\n", __func__);
         print_usage();

--- a/examples/server_discard.c
+++ b/examples/server_discard.c
@@ -171,6 +171,14 @@ main(int argc, char *argv[])
         }
     }
 
+    if (config_log_level == 0) {
+        neat_log_level(NEAT_LOG_ERROR);
+    } else if (config_log_level == 1){
+        neat_log_level(NEAT_LOG_WARNING);
+    } else {
+        neat_log_level(NEAT_LOG_DEBUG);
+    }
+
     if (optind != argc) {
         fprintf(stderr, "%s - argument error\n", __func__);
         print_usage();

--- a/examples/server_echo.c
+++ b/examples/server_echo.c
@@ -21,7 +21,7 @@ A TLS example:
 **********************************************************************/
 
 static uint32_t config_buffer_size = 512;
-static uint16_t config_log_level = 2;
+static uint16_t config_log_level = 1;
 static uint16_t config_number_of_streams = 1988;
 static char *config_property = "{\n\
     \"transport\": [\n\
@@ -267,6 +267,14 @@ main(int argc, char *argv[])
             goto cleanup;
             break;
         }
+    }
+
+    if (config_log_level == 0) {
+        neat_log_level(NEAT_LOG_ERROR);
+    } else if (config_log_level == 1){
+        neat_log_level(NEAT_LOG_WARNING);
+    } else {
+        neat_log_level(NEAT_LOG_DEBUG);
     }
 
     if (optind != argc) {

--- a/examples/tneat.c
+++ b/examples/tneat.c
@@ -30,7 +30,7 @@ static uint32_t config_runtime_max = 0;
 static uint16_t config_active = 0;
 static uint16_t config_chargen_offset = 0;
 static uint16_t config_port = 8080;
-static uint16_t config_log_level = 2;
+static uint16_t config_log_level = 1;
 static char *config_property = "{\
     \"transport\": [\
         {\
@@ -435,6 +435,14 @@ main(int argc, char *argv[])
             goto cleanup;
             break;
         }
+    }
+
+    if (config_log_level == 0) {
+        neat_log_level(NEAT_LOG_ERROR);
+    } else if (config_log_level == 1){
+        neat_log_level(NEAT_LOG_WARNING);
+    } else {
+        neat_log_level(NEAT_LOG_DEBUG);
     }
 
     if (optind == argc) {

--- a/neat.h
+++ b/neat.h
@@ -32,6 +32,8 @@ NEAT_EXTERN neat_error_code neat_start_event_loop(struct neat_ctx *nc, neat_run_
 NEAT_EXTERN void neat_stop_event_loop(struct neat_ctx *nc);
 NEAT_EXTERN int neat_get_backend_fd(struct neat_ctx *nc);
 NEAT_EXTERN void neat_free_ctx(struct neat_ctx *nc);
+NEAT_EXTERN void neat_log_level(uint8_t level);
+NEAT_EXTERN uint8_t neat_log_file(const char* file_name);
 
 struct neat_flow_operations;
 typedef neat_error_code (*neat_flow_operations_fx)(struct neat_flow_operations *);
@@ -208,6 +210,12 @@ NEAT_EXTERN neat_error_code neat_set_ecn(struct neat_ctx *ctx,
 #define NEAT_ERROR_OUT_OF_MEMORY (10)
 
 #define NEAT_INVALID_STREAM (-1)
+
+#define NEAT_LOG_OFF            (0)
+#define NEAT_LOG_ERROR          (1)
+#define NEAT_LOG_WARNING        (2)
+#define NEAT_LOG_INFO           (3)
+#define NEAT_LOG_DEBUG          (4)
 
 #define NEAT_OPTARGS (__optional_arguments)
 #define NEAT_OPTARGS_COUNT (__optional_argument_count)

--- a/neat_log.c
+++ b/neat_log.c
@@ -79,7 +79,8 @@ neat_log_file(const char* file_name)
 
         return RETVAL_SUCCESS;
     } else {
-        return RETVAL_FAILURE;
+        neat_log_fd = stderr;
+        return RETVAL_SUCCESS;
     }
 }
 

--- a/neat_log.c
+++ b/neat_log.c
@@ -11,7 +11,7 @@
 
 #include "neat_log.h"
 
-uint8_t neat_log_level = NEAT_LOG_DEBUG;
+uint8_t log_level = NEAT_LOG_DEBUG;
 struct timeval tv_init;
 FILE *neat_log_fd = NULL;
 
@@ -19,62 +19,80 @@ FILE *neat_log_fd = NULL;
  * Initiate log system
  *  - currently supports stderr and file
  */
-uint8_t neat_log_init() {
-    const char* env_log_level;
-    const char* env_log_file;
-
-    env_log_level = getenv("NEAT_LOG_LEVEL");
-    env_log_file = getenv("NEAT_LOG_FILE");
+uint8_t
+neat_log_init()
+{
+    // set initial timestamp
     gettimeofday(&tv_init, NULL);
 
-
-    // use stderr as default output until init finished...
-    neat_log_fd = stderr;
-
-    // determine log level
-    if (env_log_level == NULL) {
-        neat_log(NEAT_LOG_INFO, "%s - NEAT_LOG_LEVEL : default", __func__);
-    } else if (strcmp(env_log_level,"NEAT_LOG_DEBUG") == 0) {
-        neat_log(NEAT_LOG_INFO, "%s - NEAT_LOG_LEVEL : NEAT_LOG_DEBUG", __func__);
-        neat_log_level = NEAT_LOG_DEBUG;
-    } else if (strcmp(env_log_level,"NEAT_LOG_INFO") == 0) {
-        neat_log(NEAT_LOG_INFO, "%s - NEAT_LOG_LEVEL : NEAT_LOG_INFO", __func__);
-        neat_log_level = NEAT_LOG_INFO;
-    } else if (strcmp(env_log_level,"NEAT_LOG_WARNING") == 0) {
-        neat_log(NEAT_LOG_INFO, "%s - NEAT_LOG_LEVEL : NEAT_LOG_WARNING", __func__);
-        neat_log_level = NEAT_LOG_WARNING;
-    } else if (strcmp(env_log_level,"NEAT_LOG_ERROR") == 0) {
-        neat_log(NEAT_LOG_INFO, "%s - NEAT_LOG_LEVEL : NEAT_LOG_ERROR", __func__);
-        neat_log_level = NEAT_LOG_ERROR;
-    } else if (strcmp(env_log_level,"NEAT_LOG_OFF") == 0) {
-        neat_log(NEAT_LOG_INFO, "%s - NEAT_LOG_LEVEL : NEAT_LOG_OFF", __func__);
-        neat_log_level = NEAT_LOG_OFF;
+    if (neat_log_fd == NULL) {
+        neat_log_fd = stderr;
     }
 
-    // determine output fd
-    if (env_log_file != NULL) {
-        neat_log(NEAT_LOG_INFO, "%s - using logfile: %s", __func__, env_log_file);
-        neat_log_fd = fopen (env_log_file, "w");
-
-        if (neat_log_fd == NULL) {
-            neat_log_fd = stderr;
-            neat_log(NEAT_LOG_ERROR, "%s - could not open logfile, using stderr", __func__);
-            return RETVAL_FAILURE;
-        }
-    }
     neat_log(NEAT_LOG_INFO, "%s - opening logfile ...", __func__);
 
     return RETVAL_SUCCESS;
 }
 
 /*
+ * Set the NEAT log level
+ */
+void
+neat_log_level(uint8_t level)
+{
+    switch (level) {
+        case NEAT_LOG_OFF:
+            log_level = NEAT_LOG_OFF;
+            break;
+        case NEAT_LOG_ERROR:
+            log_level = NEAT_LOG_ERROR;
+            break;
+        case NEAT_LOG_WARNING:
+            log_level = NEAT_LOG_WARNING;
+            break;
+        case NEAT_LOG_INFO:
+            log_level = NEAT_LOG_INFO;
+            break;
+        case NEAT_LOG_DEBUG:
+            log_level = NEAT_LOG_DEBUG;
+            break;
+        default:
+            log_level = NEAT_LOG_DEBUG;
+            fprintf(stderr, "%s - unknown log-level - using default\n", __func__);
+            break;
+    }
+}
+
+uint8_t
+neat_log_file(const char* file_name)
+{
+    // determine output fd
+    if (file_name != NULL) {
+        neat_log(NEAT_LOG_INFO, "%s - using logfile: %s", __func__, file_name);
+        neat_log_fd = fopen(file_name, "w");
+
+        if (neat_log_fd == NULL) {
+            neat_log_fd = stderr;
+            neat_log(NEAT_LOG_ERROR, "%s - could not open logfile, using stderr", __func__);
+            return RETVAL_FAILURE;
+        }
+
+        return RETVAL_SUCCESS;
+    } else {
+        return RETVAL_FAILURE;
+    }
+}
+
+/*
  * Write log entry
  */
-void neat_log(uint8_t level, const char* format, ...) {
+void
+neat_log(uint8_t level, const char* format, ...)
+{
 
     struct timeval tv_now, tv_diff;
     // skip unwanted loglevels
-    if (neat_log_level < level) {
+    if (log_level < level) {
         return;
     }
 
@@ -122,8 +140,9 @@ void neat_log(uint8_t level, const char* format, ...) {
 /*
  * Write log entry for usrsctp
  */
-
-void neat_log_usrsctp(const char* format, ...) {
+void
+neat_log_usrsctp(const char* format, ...)
+{
 
     if (neat_log_fd == NULL) {
         fprintf(stderr, "neat_log_fd is NULL - neat_log_init() required!\n");
@@ -141,7 +160,9 @@ void neat_log_usrsctp(const char* format, ...) {
 /*
  * Close logfile
  */
-uint8_t neat_log_close() {
+uint8_t
+neat_log_close()
+{
     neat_log(NEAT_LOG_INFO, "%s - closing logfile ...", __func__);
     if (neat_log_fd != stderr) {
         if (fclose(neat_log_fd) == 0) {
@@ -155,21 +176,39 @@ uint8_t neat_log_close() {
 }
 
 #else // NEAT_LOG
-    uint8_t neat_log_init() {
-        return RETVAL_SUCCESS;
-    }
+uint8_t
+neat_log_init() {
+    return RETVAL_SUCCESS;
+}
 
-    void neat_log(uint8_t level, const char* format, ...) {
-        return;
-    }
+void
+neat_log_level(uint8_t level) {
+    return;
+}
 
-    void neat_log_usrsctp(const char* format, ...) {
-        return;
-    }
+uint8_t
+neat_log_file(const char* file_name)
+{
+    return RETVAL_SUCCESS;
+}
 
-    uint8_t neat_log_close() {
-        return RETVAL_SUCCESS;
-    }
+void
+neat_log(uint8_t level, const char* format, ...)
+{
+    return;
+}
+
+void
+neat_log_usrsctp(const char* format, ...)
+{
+    return;
+}
+
+uint8_t
+neat_log_close()
+{
+    return RETVAL_SUCCESS;
+}
 
 
 #endif

--- a/neat_log.h
+++ b/neat_log.h
@@ -2,19 +2,11 @@
 #define NEAT_LOG_H
 
 #include <stdint.h>
-
-#define NEAT_LOG_OFF 0
-#define NEAT_LOG_ERROR 1
-#define NEAT_LOG_WARNING 2
-#define NEAT_LOG_INFO 3
-#define NEAT_LOG_DEBUG 4
-
-#define NEAT_LOG_STDERR 0
+#include "neat.h"
 
 uint8_t neat_log_init();
 void neat_log(uint8_t level, const char* format, ...);
 void neat_log_usrsctp(const char* format, ...);
 uint8_t neat_log_close();
-
 
 #endif


### PR DESCRIPTION
Examples now make use of `neat_log_level` and aren't using DEBUG log level by default. 
Also added documentation for neat_log_level and neat_log_file