### PR TITLE
neat_set_operations() fix for bug #231

### DIFF
--- a/neat_core.c
+++ b/neat_core.c
@@ -693,8 +693,11 @@ neat_error_code neat_set_operations(neat_ctx *mgr, neat_flow *flow,
 {
     neat_log(NEAT_LOG_DEBUG, "%s", __func__);
 
-    flow->operations = ops;
+    if( (flow->operations) && (flow->ownedByCore) ) {
+       free(flow->operations);
+    }
     flow->ownedByCore = 0;
+    flow->operations = ops;
 
     if (flow->socket == NULL)
         return NEAT_OK;

--- a/neat_core.c
+++ b/neat_core.c
@@ -694,6 +694,7 @@ neat_error_code neat_set_operations(neat_ctx *mgr, neat_flow *flow,
     neat_log(NEAT_LOG_DEBUG, "%s", __func__);
 
     flow->operations = ops;
+    flow->ownedByCore = 0;
 
     if (flow->socket == NULL)
         return NEAT_OK;


### PR DESCRIPTION
neat_set_operations() fix for bug #231:
- Free flow->operations, if owned by NEAT
- flow->ownedByCore = 0 for user-defined operations