### PR TITLE
neat_read: init *actualAmt to zero

### DIFF
--- a/neat_core.c
+++ b/neat_core.c
@@ -4835,6 +4835,7 @@ neat_read(struct neat_ctx *ctx, struct neat_flow *flow,
 {
     neat_log(NEAT_LOG_DEBUG, "%s", __func__);
 
+    *actualAmt = 0;
     neat_error_code rv = flow->readfx(ctx, flow, buffer, amt, actualAmt, optional, opt_count);
     if (rv != NEAT_OK) {
         return rv;


### PR DESCRIPTION
... for error cases primarily.

As previously mentioned in #247