### PR TITLE
neat_flow: remove unused 'buffer_count' from struct

### DIFF
--- a/neat_core.c
+++ b/neat_core.c
@@ -5536,7 +5536,6 @@ neat_flow
     rv->close2fx            = neat_close_socket_2;
     rv->listenfx            = NULL; // TODO: Consider reimplementing
     rv->shutdownfx          = neat_shutdown_via_kernel;
-    rv->buffer_count        = 0;
 #if defined(USRSCTP_SUPPORT)
     rv->acceptusrsctpfx     = neat_accept_via_usrsctp;
 #endif

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -244,7 +244,6 @@ struct neat_flow
     const char *local_address; // Src address or addresses
 
     struct neat_message_queue_head bufferedMessages;
-    size_t buffer_count;
     struct neat_flow_statistics flow_stats;
 
     // The memory buffer for reading. Used of SCTP reassembly.


### PR DESCRIPTION
Fixes #259