### PR TITLE
neat_log: add a neat_ctx argument to logging API

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -464,14 +464,6 @@ main(int argc, char *argv[])
         }
     }
 
-    if (config_log_level == 0) {
-        neat_log_level(NEAT_LOG_ERROR);
-    } else if (config_log_level == 1){
-        neat_log_level(NEAT_LOG_WARNING);
-    } else {
-        neat_log_level(NEAT_LOG_DEBUG);
-    }
-
     if (optind + 2 != argc) {
         fprintf(stderr, "%s - error: option - argument error\n", __func__);
         print_usage();
@@ -512,6 +504,14 @@ main(int argc, char *argv[])
         fprintf(stderr, "%s - error: neat_set_property\n", __func__);
         result = EXIT_FAILURE;
         goto cleanup;
+    }
+
+    if (config_log_level == 0) {
+        neat_log_level(ctx, NEAT_LOG_ERROR);
+    } else if (config_log_level == 1){
+        neat_log_level(ctx, NEAT_LOG_WARNING);
+    } else {
+        neat_log_level(ctx, NEAT_LOG_DEBUG);
     }
 
     // set callbacks

--- a/examples/client_http_get.c
+++ b/examples/client_http_get.c
@@ -148,8 +148,6 @@ main(int argc, char *argv[])
     char *arg_property = NULL;
     result = EXIT_SUCCESS;
 
-    neat_log_level(NEAT_LOG_DEBUG);
-
     memset(&ops, 0, sizeof(ops));
     memset(flows, 0, sizeof(flows));
 
@@ -191,14 +189,6 @@ main(int argc, char *argv[])
         }
     }
 
-    if (config_log_level == 0) {
-        neat_log_level(NEAT_LOG_ERROR);
-    } else if (config_log_level == 1){
-        neat_log_level(NEAT_LOG_WARNING);
-    } else {
-        neat_log_level(NEAT_LOG_DEBUG);
-    }
-
     if (optind + 1 != argc) {
         fprintf(stderr, "usage: client_http_get [OPTIONS] HOST\n");
         goto cleanup;
@@ -210,6 +200,16 @@ main(int argc, char *argv[])
         fprintf(stderr, "could not initialize context\n");
         result = EXIT_FAILURE;
         goto cleanup;
+    }
+
+    neat_log_level(ctx, NEAT_LOG_DEBUG);
+
+    if (config_log_level == 0) {
+        neat_log_level(ctx, NEAT_LOG_ERROR);
+    } else if (config_log_level == 1){
+        neat_log_level(ctx, NEAT_LOG_WARNING);
+    } else {
+        neat_log_level(ctx, NEAT_LOG_DEBUG);
     }
 
     for (i = 0; i < num_flows; i++) {

--- a/examples/server_chargen.c
+++ b/examples/server_chargen.c
@@ -220,14 +220,6 @@ main(int argc, char *argv[])
         }
     }
 
-    if (config_log_level == 0) {
-        neat_log_level(NEAT_LOG_ERROR);
-    } else if (config_log_level == 1){
-        neat_log_level(NEAT_LOG_WARNING);
-    } else {
-        neat_log_level(NEAT_LOG_DEBUG);
-    }
-
     if (optind != argc) {
         fprintf(stderr, "%s - argument error\n", __func__);
         print_usage();
@@ -238,6 +230,14 @@ main(int argc, char *argv[])
         fprintf(stderr, "%s - neat_init_ctx failed\n", __func__);
         result = EXIT_FAILURE;
         goto cleanup;
+    }
+
+    if (config_log_level == 0) {
+        neat_log_level(ctx, NEAT_LOG_ERROR);
+    } else if (config_log_level == 1){
+        neat_log_level(ctx, NEAT_LOG_WARNING);
+    } else {
+        neat_log_level(ctx, NEAT_LOG_DEBUG);
     }
 
     // new neat flow

--- a/examples/server_daytime.c
+++ b/examples/server_daytime.c
@@ -226,15 +226,6 @@ main(int argc, char *argv[])
         }
     }
 
-    if (config_log_level == 0) {
-        neat_log_level(NEAT_LOG_ERROR);
-    } else if (config_log_level == 1){
-        neat_log_level(NEAT_LOG_WARNING);
-    } else {
-        neat_log_level(NEAT_LOG_DEBUG);
-    }
-
-
     if (optind != argc) {
         fprintf(stderr, "%s - argument error\n", __func__);
         print_usage();
@@ -245,6 +236,14 @@ main(int argc, char *argv[])
         fprintf(stderr, "%s - neat_init_ctx failed\n", __func__);
         result = EXIT_FAILURE;
         goto cleanup;
+    }
+
+    if (config_log_level == 0) {
+        neat_log_level(ctx, NEAT_LOG_ERROR);
+    } else if (config_log_level == 1){
+        neat_log_level(ctx, NEAT_LOG_WARNING);
+    } else {
+        neat_log_level(ctx, NEAT_LOG_DEBUG);
     }
 
     // new neat flow

--- a/examples/server_discard.c
+++ b/examples/server_discard.c
@@ -176,14 +176,6 @@ main(int argc, char *argv[])
         }
     }
 
-    if (config_log_level == 0) {
-        neat_log_level(NEAT_LOG_ERROR);
-    } else if (config_log_level == 1){
-        neat_log_level(NEAT_LOG_WARNING);
-    } else {
-        neat_log_level(NEAT_LOG_DEBUG);
-    }
-
     if (optind != argc) {
         fprintf(stderr, "%s - argument error\n", __func__);
         print_usage();
@@ -200,6 +192,14 @@ main(int argc, char *argv[])
         fprintf(stderr, "%s - neat_init_ctx failed\n", __func__);
         result = EXIT_FAILURE;
         goto cleanup;
+    }
+
+    if (config_log_level == 0) {
+        neat_log_level(ctx, NEAT_LOG_ERROR);
+    } else if (config_log_level == 1){
+        neat_log_level(ctx, NEAT_LOG_WARNING);
+    } else {
+        neat_log_level(ctx, NEAT_LOG_DEBUG);
     }
 
     // new neat flow

--- a/examples/server_echo.c
+++ b/examples/server_echo.c
@@ -274,14 +274,6 @@ main(int argc, char *argv[])
         }
     }
 
-    if (config_log_level == 0) {
-        neat_log_level(NEAT_LOG_ERROR);
-    } else if (config_log_level == 1){
-        neat_log_level(NEAT_LOG_WARNING);
-    } else {
-        neat_log_level(NEAT_LOG_DEBUG);
-    }
-
     if (optind != argc) {
         fprintf(stderr, "%s - argument error\n", __func__);
         print_usage();
@@ -292,6 +284,14 @@ main(int argc, char *argv[])
         fprintf(stderr, "%s - neat_init_ctx failed\n", __func__);
         result = EXIT_FAILURE;
         goto cleanup;
+    }
+
+    if (config_log_level == 0) {
+        neat_log_level(ctx, NEAT_LOG_ERROR);
+    } else if (config_log_level == 1){
+        neat_log_level(ctx, NEAT_LOG_WARNING);
+    } else {
+        neat_log_level(ctx, NEAT_LOG_DEBUG);
     }
 
     // new neat flow

--- a/examples/server_http.c
+++ b/examples/server_http.c
@@ -223,14 +223,6 @@ main(int argc, char *argv[])
         }
     }
 
-    if (config_log_level == 0) {
-        neat_log_level(NEAT_LOG_ERROR);
-    } else if (config_log_level == 1){
-        neat_log_level(NEAT_LOG_WARNING);
-    } else {
-        neat_log_level(NEAT_LOG_DEBUG);
-    }
-
     if (optind != argc) {
         fprintf(stderr, "%s - argument error\n", __func__);
         print_usage();
@@ -241,6 +233,14 @@ main(int argc, char *argv[])
         fprintf(stderr, "%s - neat_init_ctx failed\n", __func__);
         result = EXIT_FAILURE;
         goto cleanup;
+    }
+
+    if (config_log_level == 0) {
+        neat_log_level(ctx, NEAT_LOG_ERROR);
+    } else if (config_log_level == 1){
+        neat_log_level(ctx, NEAT_LOG_WARNING);
+    } else {
+        neat_log_level(ctx, NEAT_LOG_DEBUG);
     }
 
     // new neat flow

--- a/examples/tneat.c
+++ b/examples/tneat.c
@@ -465,16 +465,6 @@ main(int argc, char *argv[])
         }
     }
 
-    if (config_log_level == 0) {
-        neat_log_level(NEAT_LOG_ERROR);
-    } else if (config_log_level == 1){
-        neat_log_level(NEAT_LOG_WARNING);
-    } else if (config_log_level == 2){
-        neat_log_level(NEAT_LOG_INFO);
-    }else {
-        neat_log_level(NEAT_LOG_DEBUG);
-    }
-
     if (optind == argc) {
         config_active = 0;
         if (config_log_level >= 1) {
@@ -495,6 +485,14 @@ main(int argc, char *argv[])
         fprintf(stderr, "%s - neat_init_ctx failed\n", __func__);
         result = EXIT_FAILURE;
         goto cleanup;
+    }
+
+    if (config_log_level == 0) {
+        neat_log_level(ctx, NEAT_LOG_ERROR);
+    } else if (config_log_level == 1){
+        neat_log_level(ctx, NEAT_LOG_WARNING);
+    } else {
+        neat_log_level(ctx, NEAT_LOG_DEBUG);
     }
 
     if (config_active) {

--- a/neat.h
+++ b/neat.h
@@ -33,8 +33,8 @@ NEAT_EXTERN void neat_stop_event_loop(struct neat_ctx *nc);
 NEAT_EXTERN int neat_get_backend_fd(struct neat_ctx *nc);
 NEAT_EXTERN int neat_get_backend_timeout(struct neat_ctx *nc);
 NEAT_EXTERN void neat_free_ctx(struct neat_ctx *nc);
-NEAT_EXTERN void neat_log_level(uint8_t level);
-NEAT_EXTERN uint8_t neat_log_file(const char* file_name);
+NEAT_EXTERN void neat_log_level(struct neat_ctx *ctx, uint8_t level);
+NEAT_EXTERN uint8_t neat_log_file(struct neat_ctx *ctx, const char* file_name);
 
 struct neat_flow_operations;
 typedef neat_error_code (*neat_flow_operations_fx)(struct neat_flow_operations *);

--- a/neat_addr.c
+++ b/neat_addr.c
@@ -19,7 +19,7 @@ static void neat_addr_print_src_addrs(struct neat_ctx *nc)
     struct pvd_info* pvd_info;
     struct pvd_result* pvd_result;
 
-    neat_log(NEAT_LOG_INFO, "Available src-addresses:");
+    neat_log(nc, NEAT_LOG_INFO, "Available src-addresses:");
     for (nsrc_addr = nc->src_addrs.lh_first; nsrc_addr != NULL;
             nsrc_addr = nsrc_addr->next_addr.le_next) {
 
@@ -27,12 +27,12 @@ static void neat_addr_print_src_addrs(struct neat_ctx *nc)
             src_addr4 = &(nsrc_addr->u.v4.addr4);
             inet_ntop(AF_INET, &(src_addr4->sin_addr), addr_str,
                     INET_ADDRSTRLEN);
-            neat_log(NEAT_LOG_INFO, "\tIPv4: %s/%u", addr_str, nsrc_addr->prefix_length);
+            neat_log(nc, NEAT_LOG_INFO, "\tIPv4: %s/%u", addr_str, nsrc_addr->prefix_length);
         } else {
             src_addr6 = &(nsrc_addr->u.v6.addr6);
             inet_ntop(AF_INET6, &(src_addr6->sin6_addr), addr_str,
                     INET6_ADDRSTRLEN);
-            neat_log(NEAT_LOG_INFO, "\tIPv6: %s/%u pref %u valid %u", addr_str,
+            neat_log(nc, NEAT_LOG_INFO, "\tIPv6: %s/%u pref %u valid %u", addr_str,
                     nsrc_addr->prefix_length, nsrc_addr->u.v6.ifa_pref,
                     nsrc_addr->u.v6.ifa_valid);
         }
@@ -45,9 +45,9 @@ static void neat_addr_print_src_addrs(struct neat_ctx *nc)
                 continue;
             }
             LIST_FOREACH(pvd, &(pvd_result->pvds), next_pvd) {
-                neat_log(NEAT_LOG_INFO, "\t\tPVD:");
+                neat_log(nc, NEAT_LOG_INFO, "\t\tPVD:");
                 LIST_FOREACH(pvd_info, &(pvd->infos), next_info) {
-                    neat_log(NEAT_LOG_INFO, "\t\t\t%s => %s", pvd_info->key, pvd_info->value);
+                    neat_log(nc, NEAT_LOG_INFO, "\t\t\t%s => %s", pvd_info->key, pvd_info->value);
                 }
             }
         }
@@ -128,7 +128,7 @@ neat_error_code neat_addr_update_src_list(struct neat_ctx *nc,
     nsrc_addr = (struct neat_addr*) calloc(sizeof(struct neat_addr), 1);
 
     if (nsrc_addr == NULL) {
-        neat_log(NEAT_LOG_ERROR, "%s: Could not allocate memory for %s", __func__, addr_str);
+        neat_log(nc, NEAT_LOG_ERROR, "%s: Could not allocate memory for %s", __func__, addr_str);
         //TODO: Trigger a refresh of available addresses
         return NEAT_ERROR_OUT_OF_MEMORY;
     }

--- a/neat_core.c
+++ b/neat_core.c
@@ -60,7 +60,7 @@ static neat_error_code neat_write_flush(struct neat_ctx *ctx, struct neat_flow *
 static int neat_listen_via_kernel(struct neat_ctx *ctx, struct neat_flow *flow,
                                   struct neat_pollable_socket *listen_socket);
 static int neat_close_via_kernel(struct neat_ctx *ctx, struct neat_flow *flow);
-static int neat_close_via_kernel_2(int fd);
+static int neat_close_via_kernel_2(struct neat_ctx *ctx, int fd);
 #if defined(USRSCTP_SUPPORT)
 static int neat_connect_via_usrsctp(struct neat_he_candidate *candidate);
 static int neat_listen_via_usrsctp(struct neat_ctx *ctx, struct neat_flow *flow,
@@ -118,23 +118,6 @@ neat_init_ctx()
 {
     struct neat_ctx *nc;
     struct neat_ctx *ctx = NULL;
-    neat_log_init();
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
-
-    // TODO: Disable these checks for non-debug builds
-    if (sizeof(neat_tag_name) / sizeof(neat_tag_name[0]) != NEAT_TAG_LAST) {
-        neat_log(NEAT_LOG_DEBUG,
-                 "Warning: Expected %d tag names, but found %d tag names",
-                 NEAT_TAG_LAST,
-                 sizeof(neat_tag_name) / sizeof(*neat_tag_name));
-    }
-
-    for (int i = 0; i < NEAT_TAG_LAST; ++i) {
-        if (neat_tag_name[i] == NULL) {
-            neat_log(NEAT_LOG_DEBUG, "Warning: Missing one or more tag names (index %d)", i);
-            break;
-        }
-    }
 
     nc = calloc(sizeof(struct neat_ctx), 1);
 
@@ -150,6 +133,25 @@ neat_init_ctx()
     }
 
     nc->error = NEAT_OK;
+    nc->log_level = NEAT_LOG_DEBUG;
+
+    neat_log_init(nc);
+    neat_log(nc, NEAT_LOG_DEBUG, "%s", __func__);
+
+    // TODO: Disable these checks for non-debug builds
+    if (sizeof(neat_tag_name) / sizeof(neat_tag_name[0]) != NEAT_TAG_LAST) {
+        neat_log(nc, NEAT_LOG_DEBUG,
+                 "Warning: Expected %d tag names, but found %d tag names",
+                 NEAT_TAG_LAST,
+                 sizeof(neat_tag_name) / sizeof(*neat_tag_name));
+    }
+
+    for (int i = 0; i < NEAT_TAG_LAST; ++i) {
+        if (neat_tag_name[i] == NULL) {
+            neat_log(nc, NEAT_LOG_DEBUG, "Warning: Missing one or more tag names (index %d)", i);
+            break;
+        }
+    }
 
     uv_loop_init(nc->loop);
     LIST_INIT(&(nc->src_addrs));
@@ -185,7 +187,7 @@ neat_error_code
 neat_start_event_loop(struct neat_ctx *nc, neat_run_mode run_mode)
 {
     if (run_mode == NEAT_RUN_DEFAULT)
-        neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+        neat_log(nc, NEAT_LOG_DEBUG, "%s", __func__);
 
     uv_run(nc->loop, (uv_run_mode) run_mode);
     uv_loop_close(nc->loop);
@@ -194,14 +196,14 @@ neat_start_event_loop(struct neat_ctx *nc, neat_run_mode run_mode)
 
 void neat_stop_event_loop(struct neat_ctx *nc)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(nc, NEAT_LOG_DEBUG, "%s", __func__);
 
     uv_stop(nc->loop);
 }
 
 int neat_get_backend_fd(struct neat_ctx *nc)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(nc, NEAT_LOG_DEBUG, "%s", __func__);
 
     return uv_backend_fd(nc->loop);
 }
@@ -223,19 +225,19 @@ neat_ctx_fail_on_error(struct neat_ctx *nc, neat_error_code error)
 int
 neat_get_backend_timeout(struct neat_ctx *nc)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(nc, NEAT_LOG_DEBUG, "%s", __func__);
 
     return uv_backend_timeout(nc->loop);
 }
 
-static void neat_walk_cb(uv_handle_t *handle, void *arg)
+static void neat_walk_cb(uv_handle_t *handle, void *ctx)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     //HACK: Can't stop the IDLE handle used by resolver. Should probably do
     //something more advanced in case we use other idle handles
     if (handle->type == UV_IDLE) {
-        neat_log(NEAT_LOG_DEBUG, "%s - handle->type == UV_IDLE - skipping", __func__);
+        neat_log(ctx, NEAT_LOG_DEBUG, "%s - handle->type == UV_IDLE - skipping", __func__);
         return;
     }
 
@@ -246,14 +248,14 @@ static void neat_walk_cb(uv_handle_t *handle, void *arg)
         // any handles. In other words, you have a memory leak.
         assert(handle->data);
 
-        neat_log(NEAT_LOG_DEBUG, "%s - closing handle", __func__);
+        neat_log(ctx, NEAT_LOG_DEBUG, "%s - closing handle", __func__);
         uv_close(handle, NULL);
     }
 }
 
 static void neat_close_loop(struct neat_ctx *nc)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(nc, NEAT_LOG_DEBUG, "%s", __func__);
 
     // Some handles may be closed inside uv_close callbacks.
     // Give those callbacks an opportunity to run first before executing uv_walk.
@@ -268,7 +270,7 @@ static void neat_close_loop(struct neat_ctx *nc)
 
 static void neat_core_cleanup(struct neat_ctx *nc)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(nc, NEAT_LOG_DEBUG, "%s", __func__);
 
     //We need to gracefully clean-up loop resources
     neat_close_loop(nc);
@@ -284,7 +286,7 @@ static void neat_core_cleanup(struct neat_ctx *nc)
 void neat_free_ctx(struct neat_ctx *nc)
 {
     struct neat_flow *flow, *prev_flow = NULL;
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(nc, NEAT_LOG_DEBUG, "%s", __func__);
 
     if (nc->resolver) {
         neat_resolver_release(nc->resolver);
@@ -319,8 +321,8 @@ void neat_free_ctx(struct neat_ctx *nc)
     free(nc->loop);
 
     neat_security_close(nc);
+    neat_log_close(nc);
     free(nc);
-    neat_log_close();
 }
 
 //The three functions that deal with the NEAT callback API. Nothing very
@@ -331,7 +333,7 @@ uint8_t neat_add_event_cb(struct neat_ctx *nc, uint8_t event_type,
     uint8_t i = 0;
     struct neat_event_cbs *cb_list_head;
     struct neat_event_cb *cb_itr;
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(nc, NEAT_LOG_DEBUG, "%s", __func__);
 
     if (event_type > NEAT_MAX_EVENT)
         return RETVAL_FAILURE;
@@ -356,13 +358,13 @@ uint8_t neat_add_event_cb(struct neat_ctx *nc, uint8_t event_type,
 
         if (cb_itr == cb) {
             //TODO: Debug level
-            neat_log(NEAT_LOG_INFO, "%s - Callback for %u has already been added", __func__, event_type);
+            neat_log(nc, NEAT_LOG_INFO, "%s - Callback for %u has already been added", __func__, event_type);
             return RETVAL_FAILURE;
         }
     }
 
     //TODO: Debug level
-    neat_log(NEAT_LOG_INFO, "%s - Added new callback for event type %u", __func__, event_type);
+    neat_log(nc, NEAT_LOG_INFO, "%s - Added new callback for event type %u", __func__, event_type);
     LIST_INSERT_HEAD(cb_list_head, cb, next_cb);
     return RETVAL_SUCCESS;
 }
@@ -372,7 +374,7 @@ uint8_t neat_remove_event_cb(struct neat_ctx *nc, uint8_t event_type,
 {
     struct neat_event_cbs *cb_list_head = NULL;
     struct neat_event_cb *cb_itr = NULL;
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(nc, NEAT_LOG_DEBUG, "%s", __func__);
 
     if (event_type > NEAT_MAX_EVENT || !nc->event_cbs)
         return RETVAL_FAILURE;
@@ -387,7 +389,7 @@ uint8_t neat_remove_event_cb(struct neat_ctx *nc, uint8_t event_type,
 
     if (cb_itr) {
         //TODO: Debug level print
-        neat_log(NEAT_LOG_INFO, "%s - Removed callback for type %u", __func__, event_type);
+        neat_log(nc, NEAT_LOG_INFO, "%s - Removed callback for type %u", __func__, event_type);
         LIST_REMOVE(cb_itr, next_cb);
     }
 
@@ -399,7 +401,7 @@ void neat_run_event_cb(struct neat_ctx *nc, uint8_t event_type,
 {
     struct neat_event_cbs *cb_list_head = NULL;
     struct neat_event_cb *cb_itr = NULL;
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(nc, NEAT_LOG_DEBUG, "%s", __func__);
 
     if (event_type > NEAT_MAX_EVENT ||
         !nc->event_cbs)
@@ -435,18 +437,18 @@ static void free_iofilters(struct neat_iofilter *filter)
     free (filter);
 }
 
-void
+static void
 on_handle_closed(uv_handle_t *handle)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    //neat_log(NEAT_LOG_DEBUG, "%s", __func__);
 
     free(handle);
 }
 
 void
-neat_free_candidate(struct neat_he_candidate *candidate)
+neat_free_candidate(struct neat_ctx *ctx, struct neat_he_candidate *candidate)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     if (candidate == NULL) {
         return;
@@ -464,16 +466,16 @@ neat_free_candidate(struct neat_he_candidate *candidate)
     // this handle is not being used by the flow.
     if (candidate->pollable_socket->handle != NULL) {
         if (candidate->pollable_socket->handle == candidate->pollable_socket->flow->socket->handle) {
-            neat_log(NEAT_LOG_DEBUG,"%s: Handle used by flow, flow should release it", __func__);
+            neat_log(ctx, NEAT_LOG_DEBUG,"%s: Handle used by flow, flow should release it", __func__);
         } else {
             if (candidate->pollable_socket->fd == -1) {
-                neat_log(NEAT_LOG_DEBUG,"%s: Candidate does not use a socket", __func__);
+                neat_log(ctx, NEAT_LOG_DEBUG,"%s: Candidate does not use a socket", __func__);
                 free(candidate->pollable_socket->handle);
             } else if (!uv_is_closing((uv_handle_t*)candidate->pollable_socket->handle)) {
-                neat_log(NEAT_LOG_DEBUG,"%s: Release candidate after closing", __func__);
+                neat_log(ctx, NEAT_LOG_DEBUG,"%s: Release candidate after closing", __func__);
                 uv_close((uv_handle_t*)candidate->pollable_socket->handle, on_handle_closed);
             } else {
-                neat_log(NEAT_LOG_DEBUG,"%s: Candidate handle is already closing", __func__);
+                neat_log(ctx, NEAT_LOG_DEBUG,"%s: Candidate handle is already closing", __func__);
             }
         }
     }
@@ -486,17 +488,17 @@ neat_free_candidate(struct neat_he_candidate *candidate)
 }
 
 void
-neat_free_candidates(struct neat_he_candidates *candidates)
+neat_free_candidates(struct neat_ctx *ctx, struct neat_he_candidates *candidates)
 {
     struct neat_he_candidate *candidate, *tmp;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     if (candidates == NULL)
         return;
 
     TAILQ_FOREACH_SAFE(candidate, candidates, next, tmp) {
-        neat_free_candidate(candidate);
+        neat_free_candidate(ctx, candidate);
     }
 
     free(candidates);
@@ -505,7 +507,7 @@ neat_free_candidates(struct neat_he_candidates *candidates)
 static void
 synchronous_free(neat_flow *flow)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(flow->ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     assert(flow);
 
@@ -523,10 +525,10 @@ synchronous_free(neat_flow *flow)
         free((char*)flow->cc_algorithm);
     }
     if (flow->resolver_results) {
-        neat_log(NEAT_LOG_DEBUG, "%s - neat_resolver_free_results", __func__);
+        neat_log(flow->ctx, NEAT_LOG_DEBUG, "%s - neat_resolver_free_results", __func__);
         neat_resolver_free_results(flow->resolver_results);
     } else {
-       neat_log(NEAT_LOG_DEBUG, "%s - NOT neat_resolver_free_results", __func__);
+        neat_log(flow->ctx, NEAT_LOG_DEBUG, "%s - NOT neat_resolver_free_results", __func__);
     }
     if (flow->ownedByCore) {
         free(flow->operations);
@@ -553,14 +555,13 @@ synchronous_free(neat_flow *flow)
 static void
 free_cb(uv_handle_t *handle)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
-
     struct neat_pollable_socket *pollable_socket = handle->data;
 #ifdef SCTP_MULTISTREAMING
     struct neat_flow *flow = NULL;
     struct neat_flow *prev_flow = NULL;
 #endif
-
+    struct neat_ctx *ctx = pollable_socket->flow->ctx;
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     if (pollable_socket->multistream) {
 #ifdef SCTP_MULTISTREAMING
@@ -582,7 +583,7 @@ free_cb(uv_handle_t *handle)
 
         assert(pollable_socket->sctp_streams_used == 0);
 
-        neat_log(NEAT_LOG_DEBUG, "%s - all multistreams closed - freeing socket", __func__);
+        neat_log(ctx, NEAT_LOG_DEBUG, "%s - all multistreams closed - freeing socket", __func__);
         free(pollable_socket->handle);
         free(pollable_socket);
 #else
@@ -599,7 +600,7 @@ static int neat_close_socket(struct neat_ctx *ctx, struct neat_flow *flow)
 {
     struct neat_pollable_socket *s;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
 
 #if defined(USRSCTP_SUPPORT)
@@ -610,24 +611,18 @@ static int neat_close_socket(struct neat_ctx *ctx, struct neat_flow *flow)
 #endif
 
     TAILQ_FOREACH(s, &(flow->listen_sockets), next) {
-        neat_close_via_kernel_2(s->fd);
+        neat_close_via_kernel_2(ctx, s->fd);
     }
 
     neat_close_via_kernel(flow->ctx, flow);
     return 0;
 }
 
-static int neat_close_socket_2(int fd)
-{
-    /* TODO: Needs fix to work with usrsctp? */
-    neat_close_via_kernel_2(fd);
-    return 0;
-}
-
 void
 neat_free_flow(neat_flow *flow)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    struct neat_ctx *ctx = flow->ctx;
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     LIST_REMOVE(flow, next_flow);
 
@@ -639,7 +634,7 @@ neat_free_flow(neat_flow *flow)
     }
 #endif
 
-    neat_free_candidates(flow->candidate_list);
+    neat_free_candidates(ctx, flow->candidate_list);
 
 
     if (flow->socket->handle != NULL
@@ -649,10 +644,10 @@ neat_free_flow(neat_flow *flow)
 #endif
     ) {
         if (!uv_is_closing((uv_handle_t *)flow->socket->handle)) {
-            neat_log(NEAT_LOG_DEBUG, "%s - closing handle and waiting for free_cb", __func__);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s - closing handle and waiting for free_cb", __func__);
             uv_close((uv_handle_t *)(flow->socket->handle), free_cb);
         } else {
-            neat_log(NEAT_LOG_DEBUG, "%s - handle is already closing", __func__);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s - handle is already closing", __func__);
         }
     } else {
         synchronous_free(flow);
@@ -660,19 +655,19 @@ neat_free_flow(neat_flow *flow)
 }
 
 neat_error_code
-neat_set_property(neat_ctx *mgr, neat_flow *flow, const char *properties)
+neat_set_property(neat_ctx *ctx, neat_flow *flow, const char *properties)
 {
     json_t *prop, *props;
     json_error_t error;
     const char *key;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     props = json_loads(properties, 0, &error);
     if (props == NULL) {
-        neat_log(NEAT_LOG_DEBUG, "Error in property string, line %d col %d",
+        neat_log(ctx, NEAT_LOG_DEBUG, "Error in property string, line %d col %d",
                  error.line, error.position);
-        neat_log(NEAT_LOG_DEBUG, "%s", error.text);
+        neat_log(ctx, NEAT_LOG_DEBUG, "%s", error.text);
 
         return NEAT_ERROR_BAD_ARGUMENT;
     }
@@ -681,7 +676,7 @@ neat_set_property(neat_ctx *mgr, neat_flow *flow, const char *properties)
 
         // This step is not strictly required, but informs of overwritten keys
         if (json_object_del(flow->properties, key) == 0) {
-            neat_log(NEAT_LOG_DEBUG, "Existing property %s was overwritten!", key);
+            neat_log(ctx, NEAT_LOG_DEBUG, "Existing property %s was overwritten!", key);
         }
 
         json_object_set(flow->properties, key, prop);
@@ -702,23 +697,23 @@ neat_error_code
 neat_get_property(neat_ctx *ctx, neat_flow *flow, const char* name, void *ptr, size_t *size)
 {
     json_t *prop;
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     if (flow->properties == NULL) {
-        neat_log(NEAT_LOG_DEBUG, "Flow has no properties (properties == NULL)");
+        neat_log(ctx, NEAT_LOG_DEBUG, "Flow has no properties (properties == NULL)");
         return NEAT_ERROR_UNABLE;
     }
 
     prop = json_object_get(flow->properties, name);
 
     if (prop == NULL) {
-        neat_log(NEAT_LOG_DEBUG, "Flow has no property named %s");
+        neat_log(ctx, NEAT_LOG_DEBUG, "Flow has no property named %s");
         return NEAT_ERROR_UNABLE;
     }
 
     prop = json_object_get(prop, "value");
     if (prop == NULL) {
-        neat_log(NEAT_LOG_DEBUG, "Flow has property %s, but it contains no \"value\" key!");
+        neat_log(ctx, NEAT_LOG_DEBUG, "Flow has property %s, but it contains no \"value\" key!");
         return NEAT_ERROR_UNABLE;
     }
 
@@ -775,10 +770,10 @@ int neat_get_stack(neat_ctx* mgr, neat_flow* flow)
     return flow->socket->stack;
 }
 
-neat_error_code neat_set_operations(neat_ctx *mgr, neat_flow *flow,
+neat_error_code neat_set_operations(neat_ctx *ctx, neat_flow *flow,
                                     struct neat_flow_operations *ops)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     if( (flow->operations) && (flow->ownedByCore) ) {
        free(flow->operations);
@@ -797,18 +792,18 @@ neat_error_code neat_set_operations(neat_ctx *mgr, neat_flow *flow,
     }
 #endif
 
-    updatePollHandle(mgr, flow, flow->socket->handle);
+    updatePollHandle(ctx, flow, flow->socket->handle);
     return NEAT_OK;
 }
 
 /* Return statistics about the flow in JSON format
    NB - the memory allocated for the return string must be freed
    by the caller */
-neat_error_code neat_get_stats(neat_ctx *mgr, char **json_stats)
+neat_error_code neat_get_stats(neat_ctx *ctx, char **json_stats)
 {
-      neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+      neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
-      neat_stats_build_json(mgr, json_stats);
+      neat_stats_build_json(ctx, json_stats);
 
       return NEAT_OK;
 }
@@ -824,7 +819,7 @@ void
 neat_io_error(neat_ctx *ctx, neat_flow *flow, neat_error_code code)
 {
     const int stream_id = NEAT_INVALID_STREAM;
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     if (!flow->operations || !flow->operations->on_error) {
         return;
@@ -836,7 +831,7 @@ neat_io_error(neat_ctx *ctx, neat_flow *flow, neat_error_code code)
 static void io_connected(neat_ctx *ctx, neat_flow *flow,
                          neat_error_code code)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
     const int stream_id = NEAT_INVALID_STREAM;
 #if defined(IPPROTO_SCTP) && defined(SCTP_STATUS) && !defined(USRSCTP_SUPPORT)
     unsigned int optlen;
@@ -858,14 +853,14 @@ static void io_connected(neat_ctx *ctx, neat_flow *flow,
             optlen = sizeof(status);
             rc = getsockopt(flow->socket->fd, IPPROTO_SCTP, SCTP_STATUS, &status, &optlen);
             if (rc < 0) {
-                neat_log(NEAT_LOG_DEBUG, "Call to getsockopt(SCTP_STATUS) failed");
+                neat_log(ctx, NEAT_LOG_DEBUG, "Call to getsockopt(SCTP_STATUS) failed");
                 flow->socket->sctp_streams_available = 1;
             } else {
                 flow->socket->sctp_streams_available = MIN(status.sstat_outstrms, status.sstat_outstrms);
             }
 
             // number of outbound streams == number of inbound streams
-            neat_log(NEAT_LOG_INFO, "%s - SCTP - number of streams: %d", __func__, flow->socket->sctp_streams_available);
+            neat_log(ctx, NEAT_LOG_INFO, "%s - SCTP - number of streams: %d", __func__, flow->socket->sctp_streams_available);
 #endif // defined(IPPROTO_SCTP) && defined(SCTP_STATUS) && !defined(USRSCTP_SUPPORT)
             break;
         case NEAT_STACK_UDPLITE:
@@ -879,7 +874,7 @@ static void io_connected(neat_ctx *ctx, neat_flow *flow,
             break;
     }
 
-    neat_log(NEAT_LOG_INFO, "Connected: %s/%s", proto, (flow->socket->family == AF_INET ? "IPv4" : "IPv6"));
+    neat_log(ctx, NEAT_LOG_INFO, "Connected: %s/%s", proto, (flow->socket->family == AF_INET ? "IPv4" : "IPv6"));
 
     if (!flow->operations || !flow->operations->on_connected) {
         return;
@@ -891,7 +886,7 @@ static void io_connected(neat_ctx *ctx, neat_flow *flow,
 
 static void io_writable(neat_ctx *ctx, neat_flow *flow, int stream_id, neat_error_code code)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     if (flow->isDraining) {
         neat_write_flush(ctx, flow);
@@ -952,29 +947,30 @@ static void
 handle_sctp_assoc_change(neat_flow *flow, struct sctp_assoc_change *sac)
 {
     unsigned int i, n;
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    struct neat_ctx *ctx = flow->ctx;
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     switch (sac->sac_state) {
         case SCTP_SHUTDOWN_COMP:
-            neat_log(NEAT_LOG_DEBUG, "%s - state : SCTP_SHUTDOWN_COMP", __func__);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s - state : SCTP_SHUTDOWN_COMP", __func__);
             neat_notify_close(flow);
             break;
 
         case SCTP_COMM_LOST:
             // Draft specifies to return cause code, D1.2 doesn't - we
             // follow D1.2
-            neat_log(NEAT_LOG_DEBUG, "%s - state : SCTP_COMM_LOST", __func__);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s - state : SCTP_COMM_LOST", __func__);
             neat_notify_aborted(flow);
             //break;
 
             // Fallthrough:
         case SCTP_COMM_UP: // Fallthrough:
-            neat_log(NEAT_LOG_DEBUG, "%s - state : SCTP_COMM_UP", __func__);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s - state : SCTP_COMM_UP", __func__);
             // TODO: Allocate send buffers here instead?
             //break;
 
         case SCTP_RESTART:
-            neat_log(NEAT_LOG_DEBUG, "%s - state : SCTP_RESTART", __func__);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s - state : SCTP_RESTART", __func__);
             // TODO: might want to "translate" the state codes to a NEAT code.
             neat_notify_network_status_changed(flow, sac->sac_state);
             break;
@@ -983,40 +979,40 @@ handle_sctp_assoc_change(neat_flow *flow, struct sctp_assoc_change *sac)
     n = sac->sac_length - sizeof(struct sctp_assoc_change);
     if (((sac->sac_state == SCTP_COMM_UP) ||
         (sac->sac_state == SCTP_RESTART)) && (n > 0)) {
-        neat_log(NEAT_LOG_DEBUG, "%s - supported features", __func__);
+        neat_log(ctx, NEAT_LOG_DEBUG, "%s - supported features", __func__);
         for (i = 0; i < n; i++) {
             switch (sac->sac_info[i]) {
 #ifdef SCTP_ASSOC_SUPPORTS_PR
                 case SCTP_ASSOC_SUPPORTS_PR:
-                    neat_log(NEAT_LOG_DEBUG, "\t- PR");
+                    neat_log(ctx, NEAT_LOG_DEBUG, "\t- PR");
                     break;
 #endif // SCTP_ASSOC_SUPPORTS_PR
 
 #ifdef SCTP_ASSOC_SUPPORTS_AUTH
                 case SCTP_ASSOC_SUPPORTS_AUTH:
-                    neat_log(NEAT_LOG_DEBUG, "\t- AUTH");
+                    neat_log(ctx, NEAT_LOG_DEBUG, "\t- AUTH");
                     break;
 #endif // SCTP_ASSOC_SUPPORTS_AUTH
 
 #ifdef SCTP_ASSOC_SUPPORTS_ASCONF
                 case SCTP_ASSOC_SUPPORTS_ASCONF:
-                    neat_log(NEAT_LOG_DEBUG, "\t- ASCONF");
+                    neat_log(ctx, NEAT_LOG_DEBUG, "\t- ASCONF");
                     break;
 #endif // SCTP_ASSOC_SUPPORTS_ASCONF
 
 #ifdef SCTP_ASSOC_SUPPORTS_MULTIBUF
                 case SCTP_ASSOC_SUPPORTS_MULTIBUF:
-                    neat_log(NEAT_LOG_DEBUG, "\t- MULTIBUF");
+                    neat_log(ctx, NEAT_LOG_DEBUG, "\t- MULTIBUF");
                     break;
 #endif
 
 #ifdef SCTP_ASSOC_SUPPORTS_RE_CONFIG
                 case SCTP_ASSOC_SUPPORTS_RE_CONFIG:
-                    neat_log(NEAT_LOG_DEBUG, "\t- RE-CONFIG");
+                    neat_log(ctx, ctx, NEAT_LOG_DEBUG, "\t- RE-CONFIG");
                     break;
 #endif // SCTP_ASSOC_SUPPORTS_RE_CONFIG
                 default:
-                    neat_log(NEAT_LOG_DEBUG, "\t- UNKNOWN(0x%02x)", sac->sac_info[i]);
+                    neat_log(ctx, NEAT_LOG_DEBUG, "\t- UNKNOWN(0x%02x)", sac->sac_info[i]);
                     break;
             }
         }
@@ -1036,7 +1032,7 @@ static void handle_sctp_send_failed(neat_flow *flow, struct sctp_send_failed *ss
 {
     uint32_t error, context;
     uint8_t *unsent_msg;
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(flow->ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
 #ifdef HAVE_SCTP_SEND_FAILED_EVENT
     error = ssfe->ssfe_error;
@@ -1057,7 +1053,8 @@ static void handle_sctp_send_failed(neat_flow *flow, struct sctp_send_failed *ss
 // Handle notifications about SCTP events
 static int handle_sctp_event(neat_flow *flow, union sctp_notification *notfn)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    struct neat_ctx *ctx = flow->ctx;
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
 #ifdef SCTP_MULTISTREAMING
     flow->socket->sctp_notification_recvd = 1;
@@ -1078,17 +1075,17 @@ static int handle_sctp_event(neat_flow *flow, union sctp_notification *notfn)
             break;
 #endif // else HAVE_SCTP_SEND_FAILED_EVENT
         case SCTP_PEER_ADDR_CHANGE:
-            neat_log(NEAT_LOG_DEBUG, "Got SCTP peer address change event");
+            neat_log(ctx, NEAT_LOG_DEBUG, "Got SCTP peer address change event");
             break;
         case SCTP_REMOTE_ERROR:
-            neat_log(NEAT_LOG_DEBUG, "Got SCTP remote error event");
+            neat_log(ctx, NEAT_LOG_DEBUG, "Got SCTP remote error event");
             break;
         case SCTP_SHUTDOWN_EVENT:
-            neat_log(NEAT_LOG_DEBUG, "Got SCTP shutdown event");
+            neat_log(ctx, NEAT_LOG_DEBUG, "Got SCTP shutdown event");
             return READ_WITH_ZERO;
             break;
         case SCTP_ADAPTATION_INDICATION:
-            neat_log(NEAT_LOG_DEBUG, "Got SCTP adaptation indication event");
+            neat_log(ctx, NEAT_LOG_DEBUG, "Got SCTP adaptation indication event");
             struct sctp_adaptation_event *adaptation = (struct sctp_adaptation_event *) notfn;
             if (adaptation->sai_adaptation_ind == SCTP_ADAPTATION_NEAT) {
 #ifdef SCTP_MULTISTREAMING
@@ -1100,22 +1097,22 @@ static int handle_sctp_event(neat_flow *flow, union sctp_notification *notfn)
                 LIST_INSERT_HEAD(&flow->socket->sctp_multistream_flows, flow, multistream_next_flow);
                 //neat_hook_mulitstream_flows(flow);
 #endif // SCTP_MULTISTREAMING
-                neat_log(NEAT_LOG_INFO, "Peer is NEAT enabled");
+                neat_log(ctx, NEAT_LOG_INFO, "Peer is NEAT enabled");
             }
             break;
         case SCTP_PARTIAL_DELIVERY_EVENT:
-            neat_log(NEAT_LOG_DEBUG, "Got SCTP partial delivery event");
+            neat_log(ctx, NEAT_LOG_DEBUG, "Got SCTP partial delivery event");
             break;
 #ifdef SCTP_RESET_STREAMS
         case SCTP_STREAM_RESET_EVENT:
-            neat_log(NEAT_LOG_DEBUG, "Got SCTP Stream Reset");
+            neat_log(ctx, NEAT_LOG_DEBUG, "Got SCTP Stream Reset");
 #ifdef SCTP_MULTISTREAMING
             neat_sctp_handle_reset_stream(flow->socket, (struct sctp_stream_reset_event *) notfn);
 #endif // SCTP_MULTISTREAMING
 #endif // SCTP_RESET_STREAMS
             break;
         default:
-            neat_log(NEAT_LOG_WARNING, "Got unhandled SCTP event type %d", notfn->sn_header.sn_type);
+            neat_log(ctx, NEAT_LOG_WARNING, "Got unhandled SCTP event type %d", notfn->sn_header.sn_type);
     }
     return READ_OK;
 }
@@ -1195,10 +1192,10 @@ static int io_readable(neat_ctx *ctx, neat_flow *flow,
     socklen_t infolen = sizeof(struct sctp_recvv_rn);
 #endif // !defined(USRSCTP_SUPPORT)
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     if (!flow->operations) {
-        neat_log(NEAT_LOG_DEBUG, "%s - No operations", __func__);
+        neat_log(ctx, NEAT_LOG_DEBUG, "%s - No operations", __func__);
         return READ_WITH_ERROR;
     }
 
@@ -1209,25 +1206,25 @@ static int io_readable(neat_ctx *ctx, neat_flow *flow,
     if (!flow->operations->on_readable && flow->acceptPending) {
 
         if (socket->stack != NEAT_STACK_UDP && socket->stack != NEAT_STACK_UDPLITE) {
-            neat_log(NEAT_LOG_WARNING, "%s - READ_WITH_ERROR 1", __func__);
+            neat_log(ctx, NEAT_LOG_WARNING, "%s - READ_WITH_ERROR 1", __func__);
             return READ_WITH_ERROR;
         }
     }
 
     if ((socket->stack == NEAT_STACK_UDP || socket->stack == NEAT_STACK_UDPLITE) && (!flow->readBufferMsgComplete)) {
         if (resize_read_buffer(flow) != READ_OK) {
-            neat_log(NEAT_LOG_WARNING, "%s - READ_WITH_ERROR 2", __func__);
+            neat_log(ctx, NEAT_LOG_WARNING, "%s - READ_WITH_ERROR 2", __func__);
             return READ_WITH_ERROR;
         }
 
         if (socket->stack == NEAT_STACK_UDP || socket->stack == NEAT_STACK_UDPLITE) {
             if (!flow->acceptPending && !flow->operations->on_readable) {
-                neat_log(NEAT_LOG_WARNING, "%s - READ_WITH_ERROR 3", __func__);
+                neat_log(ctx, NEAT_LOG_WARNING, "%s - READ_WITH_ERROR 3", __func__);
                 return READ_WITH_ERROR;
             }
 
             if ((n = recvfrom(socket->fd, flow->readBuffer, flow->readBufferAllocation, 0, (struct sockaddr *)&peerAddr, &peerAddrLen)) < 0)  {
-                neat_log(NEAT_LOG_WARNING, "%s - READ_WITH_ERROR 4", __func__);
+                neat_log(ctx, NEAT_LOG_WARNING, "%s - READ_WITH_ERROR 4", __func__);
                 return READ_WITH_ERROR;
             }
 
@@ -1236,7 +1233,7 @@ static int io_readable(neat_ctx *ctx, neat_flow *flow,
 
             if (n == 0) {
                 flow->readBufferMsgComplete = 0;
-                neat_log(NEAT_LOG_WARNING, "%s - READ_WITH_ERROR 5", __func__);
+                neat_log(ctx, NEAT_LOG_WARNING, "%s - READ_WITH_ERROR 5", __func__);
                 return READ_WITH_ZERO;
             }
 
@@ -1246,7 +1243,7 @@ static int io_readable(neat_ctx *ctx, neat_flow *flow,
                 neat_flow *newFlow = neat_find_flow(ctx, &socket->src_sockaddr, &peerAddr);
 
                 if (!newFlow) {
-                    neat_log(NEAT_LOG_DEBUG, "%s - Creating new UDP flow", __func__);
+                    neat_log(ctx, NEAT_LOG_DEBUG, "%s - Creating new UDP flow", __func__);
 
                     memcpy(&socket->dst_sockaddr, &peerAddr, sizeof(struct sockaddr_storage));
                     newFlow = do_accept(ctx, flow, socket);
@@ -1255,7 +1252,7 @@ static int io_readable(neat_ctx *ctx, neat_flow *flow,
                 assert(newFlow);
 
                 if (resize_read_buffer(newFlow) != READ_OK) {
-                    neat_log(NEAT_LOG_WARNING, "%s - READ_WITH_ERROR 6", __func__);
+                    neat_log(ctx, NEAT_LOG_WARNING, "%s - READ_WITH_ERROR 6", __func__);
                     return READ_WITH_ERROR;
                 }
                 newFlow->readBufferSize = n;
@@ -1274,7 +1271,7 @@ static int io_readable(neat_ctx *ctx, neat_flow *flow,
     if ((neat_base_stack(socket->stack) == NEAT_STACK_SCTP) && ((!flow->readBufferMsgComplete) || socket->multistream)) {
 
         if (resize_read_buffer(flow) != READ_OK) {
-            neat_log(NEAT_LOG_WARNING, "%s - READ_WITH_ERROR 7", __func__);
+            neat_log(ctx, NEAT_LOG_WARNING, "%s - READ_WITH_ERROR 7", __func__);
             return READ_WITH_ERROR;
         }
 
@@ -1283,9 +1280,9 @@ static int io_readable(neat_ctx *ctx, neat_flow *flow,
 
 #ifdef SCTP_MULTISTREAMING
 
-            neat_log(NEAT_LOG_INFO, "%s - allocating %d bytes", __func__, socket->read_size);
+            neat_log(ctx, NEAT_LOG_INFO, "%s - allocating %d bytes", __func__, socket->read_size);
             if ((multistream_buffer = malloc(socket->read_size)) == NULL) {
-                neat_log(NEAT_LOG_ERROR, "%s - allocating multistream buffer failed", __func__);
+                neat_log(ctx, NEAT_LOG_ERROR, "%s - allocating multistream buffer failed", __func__);
                 return READ_WITH_ERROR;
             }
 
@@ -1297,7 +1294,7 @@ static int io_readable(neat_ctx *ctx, neat_flow *flow,
 
         } else {
             if (resize_read_buffer(flow) != READ_OK) {
-                neat_log(NEAT_LOG_WARNING, "%s - READ_WITH_ERROR 8", __func__);
+                neat_log(ctx, NEAT_LOG_WARNING, "%s - READ_WITH_ERROR 8", __func__);
                 return READ_WITH_ERROR;
             }
 
@@ -1331,41 +1328,41 @@ static int io_readable(neat_ctx *ctx, neat_flow *flow,
                 free(multistream_buffer);
             }
 #endif
-            neat_log(NEAT_LOG_WARNING, "%s - READ_WITH_ERROR 9 - %s", __func__, strerror(errno));
+            neat_log(ctx, NEAT_LOG_WARNING, "%s - READ_WITH_ERROR 9 - %s", __func__, strerror(errno));
             return READ_WITH_ERROR;
         }
 
 #if (defined(SCTP_RCVINFO) || defined (SCTP_SNDRCV))
         for (cmsg = CMSG_FIRSTHDR(&msghdr); cmsg != NULL; cmsg = CMSG_NXTHDR(&msghdr, cmsg)) {
             if (cmsg->cmsg_len == 0) {
-                neat_log(NEAT_LOG_DEBUG, "%s - Error in ancilliary data from recvmsg", __func__);
+                neat_log(ctx, NEAT_LOG_DEBUG, "%s - Error in ancilliary data from recvmsg", __func__);
                 break;
             }
 #ifdef IPPROTO_SCTP
             if (cmsg->cmsg_level == IPPROTO_SCTP) {
 #if defined (SCTP_RCVINFO)
                 if (cmsg->cmsg_type == SCTP_RCVINFO) {
-                    neat_log(NEAT_LOG_DEBUG, "%s - got SCTP_RCVINFO", __func__);
+                    neat_log(ctx, NEAT_LOG_DEBUG, "%s - got SCTP_RCVINFO", __func__);
                     rcvinfo = (struct sctp_rcvinfo *)CMSG_DATA(cmsg);
                     stream_id = rcvinfo->rcv_sid;
 
                 }
 #elif defined (SCTP_SNDRCV)
                 if (cmsg->cmsg_type == SCTP_SNDRCV) {
-                    neat_log(NEAT_LOG_DEBUG, "%s - got SCTP_SNDRCV", __func__);
+                    neat_log(ctx, NEAT_LOG_DEBUG, "%s - got SCTP_SNDRCV", __func__);
                     sndrcvinfo = (struct sctp_sndrcvinfo *)CMSG_DATA(cmsg);
                     stream_id = sndrcvinfo->sinfo_stream;
                 }
 #endif // defined (SCTP_SNDRCV)
 #if defined (SCTP_NXTINFO)
                 if (cmsg->cmsg_type == SCTP_NXTINFO) {
-                    neat_log(NEAT_LOG_DEBUG, "%s - got SCTP_NXTINFO", __func__);
+                    neat_log(ctx, NEAT_LOG_DEBUG, "%s - got SCTP_NXTINFO", __func__);
                     //sndrcvinfo = (struct sctp_sndrcvinfo *)CMSG_DATA(cmsg);
                     //stream_id = sndrcvinfo->sinfo_stream;
                 }
 #endif // defined (SCTP_NXTINFO)
                 if (stream_id >= 0) {
-                    neat_log(NEAT_LOG_DEBUG, "%s - Received %d bytes on SCTP stream %d", __func__, n, stream_id);
+                    neat_log(ctx, NEAT_LOG_DEBUG, "%s - Received %d bytes on SCTP stream %d", __func__, n, stream_id);
                 }
             }
 #endif // defined(IPPROTP_SCTP)
@@ -1393,7 +1390,7 @@ static int io_readable(neat_ctx *ctx, neat_flow *flow,
         if (n < 0) {
           /*  if (errno == EAGAIN)
                 return READ_OK;*/
-            neat_log(NEAT_LOG_WARNING, "%s - READ_WITH_ERROR 10 - usrsctp_recvv error", __func__);
+            neat_log(ctx, NEAT_LOG_WARNING, "%s - READ_WITH_ERROR 10 - usrsctp_recvv error", __func__);
             return READ_WITH_ERROR;
         }
 #endif // else !defined(USRSCTP_SUPPORT)
@@ -1401,12 +1398,12 @@ static int io_readable(neat_ctx *ctx, neat_flow *flow,
 #if defined(MSG_NOTIFICATION)
         if (msghdr.msg_flags & MSG_NOTIFICATION) {
             // Event notification
-            neat_log(NEAT_LOG_INFO, "SCTP event notification");
+            neat_log(ctx, NEAT_LOG_INFO, "SCTP event notification");
 
             if (!(msghdr.msg_flags & MSG_EOR)) {
-                neat_log(NEAT_LOG_WARNING, "buffer overrun reading SCTP notification");
+                neat_log(ctx, NEAT_LOG_WARNING, "buffer overrun reading SCTP notification");
                 // TODO: handle this properly
-                neat_log(NEAT_LOG_WARNING, "%s - READ_WITH_ERROR 11", __func__);
+                neat_log(ctx, NEAT_LOG_WARNING, "%s - READ_WITH_ERROR 11", __func__);
                 return READ_WITH_ERROR;
             }
 
@@ -1434,7 +1431,7 @@ static int io_readable(neat_ctx *ctx, neat_flow *flow,
 #ifdef SCTP_MULTISTREAMING
         if (socket->sctp_notification_wait) {
             socket->sctp_notification_wait = 0;
-            neat_log(NEAT_LOG_ERROR, "%s - got all SCTP notifications", __func__);
+            neat_log(ctx, NEAT_LOG_ERROR, "%s - got all SCTP notifications", __func__);
         }
 
         if (stream_id > 0 && socket->sctp_neat_peer) {
@@ -1483,7 +1480,7 @@ static int io_readable(neat_ctx *ctx, neat_flow *flow,
 
         if (socket->multistream) {
 #ifdef SCTP_MULTISTREAMING
-            neat_log(NEAT_LOG_DEBUG, "%s - got data for multistream flow %d", __func__, stream_id);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s - got data for multistream flow %d", __func__, stream_id);
 
             multistream_flow = neat_sctp_get_flow_by_sid(socket, stream_id);
             assert(multistream_flow);
@@ -1499,21 +1496,21 @@ static int io_readable(neat_ctx *ctx, neat_flow *flow,
 
             TAILQ_INSERT_TAIL(&flow->multistream_read_queue, multistream_message, message_next);
 #else // SCTP_MULTISTREAMING
-            neat_log(NEAT_LOG_ERROR, "%s - multistream set but not supported", __func__);
+            neat_log(ctx, NEAT_LOG_ERROR, "%s - multistream set but not supported", __func__);
             assert(false);
 #endif // SCTP_MULTISTREAMING
         } else {
 
             flow->readBufferSize += n;
 
-            neat_log(NEAT_LOG_INFO, " %zd bytes received", n);
+            neat_log(ctx, NEAT_LOG_INFO, " %zd bytes received", n);
 
             if ((msghdr.msg_flags & MSG_EOR) || (n == 0)) {
                 flow->readBufferMsgComplete = 1;
             }
 
             if (!flow->readBufferMsgComplete) {
-                neat_log(NEAT_LOG_WARNING, "%s - READ_WITH_ERROR 12", __func__);
+                neat_log(ctx, NEAT_LOG_WARNING, "%s - READ_WITH_ERROR 12", __func__);
                 return READ_WITH_ERROR;
             }
 #if defined(USRSCTP_SUPPORT)
@@ -1535,7 +1532,7 @@ static int io_readable(neat_ctx *ctx, neat_flow *flow,
 static void
 io_all_written(neat_ctx *ctx, neat_flow *flow, int stream_id)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
     stream_id = NEAT_INVALID_STREAM;
 
     if (!flow->operations || !flow->operations->on_all_written) {
@@ -1549,7 +1546,7 @@ io_all_written(neat_ctx *ctx, neat_flow *flow, int stream_id)
 static void
 io_timeout(neat_ctx *ctx, neat_flow *flow)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
     const int stream_id = NEAT_INVALID_STREAM;
 
     if (!flow->operations || !flow->operations->on_timeout) {
@@ -1569,12 +1566,12 @@ updatePollHandle(neat_ctx *ctx, neat_flow *flow, uv_poll_t *handle)
     struct neat_pollable_socket *pollable_socket = handle->data;
     int newEvents = 0;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
 #ifdef SCTP_MULTISTREAMING
     if (pollable_socket != NULL && pollable_socket->multistream) {
         flow = LIST_FIRST(&pollable_socket->sctp_multistream_flows);
-        neat_log(NEAT_LOG_DEBUG, "%s - multistreaming - taking first flow from ctx", __func__);
+        neat_log(ctx, NEAT_LOG_DEBUG, "%s - multistreaming - taking first flow from ctx", __func__);
     }
 #endif
 
@@ -1589,7 +1586,7 @@ updatePollHandle(neat_ctx *ctx, neat_flow *flow, uv_poll_t *handle)
     }
 
     do {
-        neat_log(NEAT_LOG_DEBUG, "%s - iterating flows ...", __func__);
+        neat_log(ctx, NEAT_LOG_DEBUG, "%s - iterating flows ...", __func__);
         assert(flow);
 
         flow->isPolling = 0;
@@ -1642,17 +1639,17 @@ updatePollHandle(neat_ctx *ctx, neat_flow *flow, uv_poll_t *handle)
 
 #ifdef SCTP_MULTISTREAMING
         flow = LIST_NEXT(flow, multistream_next_flow);
-        neat_log(NEAT_LOG_DEBUG, "%s - next multistream flow : %p", __func__, flow);
+        neat_log(ctx, NEAT_LOG_DEBUG, "%s - next multistream flow : %p", __func__, flow);
 #endif
 
     // iterate through all flows
     } while (pollable_socket != NULL && pollable_socket->multistream == 1 && flow != NULL);
 
     if (newEvents) {
-        neat_log(NEAT_LOG_DEBUG, "%s - events - starting poll - readable : %d - writable : %d", __func__, (newEvents & UV_READABLE), (newEvents & UV_WRITABLE));
+        neat_log(ctx, NEAT_LOG_DEBUG, "%s - events - starting poll - readable : %d - writable : %d", __func__, (newEvents & UV_READABLE), (newEvents & UV_WRITABLE));
         uv_poll_start(handle, newEvents, uvpollable_cb);
     } else {
-        neat_log(NEAT_LOG_DEBUG, "%s - no events - stopping poll", __func__);
+        neat_log(ctx, NEAT_LOG_DEBUG, "%s - no events - stopping poll", __func__);
         uv_poll_stop(handle);
     }
 }
@@ -1660,7 +1657,7 @@ updatePollHandle(neat_ctx *ctx, neat_flow *flow, uv_poll_t *handle)
 static void
 free_he_handle_cb(uv_handle_t *handle)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    //neat_log(NEAT_LOG_DEBUG, "%s", __func__);
     free(handle);
 }
 
@@ -1674,19 +1671,20 @@ install_security(struct neat_he_candidate *candidate)
 {
     struct neat_flow *flow = candidate->pollable_socket->flow;
     json_t *security = NULL, *val = NULL;
+    struct neat_ctx *ctx = flow->ctx;
 
     if ((security = json_object_get(candidate->properties, "security")) != NULL &&
         (val = json_object_get(security, "value")) != NULL &&
         json_typeof(val) == JSON_TRUE)
     {
-        neat_log(NEAT_LOG_DEBUG, "Flow required security");
+        neat_log(ctx, NEAT_LOG_DEBUG, "Flow required security");
         if (neat_security_install(flow->ctx, flow) != NEAT_OK) {
             neat_io_error(flow->ctx, flow, NEAT_ERROR_SECURITY);
         }
 
         return 1;
     } else {
-        neat_log(NEAT_LOG_DEBUG, "Flow did not require security");
+        neat_log(ctx, NEAT_LOG_DEBUG, "Flow did not require security");
         return 0;
     }
 }
@@ -1704,20 +1702,20 @@ send_result_connection_attempt_to_pm(neat_ctx *ctx, neat_flow *flow, struct cib_
     json_t *result_obj = NULL;
     json_t *result_array = NULL;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     assert(he_res);
 
     socket_path = getenv("NEAT_PM_SOCKET");
     if (!socket_path) {
         if ((home_dir = getenv("HOME")) == NULL) {
-            neat_log(NEAT_LOG_DEBUG, "Unable to locate the $HOME directory");
+            neat_log(ctx, NEAT_LOG_DEBUG, "Unable to locate the $HOME directory");
             goto end;
         }
 
         rc = snprintf(socket_path_buf, 128, "%s/.neat/neat_cib_socket", home_dir);
         if (rc < 0 || rc >= 128) {
-            neat_log(NEAT_LOG_DEBUG, "Unable to construct default path to PM socket");
+            neat_log(ctx, NEAT_LOG_DEBUG, "Unable to construct default path to PM socket");
             goto end;
         }
 
@@ -1788,10 +1786,11 @@ he_connected_cb(uv_poll_t *handle, int status, int events)
     struct neat_flow *flow = candidate->pollable_socket->flow;
     struct neat_he_candidates *candidate_list = flow->candidate_list;
     struct cib_he_res *he_res = NULL;
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    struct neat_ctx *ctx = flow->ctx;
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     c++;
-    neat_log(NEAT_LOG_DEBUG, "Invokation count: %d", c);
+    neat_log(ctx, NEAT_LOG_DEBUG, "Invokation count: %d", c);
 
     assert(candidate);
     assert(candidate->pollable_socket);
@@ -1830,7 +1829,7 @@ he_connected_cb(uv_poll_t *handle, int status, int events)
         break;
     };
 
-    neat_log(NEAT_LOG_DEBUG,
+    neat_log(ctx, NEAT_LOG_DEBUG,
              "HE Candidate connected: %8s [%2d] %8s/%s <saddr %s> <dstaddr %s> port %5d priority %d",
              candidate->if_name,
              candidate->if_idx,
@@ -1845,7 +1844,7 @@ he_connected_cb(uv_poll_t *handle, int status, int events)
     unsigned int len = sizeof(so_error);
     if (getsockopt(candidate->pollable_socket->fd, SOL_SOCKET, SO_ERROR, &so_error, &len) < 0) {
 
-        neat_log(NEAT_LOG_DEBUG, "Call to getsockopt for fd %d failed: %s", candidate->pollable_socket->fd, strerror(errno));
+        neat_log(ctx, NEAT_LOG_DEBUG, "Call to getsockopt for fd %d failed: %s", candidate->pollable_socket->fd, strerror(errno));
 
         uv_poll_stop(handle);
         uv_close((uv_handle_t*)handle, free_he_handle_cb);
@@ -1854,7 +1853,7 @@ he_connected_cb(uv_poll_t *handle, int status, int events)
         return;
     }
     status = so_error;
-    neat_log(NEAT_LOG_DEBUG, "%s - Connection status: %d", __func__, status);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s - Connection status: %d", __func__, status);
 
     he_res = calloc(1, sizeof(struct cib_he_res));
     assert(he_res);
@@ -1866,7 +1865,7 @@ he_connected_cb(uv_poll_t *handle, int status, int events)
     // TODO: In which circumstances do we end up in the three different cases?
     if (flow->firstWritePending) {
         // assert(0);
-        neat_log(NEAT_LOG_DEBUG, "First successful connect (flow->firstWritePending)");
+        neat_log(ctx, NEAT_LOG_DEBUG, "First successful connect (flow->firstWritePending)");
 
         assert(flow->socket);
 
@@ -1878,7 +1877,7 @@ he_connected_cb(uv_poll_t *handle, int status, int events)
         uvpollable_cb(flow->socket->handle, NEAT_OK, UV_WRITABLE);
     } else if (flow->hefirstConnect && (status == 0)) {
         flow->hefirstConnect = 0;
-        neat_log(NEAT_LOG_DEBUG, "First successful connect (flow->hefirstConnect)");
+        neat_log(ctx, NEAT_LOG_DEBUG, "First successful connect (flow->hefirstConnect)");
 
         assert(flow->socket);
 
@@ -1933,14 +1932,14 @@ he_connected_cb(uv_poll_t *handle, int status, int events)
             uvpollable_cb(flow->socket->handle, NEAT_OK, UV_WRITABLE);
         }
     } else {
-        neat_log(NEAT_LOG_DEBUG, "%s - NOT first connect", __func__);
+        neat_log(ctx, NEAT_LOG_DEBUG, "%s - NOT first connect", __func__);
 
         send_result_connection_attempt_to_pm(flow->ctx, flow, he_res, false);
 
         uv_poll_stop(handle);
         uv_close((uv_handle_t*)handle, free_he_handle_cb);
 
-        neat_log(NEAT_LOG_DEBUG, "%s:Release candidate", __func__);
+        neat_log(ctx, NEAT_LOG_DEBUG, "%s:Release candidate", __func__);
         TAILQ_REMOVE(candidate_list, candidate, next);
         free(candidate->pollable_socket->dst_address);
         free(candidate->pollable_socket->src_address);
@@ -1974,12 +1973,12 @@ void uvpollable_cb(uv_poll_t *handle, int status, int events)
     }
 
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     if ((events & UV_READABLE) && flow && flow->acceptPending) {
         if (pollable_socket->stack == NEAT_STACK_UDP ||
            pollable_socket->stack == NEAT_STACK_UDPLITE) {
-            neat_log(NEAT_LOG_DEBUG, "%s - UDP or UDPLite accept flow", __func__);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s - UDP or UDPLite accept flow", __func__);
             io_readable(ctx, flow, pollable_socket, NEAT_OK);
         } else {
             do_accept(ctx, flow, pollable_socket);
@@ -1989,7 +1988,7 @@ void uvpollable_cb(uv_poll_t *handle, int status, int events)
 
     // TODO: Are there cases when we should keep polling?
     if (status < 0) {
-        neat_log(NEAT_LOG_DEBUG, "ERROR: %s", uv_strerror(status));
+        neat_log(ctx, NEAT_LOG_DEBUG, "ERROR: %s", uv_strerror(status));
 
 #if !defined(USRSCTP_SUPPORT)
         if (neat_base_stack(pollable_socket->stack) == NEAT_STACK_TCP ||
@@ -2001,12 +2000,12 @@ void uvpollable_cb(uv_poll_t *handle, int status, int events)
             int so_error = 0;
             unsigned int len = sizeof(so_error);
             if (getsockopt(flow->socket->fd, SOL_SOCKET, SO_ERROR, &so_error, &len) < 0) {
-                neat_log(NEAT_LOG_DEBUG, "Call to getsockopt failed: %s", strerror(errno));
+                neat_log(ctx, NEAT_LOG_DEBUG, "Call to getsockopt failed: %s", strerror(errno));
                 neat_io_error(ctx, flow, NEAT_ERROR_INTERNAL);
                 return;
             }
 
-            neat_log(NEAT_LOG_DEBUG, "Socket layer errno: %d (%s)", so_error, strerror(so_error));
+            neat_log(ctx, NEAT_LOG_DEBUG, "Socket layer errno: %d (%s)", so_error, strerror(so_error));
 
             if (so_error == ETIMEDOUT) {
                 io_timeout(ctx, flow);
@@ -2017,7 +2016,7 @@ void uvpollable_cb(uv_poll_t *handle, int status, int events)
         }
 
 
-        neat_log(NEAT_LOG_ERROR, "Unspecified internal error when polling socket");
+        neat_log(ctx, NEAT_LOG_ERROR, "Unspecified internal error when polling socket");
         neat_io_error(ctx, flow, NEAT_ERROR_INTERNAL);
 
         return;
@@ -2031,7 +2030,7 @@ void uvpollable_cb(uv_poll_t *handle, int status, int events)
     if (pollable_socket->multistream) {
 #ifdef SCTP_MULTISTREAMING
         flow = LIST_FIRST(&pollable_socket->sctp_multistream_flows);
-        neat_log(NEAT_LOG_DEBUG, "%s - multistreaming - taking first flow from ctx", __func__);
+        neat_log(ctx, NEAT_LOG_DEBUG, "%s - multistreaming - taking first flow from ctx", __func__);
         assert(flow);
 #else // SCTP_MULTISTREAMING
         assert(false);
@@ -2044,13 +2043,13 @@ void uvpollable_cb(uv_poll_t *handle, int status, int events)
 #ifdef SCTP_MULTISTREAMING
         if (flow->socket->sctp_notification_wait) {
             if ((events & UV_READABLE)) {
-                neat_log(NEAT_LOG_DEBUG, "%s - awaiting notifications", __func__);
+                neat_log(ctx, NEAT_LOG_DEBUG, "%s - awaiting notifications", __func__);
                 io_readable(ctx, flow, pollable_socket, NEAT_OK);
             } else if (flow->socket->sctp_notification_recvd) {
-                neat_log(NEAT_LOG_DEBUG, "%s - got notifications but socket is not readable anymore ...", __func__);
+                neat_log(ctx, NEAT_LOG_DEBUG, "%s - got notifications but socket is not readable anymore ...", __func__);
                 flow->socket->sctp_notification_wait = 0;
             } else {
-                neat_log(NEAT_LOG_DEBUG, "%s - awaiting notifications, socket not readable yet, skipping...", __func__);
+                neat_log(ctx, NEAT_LOG_DEBUG, "%s - awaiting notifications, socket not readable yet, skipping...", __func__);
             }
 
             break;
@@ -2081,13 +2080,13 @@ void uvpollable_cb(uv_poll_t *handle, int status, int events)
 #ifdef SCTP_MULTISTREAMING
         // next flow
         flow = LIST_NEXT(flow, multistream_next_flow);
-        neat_log(NEAT_LOG_DEBUG, "%s - next flow : %p", __func__, flow);
+        neat_log(ctx, NEAT_LOG_DEBUG, "%s - next flow : %p", __func__, flow);
 #endif
 
         // iterate through all flows
     } while (pollable_socket->multistream && flow);
 
-    neat_log(NEAT_LOG_DEBUG, "%s - finished", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s - finished", __func__);
 
     flow = pollable_socket->flow;
     updatePollHandle(ctx, flow, handle);
@@ -2138,7 +2137,7 @@ static neat_flow *
 do_accept(neat_ctx *ctx, neat_flow *flow, struct neat_pollable_socket *listen_socket)
 {
     const char *proto = NULL;
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 #if defined(IPPROTO_SCTP)
 #if defined(SCTP_RECVRCVINFO) && !defined(USRSCTP_SUPPORT)
     int optval;
@@ -2218,7 +2217,7 @@ do_accept(neat_ctx *ctx, neat_flow *flow, struct neat_pollable_socket *listen_so
     newFlow->socket->read_size          = listen_socket->read_size;
     newFlow->socket->sctp_explicit_eor  = listen_socket->sctp_explicit_eor;
 
-    neat_log(NEAT_LOG_INFO, "%s - write_size %d - read_size %d", __func__, listen_socket->write_size, listen_socket->read_size);
+    neat_log(ctx, NEAT_LOG_INFO, "%s - write_size %d - read_size %d", __func__, listen_socket->write_size, listen_socket->read_size);
 
     newFlow->ctx            = ctx;
     newFlow->ownedByCore    = 1;
@@ -2254,7 +2253,7 @@ do_accept(neat_ctx *ctx, neat_flow *flow, struct neat_pollable_socket *listen_so
             newFlow->acceptPending = 0;
         }
 #else
-        neat_log(NEAT_LOG_DEBUG, "Creating new SCTP socket");
+        neat_log(ctx, NEAT_LOG_DEBUG, "Creating new SCTP socket");
         newFlow->socket->fd = newFlow->acceptfx(ctx, newFlow, listen_socket->fd);
         if (newFlow->socket->fd == -1) {
             neat_free_flow(newFlow);
@@ -2276,7 +2275,7 @@ do_accept(neat_ctx *ctx, neat_flow *flow, struct neat_pollable_socket *listen_so
         optlen = sizeof(optval);
         rc = setsockopt(newFlow->socket->fd, IPPROTO_SCTP, SCTP_RECVRCVINFO, &optval, optlen);
         if (rc < 0)
-            neat_log(NEAT_LOG_DEBUG, "Call to setsockopt(SCTP_RECVRCVINFO) failed");
+            neat_log(ctx, NEAT_LOG_DEBUG, "Call to setsockopt(SCTP_RECVRCVINFO) failed");
 #endif // defined(SCTP_RECVRCVINFO)
 #if defined(SCTP_RECVNXTINFO)
         // Enable anciliarry data when receiving data from SCTP
@@ -2284,12 +2283,12 @@ do_accept(neat_ctx *ctx, neat_flow *flow, struct neat_pollable_socket *listen_so
         optlen = sizeof(optval);
         rc = setsockopt(newFlow->socket->fd, IPPROTO_SCTP, SCTP_RECVNXTINFO, &optval, optlen);
         if (rc < 0)
-            neat_log(NEAT_LOG_DEBUG, "Call to setsockopt(SCTP_RECVNXTINFO) failed");
+            neat_log(ctx, NEAT_LOG_DEBUG, "Call to setsockopt(SCTP_RECVNXTINFO) failed");
 #endif // defined(SCTP_RECVNXTINFO)
 #endif
         break;
     case NEAT_STACK_UDP:
-        neat_log(NEAT_LOG_DEBUG, "Creating new UDP socket");
+        neat_log(ctx, NEAT_LOG_DEBUG, "Creating new UDP socket");
         newFlow->socket->fd = socket(newFlow->socket->family, newFlow->socket->type, IPPROTO_UDP);
 
         if (newFlow->socket->fd == -1) {
@@ -2318,7 +2317,7 @@ do_accept(neat_ctx *ctx, neat_flow *flow, struct neat_pollable_socket *listen_so
 #if defined(__NetBSD__) || defined(__APPLE__)
         assert(0); // Should not reach this point
 #else
-        neat_log(NEAT_LOG_DEBUG, "Creating new UDPLite socket");
+        neat_log(ctx, NEAT_LOG_DEBUG, "Creating new UDPLite socket");
         newFlow->socket->fd = socket(newFlow->socket->family, newFlow->socket->type, IPPROTO_UDPLITE);
 
         if (newFlow->socket->fd == -1) {
@@ -2378,7 +2377,7 @@ do_accept(neat_ctx *ctx, neat_flow *flow, struct neat_pollable_socket *listen_so
             newFlow->acceptPending = 0;
             if ((newFlow->propertyMask & NEAT_PROPERTY_REQUIRED_SECURITY) &&
                 (newFlow->socket->stack == NEAT_STACK_TCP)) {
-                neat_log(NEAT_LOG_DEBUG, "TCP Server Security");
+                neat_log(ctx, NEAT_LOG_DEBUG, "TCP Server Security");
                 if (neat_security_install(newFlow->ctx, newFlow) != NEAT_OK) {
                     neat_io_error(flow->ctx, flow, NEAT_ERROR_SECURITY);
                 }
@@ -2395,7 +2394,7 @@ do_accept(neat_ctx *ctx, neat_flow *flow, struct neat_pollable_socket *listen_so
         optlen = sizeof(status);
         rc = getsockopt(newFlow->socket->fd, IPPROTO_SCTP, SCTP_STATUS, &status, &optlen);
         if (rc < 0) {
-            neat_log(NEAT_LOG_DEBUG, "Call to getsockopt(SCTP_STATUS) failed");
+            neat_log(ctx, NEAT_LOG_DEBUG, "Call to getsockopt(SCTP_STATUS) failed");
             newFlow->socket->sctp_streams_available = 1;
         } else {
             newFlow->socket->sctp_streams_available = MIN(status.sstat_instrms, status.sstat_outstrms);
@@ -2405,7 +2404,7 @@ do_accept(neat_ctx *ctx, neat_flow *flow, struct neat_pollable_socket *listen_so
         newFlow->multistream_id = 0;
 #endif
         // number of outbound streams == number of inbound streams
-        neat_log(NEAT_LOG_DEBUG, "%s - SCTP - number of streams: %d", __func__, newFlow->socket->sctp_streams_available);
+        neat_log(ctx, NEAT_LOG_DEBUG, "%s - SCTP - number of streams: %d", __func__, newFlow->socket->sctp_streams_available);
         break;
 #endif
     default:
@@ -2426,7 +2425,7 @@ build_he_candidates(neat_ctx *ctx, neat_flow *flow, json_t *json, struct neat_he
     int if_idx;
     json_t *value;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     json_array_foreach(json, i, value) {
         neat_protocol_stack_type stack;
@@ -2434,7 +2433,7 @@ build_he_candidates(neat_ctx *ctx, neat_flow *flow, json_t *json, struct neat_he
         char dummy[sizeof(struct sockaddr_storage)];
         struct neat_he_candidate *candidate;
 
-        neat_log(NEAT_LOG_DEBUG, "Now processing PM candidate %zu", i);
+        neat_log(ctx, NEAT_LOG_DEBUG, "Now processing PM candidate %zu", i);
 
         interface = json_string_value(get_property(value, "interface", JSON_STRING));
         if (!interface)
@@ -2451,7 +2450,7 @@ build_he_candidates(neat_ctx *ctx, neat_flow *flow, json_t *json, struct neat_he
         transport = json_string_value(get_property(value, "transport", JSON_STRING));
 
         if ((stack = string_to_stack(transport)) == 0) {
-            neat_log(NEAT_LOG_DEBUG, "Unkown transport stack %s", transport);
+            neat_log(ctx, NEAT_LOG_DEBUG, "Unkown transport stack %s", transport);
             continue;
         }
 
@@ -2463,7 +2462,7 @@ build_he_candidates(neat_ctx *ctx, neat_flow *flow, json_t *json, struct neat_he
 
         if_idx = if_nametoindex(interface);
         if (!if_idx) {
-            neat_log(NEAT_LOG_DEBUG, "Unable to get interface id for \"%s\"",
+            neat_log(ctx, NEAT_LOG_DEBUG, "Unable to get interface id for \"%s\"",
                      interface);
             if_idx = 0;
         }
@@ -2515,7 +2514,7 @@ build_he_candidates(neat_ctx *ctx, neat_flow *flow, json_t *json, struct neat_he
             ((struct sockaddr*) &candidate->pollable_socket->src_sockaddr)->sa_family = AF_INET;
         } else {
             // Not AF_INET or AF_INET6?...
-            neat_log(NEAT_LOG_DEBUG, "Received candidate with address \"%s\" which neither AF_INET nor AF_INET6", candidate->pollable_socket->dst_address);
+            neat_log(ctx, NEAT_LOG_DEBUG, "Received candidate with address \"%s\" which neither AF_INET nor AF_INET6", candidate->pollable_socket->dst_address);
             rc = NEAT_ERROR_BAD_ARGUMENT;
             goto error;
         }
@@ -2552,14 +2551,14 @@ on_pm_reply_post_resolve(neat_ctx *ctx, neat_flow *flow, json_t *json)
     struct sockaddr *sa = NULL;
     struct sockaddr *da = NULL;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
 #if 0
     char *str = json_dumps(json, JSON_INDENT(2));
-    neat_log(NEAT_LOG_DEBUG, "Reply from PM was: %s", str);
+    neat_log(ctx, NEAT_LOG_DEBUG, "Reply from PM was: %s", str);
     free(str);
 #else
-    neat_log(NEAT_LOG_DEBUG, "Received second reply from PM");
+    neat_log(ctx, NEAT_LOG_DEBUG, "Received second reply from PM");
 #endif
 
     candidate_list = calloc(1, sizeof(*candidate_list));
@@ -2596,7 +2595,7 @@ on_candidates_resolved(neat_ctx *ctx, neat_flow *flow, struct neat_he_candidates
     char socket_path_buf[128];
     struct neat_he_candidate *candidate, *tmp;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     // Now that the names in the list are resolved, append the new data to the
     // json objects and perform a new call to the PM
@@ -2607,11 +2606,11 @@ on_candidates_resolved(neat_ctx *ctx, neat_flow *flow, struct neat_he_candidates
         json_t *dst_address, *str;
 
         if (candidate->if_idx == 0) {
-            // neat_log(NEAT_LOG_DEBUG, "Removing...");
+            // neat_log(ctx, NEAT_LOG_DEBUG, "Removing...");
             continue;
         }
 
-        // neat_log(NEAT_LOG_DEBUG, "%s %s", json_string_value(get_property(candidate->properties, "transport", JSON_STRING)), candidate->pollable_socket->dst_address);
+        // neat_log(ctx, NEAT_LOG_DEBUG, "%s %s", json_string_value(get_property(candidate->properties, "transport", JSON_STRING)), candidate->pollable_socket->dst_address);
 
         assert(candidate->pollable_socket->dst_address);
 
@@ -2630,28 +2629,28 @@ on_candidates_resolved(neat_ctx *ctx, neat_flow *flow, struct neat_he_candidates
     }
 
     if (json_array_size(array) == 0) {
-        neat_log(NEAT_LOG_DEBUG, "No usable candidates after name resolution");
+        neat_log(ctx, NEAT_LOG_DEBUG, "No usable candidates after name resolution");
         neat_io_error(ctx, flow, NEAT_ERROR_UNABLE);
         return;
     }
 
-    neat_free_candidates(candidate_list);
+    neat_free_candidates(ctx, candidate_list);
 
 #if 0
-    neat_log(NEAT_LOG_DEBUG, "Sending post-resolve properties to PM\n%s\n", buffer);
+    neat_log(ctx, NEAT_LOG_DEBUG, "Sending post-resolve properties to PM\n%s\n", buffer);
 #else
 
     socket_path = getenv("NEAT_PM_SOCKET");
     if (!socket_path) {
         if ((home_dir = getenv("HOME")) == NULL) {
-            neat_log(NEAT_LOG_DEBUG, "Unable to locate the $HOME directory");
+            neat_log(ctx, NEAT_LOG_DEBUG, "Unable to locate the $HOME directory");
             neat_io_error(ctx, flow, NEAT_ERROR_INTERNAL);
             return;
         }
 
         rc = snprintf(socket_path_buf, 128, "%s/.neat/neat_pm_socket", home_dir);
         if (rc < 0 || rc >= 128) {
-            neat_log(NEAT_LOG_DEBUG, "Unable to construct default path to PM socket");
+            neat_log(ctx, NEAT_LOG_DEBUG, "Unable to construct default path to PM socket");
             neat_io_error(ctx, flow, NEAT_ERROR_INTERNAL);
             return;
         }
@@ -2659,7 +2658,7 @@ on_candidates_resolved(neat_ctx *ctx, neat_flow *flow, struct neat_he_candidates
         socket_path = socket_path_buf;
     }
 
-    neat_log(NEAT_LOG_DEBUG, "Sending post-resolve properties to PM");
+    neat_log(ctx, NEAT_LOG_DEBUG, "Sending post-resolve properties to PM");
     // buffer is freed by the PM interface
     neat_json_send_once(flow->ctx, flow, socket_path, array, on_pm_reply_post_resolve, on_pm_error);
     json_decref(array);
@@ -2693,16 +2692,16 @@ on_candidate_resolved(struct neat_resolver_results *results,
     struct candidate_resolver_data *data = user_data;
     struct neat_he_candidate *candidate, *tmp;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    //neat_log(NEAT_LOG_DEBUG, "%s", __func__);
 
     if (code == NEAT_RESOLVER_TIMEOUT)  {
         *data->status = -1;
         // neat_io_error(flow->ctx, flow, NEAT_ERROR_IO);
-        neat_log(NEAT_LOG_DEBUG, "Resolution timed out");
+        // neat_log(NEAT_LOG_DEBUG, "Resolution timed out");
     } else if ( code == NEAT_RESOLVER_ERROR ) {
         *data->status = -1;
         // neat_io_error(flow->ctx, flow, NEAT_ERROR_IO);
-        neat_log(NEAT_LOG_DEBUG, "Resolver error");
+        //neat_log(NEAT_LOG_DEBUG, "Resolver error");
     }
 
     LIST_FOREACH(result, results, next_res) {
@@ -2710,27 +2709,28 @@ on_candidate_resolved(struct neat_resolver_results *results,
         char ifname2[IF_NAMESIZE];
 
         if ((rc = getnameinfo((struct sockaddr*)&result->dst_addr, result->dst_addr_len, namebuf, NI_MAXHOST, NULL, 0, NI_NUMERICHOST)) != 0) {
-            neat_log(NEAT_LOG_DEBUG, "getnameinfo error");
+            //neat_log(NEAT_LOG_DEBUG, "getnameinfo error");
             continue;
         }
 
         TAILQ_FOREACH_SAFE(candidate, &data->resolution_group, resolution_list, tmp) {
+            struct neat_ctx *ctx = candidate->ctx;
 
             // The interface index must be the same as the interface index of the candidate
             if (result->if_idx != candidate->if_idx) {
-                neat_log(NEAT_LOG_DEBUG, "Interface did not match, %s [%d] != %s [%d]", if_indextoname(result->if_idx, ifname1), result->if_idx, if_indextoname(candidate->if_idx, ifname2), candidate->if_idx);
+                neat_log(ctx, NEAT_LOG_DEBUG, "Interface did not match, %s [%d] != %s [%d]", if_indextoname(result->if_idx, ifname1), result->if_idx, if_indextoname(candidate->if_idx, ifname2), candidate->if_idx);
                 continue;
             }
 
             // TODO: Move inet_pton out of the loop
             if (result->ai_family == AF_INET && inet_pton(AF_INET6, candidate->pollable_socket->src_address, &dummy) == 1) {
-                neat_log(NEAT_LOG_DEBUG, "Address family did not match");
+                neat_log(ctx, NEAT_LOG_DEBUG, "Address family did not match");
                 continue;
             }
 
             // TODO: Move inet_pton out of the loop
             if (result->ai_family == AF_INET6 && inet_pton(AF_INET, candidate->pollable_socket->src_address, &dummy) == 1) {
-                neat_log(NEAT_LOG_DEBUG, "Address family did not match");
+                neat_log(ctx, NEAT_LOG_DEBUG, "Address family did not match");
                 continue;
             }
 
@@ -2738,7 +2738,7 @@ on_candidate_resolved(struct neat_resolver_results *results,
             free(candidate->pollable_socket->dst_address);
 
             if ((candidate->pollable_socket->dst_address = strdup(namebuf)) != NULL) {
-                neat_log(NEAT_LOG_DEBUG, "%s -> %s", candidate->pollable_socket->src_address, namebuf);
+                neat_log(ctx, NEAT_LOG_DEBUG, "%s -> %s", candidate->pollable_socket->src_address, namebuf);
             } else {
                 *(data->status) = NEAT_ERROR_OUT_OF_MEMORY;
             }
@@ -2781,12 +2781,12 @@ neat_resolve_candidates(neat_ctx *ctx, neat_flow *flow,
     TAILQ_HEAD(resolution_group_list, candidate_resolver_data) resolutions;
     TAILQ_INIT(&resolutions);
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     assert(candidate_list);
 
     if (TAILQ_EMPTY(candidate_list)) {
-        neat_log(NEAT_LOG_WARNING, "neat_resolve_candidates called with an empty candidate list");
+        neat_log(ctx, NEAT_LOG_WARNING, "neat_resolve_candidates called with an empty candidate list");
         return;
     }
 
@@ -2818,7 +2818,7 @@ neat_resolve_candidates(neat_ctx *ctx, neat_flow *flow,
 
             // TODO: Split on ipv4/ipv6/no preference
 
-            neat_log(NEAT_LOG_DEBUG, "Adding candidate to existing resolution group for %s:%u",
+            neat_log(ctx, NEAT_LOG_DEBUG, "Adding candidate to existing resolution group for %s:%u",
                      existing_resolution->domain_name, existing_resolution->port);
 
             TAILQ_INSERT_TAIL(&existing_resolution->resolution_group, candidate, resolution_list);
@@ -2840,7 +2840,7 @@ neat_resolve_candidates(neat_ctx *ctx, neat_flow *flow,
         resolver_data->remaining = remaining;
         (*remaining)++;
 
-        neat_log(NEAT_LOG_DEBUG, "Creating new resolution group for %s:%u", resolver_data->domain_name, resolver_data->port);
+        neat_log(ctx, NEAT_LOG_DEBUG, "Creating new resolution group for %s:%u", resolver_data->domain_name, resolver_data->port);
         TAILQ_INSERT_TAIL(&resolver_data->resolution_group, candidate, resolution_list);
         TAILQ_INSERT_TAIL(&resolutions, resolver_data, next);
 next_candidate:
@@ -2859,7 +2859,7 @@ error:
         free(resolver_data);
     }
 
-    neat_free_candidates(candidate_list);
+    neat_free_candidates(ctx, candidate_list);
 
     if (remaining)
         free(remaining);
@@ -2881,7 +2881,7 @@ open_resolve_cb(struct neat_resolver_results *results, uint8_t code,
     struct neat_resolver_res *result;
     struct neat_he_candidates *candidates;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     if (code != NEAT_RESOLVER_OK) {
         neat_io_error(ctx, flow, code);
@@ -2925,7 +2925,7 @@ open_resolve_cb(struct neat_resolver_results *results, uint8_t code,
                          dst_buffer, sizeof(dst_buffer), NULL, 0, NI_NUMERICHOST);
 
         if (rc != 0) {
-            neat_log(NEAT_LOG_DEBUG, "getnameinfo() failed: %s\n",
+            neat_log(ctx, NEAT_LOG_DEBUG, "getnameinfo() failed: %s\n",
                      gai_strerror(rc));
             continue;
         }
@@ -2935,7 +2935,7 @@ open_resolve_cb(struct neat_resolver_results *results, uint8_t code,
                          src_buffer, sizeof(src_buffer), NULL, 0, NI_NUMERICHOST);
 
         if (rc != 0) {
-            neat_log(NEAT_LOG_DEBUG, "getnameinfo() failed: %s\n",
+            neat_log(ctx, NEAT_LOG_DEBUG, "getnameinfo() failed: %s\n",
                      gai_strerror(rc));
             continue;
         }
@@ -3011,7 +3011,7 @@ open_resolve_cb(struct neat_resolver_results *results, uint8_t code,
                                     strcat(candidate->pollable_socket->src_address, ",");
                                     strcat(candidate->pollable_socket->src_address, src_buffer);
                                 } else {
-                                    neat_log(NEAT_LOG_ERROR, "The maximum number of local addresses (%d) is exceeded", MAX_LOCAL_ADDR);
+                                    neat_log(ctx, NEAT_LOG_ERROR, "The maximum number of local addresses (%d) is exceeded", MAX_LOCAL_ADDR);
                                 }
                                 TAILQ_REMOVE(candidates, cand, next);
                                 free(cand->pollable_socket->dst_address);
@@ -3064,13 +3064,13 @@ open_resolve_cb(struct neat_resolver_results *results, uint8_t code,
 static void
 on_pm_error(struct neat_ctx *ctx, struct neat_flow *flow, int error)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     switch (error) {
         case PM_ERROR_SOCKET_UNAVAILABLE:
         case PM_ERROR_SOCKET:
         case PM_ERROR_INVALID_JSON:
-            neat_log(NEAT_LOG_DEBUG, "===== Unable to communicate with PM, using fallback =====, error code = %d", error);
+            neat_log(ctx, NEAT_LOG_DEBUG, "===== Unable to communicate with PM, using fallback =====, error code = %d", error);
             neat_resolve(ctx->resolver, AF_UNSPEC, flow->name, flow->port,
                          open_resolve_cb, flow);
             break;
@@ -3086,13 +3086,13 @@ on_pm_error(struct neat_ctx *ctx, struct neat_flow *flow, int error)
 static void
 on_pm_he_error(struct neat_ctx *ctx, struct neat_flow *flow, int error)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     switch (error) {
         case PM_ERROR_SOCKET_UNAVAILABLE:
         case PM_ERROR_SOCKET:
         case PM_ERROR_INVALID_JSON:
-            neat_log(NEAT_LOG_DEBUG, "Unable to communicate with PM, error code = %d", error);
+            neat_log(ctx, NEAT_LOG_DEBUG, "Unable to communicate with PM, error code = %d", error);
             break;
         case PM_ERROR_OOM:
             break;
@@ -3111,14 +3111,14 @@ on_pm_reply_pre_resolve(struct neat_ctx *ctx, struct neat_flow *flow, json_t *js
     json_t *value;
     struct neat_he_candidates *candidate_list;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
 #if 0
     char *str = json_dumps(json, JSON_INDENT(2));
-    neat_log(NEAT_LOG_DEBUG, "Reply from PM was: %s", str);
+    neat_log(ctx, NEAT_LOG_DEBUG, "Reply from PM was: %s", str);
     free(str);
 #else
-    neat_log(NEAT_LOG_DEBUG, "Received reply from PM");
+    neat_log(ctx, NEAT_LOG_DEBUG, "Received reply from PM");
 #endif
 
     if ((candidate_list = calloc(1, sizeof(*candidate_list))) == NULL) {
@@ -3154,7 +3154,7 @@ on_pm_reply_pre_resolve(struct neat_ctx *ctx, struct neat_flow *flow, json_t *js
             goto loop_oom;
 
         if ((candidate->if_idx = if_nametoindex(candidate->if_name)) == 0) {
-            neat_log(NEAT_LOG_DEBUG, "Unknown interface %s", candidate->if_name);
+            neat_log(ctx, NEAT_LOG_DEBUG, "Unknown interface %s", candidate->if_name);
             goto loop_error;
         }
 printf("set src_address to %s\n", local_ip);
@@ -3192,7 +3192,7 @@ loop_error:
 #if 0
     struct neat_he_candidate *tmp;
     TAILQ_FOREACH(tmp, candidate_list, next) {
-        neat_log(NEAT_LOG_DEBUG, "%s %s", json_string_value(get_property(tmp->properties, "transport", JSON_STRING)), tmp->pollable_socket->dst_address);
+        neat_log(ctx, NEAT_LOG_DEBUG, "%s %s", json_string_value(get_property(tmp->properties, "transport", JSON_STRING)), tmp->pollable_socket->dst_address);
     }
 
     // Deallocation test
@@ -3206,7 +3206,7 @@ loop_error:
     return;
 error:
     json_decref(json);
-    neat_free_candidates(candidate_list);
+    neat_free_candidates(ctx, candidate_list);
 
     neat_io_error(ctx, flow, rc);
 }
@@ -3221,19 +3221,19 @@ send_properties_to_pm(neat_ctx *ctx, neat_flow *flow)
     const char *socket_path;
     char socket_path_buf[128];
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     socket_path = getenv("NEAT_PM_SOCKET");
     if (!socket_path) {
         if ((home_dir = getenv("HOME")) == NULL) {
-            neat_log(NEAT_LOG_DEBUG, "Unable to locate the $HOME directory");
+            neat_log(ctx, NEAT_LOG_DEBUG, "Unable to locate the $HOME directory");
 
             goto end;
         }
 
         rc = snprintf(socket_path_buf, 128, "%s/.neat/neat_pm_socket", home_dir);
         if (rc < 0 || rc >= 128) {
-            neat_log(NEAT_LOG_DEBUG, "Unable to construct default path to PM socket");
+            neat_log(ctx, NEAT_LOG_DEBUG, "Unable to construct default path to PM socket");
             goto end;
         }
 
@@ -3251,7 +3251,7 @@ send_properties_to_pm(neat_ctx *ctx, neat_flow *flow)
 
     rc = getifaddrs(&ifaddrs);
     if (rc < 0) {
-        neat_log(NEAT_LOG_DEBUG, "getifaddrs: %s", strerror(errno));
+        neat_log(ctx, NEAT_LOG_DEBUG, "getifaddrs: %s", strerror(errno));
         goto end;
     }
 
@@ -3262,7 +3262,7 @@ send_properties_to_pm(neat_ctx *ctx, neat_flow *flow)
 
         // Doesn't actually contain any address (?)
         if (ifaddr->ifa_addr == NULL) {
-            neat_log(NEAT_LOG_DEBUG, "ifaddr entry with no address");
+            neat_log(ctx, NEAT_LOG_DEBUG, "ifaddr entry with no address");
             continue;
         }
 
@@ -3275,12 +3275,12 @@ send_properties_to_pm(neat_ctx *ctx, neat_flow *flow)
         rc = getnameinfo(ifaddr->ifa_addr, addrlen, namebuf, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
 
         if (rc != 0) {
-            neat_log(NEAT_LOG_DEBUG, "getnameinfo: %s", gai_strerror(rc));
+            neat_log(ctx, NEAT_LOG_DEBUG, "getnameinfo: %s", gai_strerror(rc));
             continue;
         }
 
         if (strncmp(namebuf, "fe80::", 6) == 0) {
-            neat_log(NEAT_LOG_DEBUG, "%s is a link-local address, skipping", namebuf);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s is a link-local address, skipping", namebuf);
             continue;
         }
 
@@ -3289,7 +3289,7 @@ send_properties_to_pm(neat_ctx *ctx, neat_flow *flow)
         if (endpoint == NULL)
             goto end;
 
-        neat_log(NEAT_LOG_DEBUG, "Added endpoint \"%s@%s\" to PM request", namebuf, ifaddr->ifa_name);
+        neat_log(ctx, NEAT_LOG_DEBUG, "Added endpoint \"%s@%s\" to PM request", namebuf, ifaddr->ifa_name);
         json_array_append(endpoints, endpoint);
         json_decref(endpoint);
     }
@@ -3331,7 +3331,7 @@ end:
 }
 
 neat_error_code
-neat_open(neat_ctx *mgr, neat_flow *flow, const char *name, uint16_t port,
+neat_open(neat_ctx *ctx, neat_flow *flow, const char *name, uint16_t port,
           struct neat_tlv optional[], unsigned int opt_count)
 {
     int stream_count = 0;
@@ -3341,10 +3341,10 @@ neat_open(neat_ctx *mgr, neat_flow *flow, const char *name, uint16_t port,
     const char *cc_algorithm = NULL;
     const char *local_address = NULL;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     if (flow->name) {
-        neat_log(NEAT_LOG_ERROR, "Flow appears to already be open");
+        neat_log(ctx, NEAT_LOG_ERROR, "Flow appears to already be open");
         return NEAT_ERROR_BAD_ARGUMENT;
     }
 
@@ -3359,11 +3359,11 @@ neat_open(neat_ctx *mgr, neat_flow *flow, const char *name, uint16_t port,
 
     if (stream_count > 1) {
         flow->streams_requested = stream_count;
-        neat_log(NEAT_LOG_DEBUG, "%s - %d streams", __func__, stream_count);
+        neat_log(ctx, NEAT_LOG_DEBUG, "%s - %d streams", __func__, stream_count);
     }
 
     if (priority > 1.0f || priority < 0.1f) {
-        neat_log(NEAT_LOG_ERROR, "Priority must be between 0.1 and 1.0");
+        neat_log(ctx, NEAT_LOG_ERROR, "Priority must be between 0.1 and 1.0");
         return NEAT_ERROR_BAD_ARGUMENT;
     }
 
@@ -3373,7 +3373,7 @@ neat_open(neat_ctx *mgr, neat_flow *flow, const char *name, uint16_t port,
     flow->port = port;
     flow->propertyAttempt = flow->propertyMask;
     //flow->stream_count = stream_count;
-    flow->ctx = mgr;
+    flow->ctx = ctx;
     flow->group = group;
     flow->priority = priority;
     flow->isSCTPMultihoming = (sctp_multihoming > 0? 1: 0);
@@ -3383,11 +3383,11 @@ neat_open(neat_ctx *mgr, neat_flow *flow, const char *name, uint16_t port,
     } else {
         flow->local_address = NULL;
     }
-    if (!mgr->resolver)
-        mgr->resolver = neat_resolver_init(mgr, "/etc/resolv.conf");
+    if (!ctx->resolver)
+        ctx->resolver = neat_resolver_init(ctx, "/etc/resolv.conf");
 
-    if (!mgr->pvd)
-        mgr->pvd = neat_pvd_init(mgr);
+    if (!ctx->pvd)
+        ctx->pvd = neat_pvd_init(ctx);
 
     if (cc_algorithm) {
         flow->cc_algorithm = strdup(cc_algorithm);
@@ -3397,10 +3397,10 @@ neat_open(neat_ctx *mgr, neat_flow *flow, const char *name, uint16_t port,
     }
 
 #if 1
-    send_properties_to_pm(mgr, flow);
+    send_properties_to_pm(ctx, flow);
 #else
     // TODO: Add name resolution call
-    neat_resolve(mgr->resolver, AF_UNSPEC, flow->name, flow->port,
+    neat_resolve(ctx->resolver, AF_UNSPEC, flow->name, flow->port,
                  open_resolve_cb, flow);
     // TODO: Generate candidates
     // TODO: Call HE
@@ -3410,33 +3410,33 @@ neat_open(neat_ctx *mgr, neat_flow *flow, const char *name, uint16_t port,
 }
 
 neat_error_code
-neat_change_timeout(neat_ctx *mgr, neat_flow *flow, unsigned int seconds)
+neat_change_timeout(neat_ctx *ctx, neat_flow *flow, unsigned int seconds)
 {
 #if defined(TCP_USER_TIMEOUT)
     unsigned int timeout_msec;
     int rc;
 #endif
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
 #if defined(TCP_USER_TIMEOUT)
     if (neat_base_stack(flow->socket->stack) != NEAT_STACK_TCP)
 #endif
     {
-        neat_log(NEAT_LOG_DEBUG, "Timeout is supported on Linux TCP only");
+        neat_log(ctx, NEAT_LOG_DEBUG, "Timeout is supported on Linux TCP only");
         return NEAT_ERROR_UNABLE;
     }
 
 #if defined(TCP_USER_TIMEOUT)
     if (flow->socket->fd == -1) {
-        neat_log(NEAT_LOG_WARNING,
+        neat_log(ctx, NEAT_LOG_WARNING,
                  "Unable to change timeout for TCP socket: "
                  "Invalid socket value");
         return NEAT_ERROR_BAD_ARGUMENT;
     }
 
     if (seconds > UINT_MAX - 1000) {
-        neat_log(NEAT_LOG_DEBUG, "Timeout value too large");
+        neat_log(ctx, NEAT_LOG_DEBUG, "Timeout value too large");
         return NEAT_ERROR_BAD_ARGUMENT;
     }
 
@@ -3449,7 +3449,7 @@ neat_change_timeout(neat_ctx *mgr, neat_flow *flow, unsigned int seconds)
                     sizeof(timeout_msec));
 
     if (rc < 0) {
-        neat_log(NEAT_LOG_ERROR,
+        neat_log(ctx, NEAT_LOG_ERROR,
                  "Unable to change timeout for TCP socket: "
                  "Call to setsockopt failed with errno=%d", errno);
         return NEAT_ERROR_IO;
@@ -3479,7 +3479,7 @@ set_primary_dest_resolve_cb(struct neat_resolver_results *results,
 #endif
 #endif
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     if (code != NEAT_RESOLVER_OK) {
         neat_io_error(ctx, flow, code);
@@ -3495,7 +3495,7 @@ set_primary_dest_resolve_cb(struct neat_resolver_results *results,
     addr.ssp_addr = results->lh_first->dst_addr;
 
     if (usrsctp_setsockopt(flow->socket->usrsctp_socket, IPPROTO_SCTP, SCTP_PRIMARY_ADDR, &addr, sizeof(addr)) < 0) {
-        neat_log(NEAT_LOG_DEBUG, "Call to usrsctp_setsockopt failed");
+        neat_log(ctx, NEAT_LOG_DEBUG, "Call to usrsctp_setsockopt failed");
         return NEAT_ERROR_IO;
     }
 #elif defined(HAVE_NETINET_SCTP_H)
@@ -3503,7 +3503,7 @@ set_primary_dest_resolve_cb(struct neat_resolver_results *results,
 
     rc = setsockopt(flow->socket->fd, IPPROTO_SCTP, SCTP_PRIMARY_ADDR, &addr, sizeof(addr));
     if (rc < 0) {
-        neat_log(NEAT_LOG_DEBUG, "Call to setsockopt failed");
+        neat_log(ctx, NEAT_LOG_DEBUG, "Call to setsockopt failed");
         return NEAT_ERROR_IO;
     }
 #endif
@@ -3512,9 +3512,9 @@ set_primary_dest_resolve_cb(struct neat_resolver_results *results,
                      dest_addr, sizeof(dest_addr), NULL, 0, 0);
 
     if (rc < 0) {
-        neat_log(NEAT_LOG_DEBUG, "getnameinfo failed for primary destination address");
+        neat_log(ctx, NEAT_LOG_DEBUG, "getnameinfo failed for primary destination address");
     } else {
-        neat_log(NEAT_LOG_DEBUG, "Updated primary destination address to: %s", dest_addr);
+        neat_log(ctx, NEAT_LOG_DEBUG, "Updated primary destination address to: %s", dest_addr);
     }
     return NEAT_ERROR_OK;
 }
@@ -3525,13 +3525,13 @@ neat_set_primary_dest(struct neat_ctx *ctx, struct neat_flow *flow, const char *
     int8_t literal;
     uint8_t family = AF_UNSPEC;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     if (neat_base_stack(flow->socket->stack) == NEAT_STACK_SCTP) {
         literal = neat_resolver_helpers_check_for_literal(&family, name);
 
         if (literal != 1) {
-            neat_log(NEAT_LOG_ERROR, "%s: provided name '%s' is not an address literal.\n",
+            neat_log(ctx, NEAT_LOG_ERROR, "%s: provided name '%s' is not an address literal.\n",
                  __func__, name);
             return NEAT_ERROR_BAD_ARGUMENT;
         }
@@ -3554,7 +3554,7 @@ neat_request_capacity(struct neat_ctx *ctx, struct neat_flow *flow, int rate, in
 neat_error_code
 neat_set_checksum_coverage(struct neat_ctx *ctx, struct neat_flow *flow, unsigned int send_coverage, unsigned int receive_coverage)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     switch (neat_base_stack(flow->socket->stack)) {
     case NEAT_STACK_UDP:
@@ -3565,13 +3565,13 @@ neat_set_checksum_coverage(struct neat_ctx *ctx, struct neat_flow *flow, unsigne
             const int state = receive_coverage ? 1 : 0;
 
             if (setsockopt(flow->socket->fd, SOL_SOCKET, SO_NO_CHECK, &state, sizeof(state)) < 0) {
-                neat_log(NEAT_LOG_DEBUG, "Unable to set SO_NO_CHECK to %d", state);
+                neat_log(ctx, NEAT_LOG_DEBUG, "Unable to set SO_NO_CHECK to %d", state);
                 return NEAT_ERROR_UNABLE;
             }
 
             return NEAT_OK;
 #else
-            neat_log(NEAT_LOG_DEBUG, "Disabling UDP checksum not supported");
+            neat_log(ctx, NEAT_LOG_DEBUG, "Disabling UDP checksum not supported");
             return NEAT_ERROR_UNABLE;
 #endif
         }
@@ -3579,18 +3579,18 @@ neat_set_checksum_coverage(struct neat_ctx *ctx, struct neat_flow *flow, unsigne
         {
 #if defined(UDPLITE_SEND_CSCOV) && defined(UDPLITE_RECV_CSCOV)
         if (setsockopt(flow->socket->fd, IPPROTO_UDPLITE, UDPLITE_SEND_CSCOV, &send_coverage, sizeof(unsigned int)) < 0) {
-            neat_log(NEAT_LOG_DEBUG, "Failed to set UDP-Lite send checksum coverage");
+            neat_log(ctx, NEAT_LOG_DEBUG, "Failed to set UDP-Lite send checksum coverage");
             return NEAT_ERROR_UNABLE;
         }
 
         if (setsockopt(flow->socket->fd, IPPROTO_UDPLITE, UDPLITE_RECV_CSCOV, &receive_coverage, sizeof(unsigned int)) < 0) {
-            neat_log(NEAT_LOG_DEBUG, "Failed to set UDP-Lite receive checksum coverage");
+            neat_log(ctx, NEAT_LOG_DEBUG, "Failed to set UDP-Lite receive checksum coverage");
             return NEAT_ERROR_UNABLE;
         }
 
         return NEAT_OK;
 #else
-        neat_log(NEAT_LOG_DEBUG, "Failed to set UDP-Lite checksum coverage, not supported");
+        neat_log(ctx, NEAT_LOG_DEBUG, "Failed to set UDP-Lite checksum coverage, not supported");
         return NEAT_ERROR_UNABLE;
 #endif
         }
@@ -3598,7 +3598,7 @@ neat_set_checksum_coverage(struct neat_ctx *ctx, struct neat_flow *flow, unsigne
         break;
     }
 
-    neat_log(NEAT_LOG_DEBUG, "Failed to set checksum coverage, protocol not supported");
+    neat_log(ctx, NEAT_LOG_DEBUG, "Failed to set checksum coverage, protocol not supported");
     return NEAT_ERROR_UNABLE;
 }
 
@@ -3614,7 +3614,7 @@ accept_resolve_cb(struct neat_resolver_results *results,
     neat_protocol_stack_type stacks[NEAT_STACK_MAX_NUM];
     neat_flow *flow = user_data;
     struct neat_ctx *ctx = flow->ctx;
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     if (code != NEAT_RESOLVER_OK) {
         neat_io_error(ctx, flow, code);
@@ -3636,8 +3636,8 @@ accept_resolve_cb(struct neat_resolver_results *results,
     json_t *empty_obj = json_object();
     if (json_equal(flow->properties, empty_obj)) {
         // No properties specified, listen to all available protocols
-        neat_log(NEAT_LOG_DEBUG, "No properties specifying protocols to listen for");
-        neat_log(NEAT_LOG_DEBUG, "Listening to all protocols...");
+        neat_log(ctx, NEAT_LOG_DEBUG, "No properties specifying protocols to listen for");
+        neat_log(ctx, NEAT_LOG_DEBUG, "Listening to all protocols...");
 
         nr_of_stacks = 0;
         stacks[nr_of_stacks++] = NEAT_STACK_UDP;
@@ -3679,7 +3679,7 @@ accept_resolve_cb(struct neat_resolver_results *results,
             continue;
 #if defined(__NetBSD__) || defined(__APPLE__)
         } else if (stacks[i] == NEAT_STACK_UDPLITE) {
-            neat_log(NEAT_LOG_DEBUG, "UDPLite not supported on this platform");
+            neat_log(ctx, NEAT_LOG_DEBUG, "UDPLite not supported on this platform");
             continue;
 #endif
         }
@@ -3760,7 +3760,7 @@ accept_resolve_cb(struct neat_resolver_results *results,
         encaps.sue_port              = htons(SCTP_UDP_TUNNELING_PORT);
 
         if (usrsctp_setsockopt(sctp_socket->usrsctp_socket, IPPROTO_SCTP, SCTP_REMOTE_UDP_ENCAPS_PORT, (const void*)&encaps, (socklen_t)sizeof(struct sctp_udpencaps)) != 0) {
-            neat_log(NEAT_LOG_DEBUG, "Unable to set UDP encapsulation port");
+            neat_log(ctx, NEAT_LOG_DEBUG, "Unable to set UDP encapsulation port");
         }
     }
 #else // ifdef USRSCTP_SUPPORT
@@ -3775,13 +3775,13 @@ accept_resolve_cb(struct neat_resolver_results *results,
 
         if (setsockopt(sctp_socket->fd, IPPROTO_SCTP, SCTP_REMOTE_UDP_ENCAPS_PORT,
                        (const void*)&encaps, (socklen_t)sizeof(struct sctp_udpencaps)) != 0) {
-            neat_log(NEAT_LOG_DEBUG, "Unable to set UDP encapsulation port");
+            neat_log(ctx, NEAT_LOG_DEBUG, "Unable to set UDP encapsulation port");
         }
     }
 
 #else // if defined(__FreeBSD__)
     if (sctp_udp_encaps && sctp_socket) {
-        neat_log(NEAT_LOG_DEBUG, "SCTP/UDP encapsulation not available");
+        neat_log(ctx, NEAT_LOG_DEBUG, "SCTP/UDP encapsulation not available");
     }
 #endif // if defined(__FreeBSD__)
 #endif // ifdef else USRSCTP_SUPPORT
@@ -3797,7 +3797,7 @@ neat_accept(struct neat_ctx *ctx, struct neat_flow *flow,
     neat_protocol_stack_type stacks[NEAT_STACK_MAX_NUM]; /* We only support SCTP, TCP, UDP, and UDPLite */
     uint8_t nr_of_stacks;
     int stream_count = 0;
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     nr_of_stacks = neat_property_translate_protocols(flow->propertyMask, stacks);
 
@@ -3815,7 +3815,7 @@ neat_accept(struct neat_ctx *ctx, struct neat_flow *flow,
 
     if (stream_count > 0) {
         flow->streams_requested = stream_count;
-        neat_log(NEAT_LOG_DEBUG, "%s - %d streams", __func__, flow->streams_requested);
+        neat_log(ctx, NEAT_LOG_DEBUG, "%s - %d streams", __func__, flow->streams_requested);
     }
 
     if (!local_name)
@@ -3859,7 +3859,7 @@ neat_write_flush(struct neat_ctx *ctx, struct neat_flow *flow)
     char cmsgbuf[CMSG_SPACE(sizeof(struct sctp_sndrcvinfo))];
     struct sctp_sndrcvinfo *sndrcvinfo;
 #endif
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     if (TAILQ_EMPTY(&flow->bufferedMessages)) {
         return NEAT_OK;
@@ -3927,16 +3927,16 @@ neat_write_flush(struct neat_ctx *ctx, struct neat_flow *flow)
             } else {
 #if defined(USRSCTP_SUPPORT)
                 if (neat_base_stack(flow->socket->stack) == NEAT_STACK_SCTP) {
-                    neat_log(NEAT_LOG_INFO, "%s - send %zd bytes on flow %p and socket %p", __func__, msg->bufferedSize, (void *)flow, (void *)flow->socket->usrsctp_socket);
+                    neat_log(ctx, NEAT_LOG_INFO, "%s - send %zd bytes on flow %p and socket %p", __func__, msg->bufferedSize, (void *)flow, (void *)flow->socket->usrsctp_socket);
                     rv = usrsctp_sendv(flow->socket->usrsctp_socket, msg->buffered + msg->bufferedOffset, msg->bufferedSize,
                                        (struct sockaddr *) (flow->sockAddr), 1, (void *)sndinfo,
                                        (socklen_t)sizeof(struct sctp_sndinfo), SCTP_SENDV_SNDINFO,
                                        0);
                 } else {
-                    neat_log(NEAT_LOG_ERROR, "%s - fd == -1 and no SCTP used ... error!", __func__);
+                    neat_log(ctx, NEAT_LOG_ERROR, "%s - fd == -1 and no SCTP used ... error!", __func__);
                 }
 #else
-                neat_log(NEAT_LOG_ERROR, "%s - fd == -1 and not usrsctp support - fixme!", __func__);
+                neat_log(ctx, NEAT_LOG_ERROR, "%s - fd == -1 and not usrsctp support - fixme!", __func__);
                 assert(false);
 #endif
             }
@@ -3966,7 +3966,7 @@ neat_write_fillbuffer(struct neat_ctx *ctx, struct neat_flow *flow,
                                  const unsigned char *buffer, uint32_t amt, int stream_id)
 {
     struct neat_buffered_message *msg;
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     // TODO: A better implementation here is a linked list of buffers
     // but this gets us started
@@ -4059,7 +4059,7 @@ neat_write_to_lower_layer(struct neat_ctx *ctx, struct neat_flow *flow,
     struct sctp_sndrcvinfo *sndrcvinfo;
     memset(&cmsgbuf, 0, sizeof(cmsgbuf));
 #endif
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     HANDLE_OPTIONAL_ARGUMENTS_START()
         OPTIONAL_INTEGER_PRESENT(NEAT_TAG_STREAM_ID, stream_id, has_stream_id)
@@ -4072,15 +4072,15 @@ neat_write_to_lower_layer(struct neat_ctx *ctx, struct neat_flow *flow,
     HANDLE_OPTIONAL_ARGUMENTS_END();
 
     if (has_stream_id && stream_id < 0) {
-        neat_log(NEAT_LOG_DEBUG, "Invalid stream id: Must be 0 or greater");
+        neat_log(ctx, NEAT_LOG_DEBUG, "Invalid stream id: Must be 0 or greater");
         return NEAT_ERROR_BAD_ARGUMENT;
     } else if (has_stream_id && flow->socket->sctp_streams_available == 1 && stream_id != 0) {
-        neat_log(NEAT_LOG_DEBUG, "Tried to specify stream id when only a single stream is in use. Ignoring.");
+        neat_log(ctx, NEAT_LOG_DEBUG, "Tried to specify stream id when only a single stream is in use. Ignoring.");
         stream_id = 0;
     } else if (has_stream_id && flow->socket->stack != NEAT_STACK_SCTP) {
         // For now, warn about this. Maybe we emulate multistreaming over TCP in
         // the future?
-        neat_log(NEAT_LOG_DEBUG, "Tried to specify stream id when using a protocol which does not support multistreaming. Ignoring.");
+        neat_log(ctx, NEAT_LOG_DEBUG, "Tried to specify stream id when using a protocol which does not support multistreaming. Ignoring.");
         stream_id = 0;
     }
 
@@ -4186,7 +4186,7 @@ neat_write_to_lower_layer(struct neat_ctx *ctx, struct neat_flow *flow,
             rv = sendmsg(flow->socket->fd, (const struct msghdr *)&msghdr, 0);
         } else {
 #if defined(USRSCTP_SUPPORT)
-            neat_log(NEAT_LOG_INFO, "%s - send %zd bytes on flow %p and socket %p", __func__, len, (void *)flow, (void *)flow->socket->usrsctp_socket);
+            neat_log(ctx, NEAT_LOG_INFO, "%s - send %zd bytes on flow %p and socket %p", __func__, len, (void *)flow, (void *)flow->socket->usrsctp_socket);
             rv = usrsctp_sendv(flow->socket->usrsctp_socket, buffer, len, NULL, 0,
                   (void *)sndinfo, (socklen_t)sizeof(struct sctp_sndinfo), SCTP_SENDV_SNDINFO,
                   0);
@@ -4196,12 +4196,12 @@ neat_write_to_lower_layer(struct neat_ctx *ctx, struct neat_flow *flow,
         }
 #ifdef IPPROTO_SCTP
         if (flow->socket->stack == NEAT_STACK_SCTP) {
-            neat_log(NEAT_LOG_DEBUG, "%zd bytes sent on stream %d", rv, stream_id);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%zd bytes sent on stream %d", rv, stream_id);
         } else {
-            neat_log(NEAT_LOG_DEBUG, "%zd bytes sent", rv);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%zd bytes sent", rv);
         }
 #else
-        neat_log(NEAT_LOG_DEBUG, "%zd bytes sent", rv);
+        neat_log(ctx, NEAT_LOG_DEBUG, "%zd bytes sent", rv);
 #endif
         if (rv < 0 ) {
             if (errno != EWOULDBLOCK) {
@@ -4247,7 +4247,7 @@ neat_read_from_lower_layer(struct neat_ctx *ctx, struct neat_flow *flow,
     struct neat_read_queue_message *multistream_message = NULL;
 #endif // SCTP_MULTISTREAMING
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     HANDLE_OPTIONAL_ARGUMENTS_START()
         SKIP_OPTARG(NEAT_TAG_STREAM_ID)
@@ -4267,11 +4267,11 @@ neat_read_from_lower_layer(struct neat_ctx *ctx, struct neat_flow *flow,
 
 
                 if (flow->multistream_reset_in) {
-                    neat_log(NEAT_LOG_DEBUG, "%s - read queue empty, got incoming stream reset, returning 0", __func__);
+                    neat_log(ctx, NEAT_LOG_DEBUG, "%s - read queue empty, got incoming stream reset, returning 0", __func__);
                     *actualAmt = 0;
                     goto end;
                 } else {
-                    neat_log(NEAT_LOG_WARNING, "%s - read queue empty - would block", __func__);
+                    neat_log(ctx, NEAT_LOG_WARNING, "%s - read queue empty - would block", __func__);
                     return NEAT_ERROR_WOULD_BLOCK;
                 }
             }
@@ -4279,11 +4279,11 @@ neat_read_from_lower_layer(struct neat_ctx *ctx, struct neat_flow *flow,
             multistream_message = TAILQ_FIRST(&flow->multistream_read_queue);
 
             if (amt < multistream_message->buffer_size) {
-                neat_log(NEAT_LOG_WARNING, "%s - Message too big", __func__);
+                neat_log(ctx, NEAT_LOG_WARNING, "%s - Message too big", __func__);
                 return NEAT_ERROR_MESSAGE_TOO_BIG;
             }
 
-            neat_log(NEAT_LOG_DEBUG, "%s - reading from multistream flow - stream_id %d", __func__, flow->multistream_id);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s - reading from multistream flow - stream_id %d", __func__, flow->multistream_id);
 
             memcpy(buffer, multistream_message->buffer, multistream_message->buffer_size);
             *actualAmt = multistream_message->buffer_size;
@@ -4299,7 +4299,7 @@ neat_read_from_lower_layer(struct neat_ctx *ctx, struct neat_flow *flow,
                 return NEAT_ERROR_WOULD_BLOCK;
             }
             if (flow->readBufferSize > amt) {
-                neat_log(NEAT_LOG_DEBUG, "%s: Message too big", __func__);
+                neat_log(ctx, NEAT_LOG_DEBUG, "%s: Message too big", __func__);
                 return NEAT_ERROR_MESSAGE_TOO_BIG;
             }
 
@@ -4314,22 +4314,22 @@ neat_read_from_lower_layer(struct neat_ctx *ctx, struct neat_flow *flow,
     }
 
     rv = recv(flow->socket->fd, buffer, amt, 0);
-    neat_log(NEAT_LOG_DEBUG, "%s %d", __func__, rv);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s %d", __func__, rv);
     if (rv == -1 && errno == EWOULDBLOCK){
-        neat_log(NEAT_LOG_DEBUG, "%s would block", __func__);
+        neat_log(ctx, NEAT_LOG_DEBUG, "%s would block", __func__);
         return NEAT_ERROR_WOULD_BLOCK;
     }
     if (rv == -1) {
         if (errno == ECONNRESET) {
-            neat_log(NEAT_LOG_ERROR, "%s: ECONNRESET", __func__);
+            neat_log(ctx, NEAT_LOG_ERROR, "%s: ECONNRESET", __func__);
             neat_notify_aborted(flow);
         } else {
-            neat_log(NEAT_LOG_ERROR, "%s: err %d (%s)", __func__,
+            neat_log(ctx, NEAT_LOG_ERROR, "%s: err %d (%s)", __func__,
                      errno, strerror(errno));
         }
         return NEAT_ERROR_IO;
     }
-    neat_log(NEAT_LOG_DEBUG, "%s %d", __func__, rv);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s %d", __func__, rv);
     *actualAmt = rv;
 
     /*Update flow statistics */
@@ -4365,7 +4365,7 @@ end:
 static int
 neat_accept_via_kernel(struct neat_ctx *ctx, struct neat_flow *flow, int fd)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     return accept(fd, NULL, NULL);
 }
@@ -4423,13 +4423,13 @@ neat_connect(struct neat_he_candidate *candidate, uv_poll_cb callback_fx)
 #ifdef __linux__
     char if_name[IF_NAMESIZE];
 #endif
-
+    struct neat_ctx *ctx = candidate->ctx;
     socklen_t slen =
             (candidate->pollable_socket->family == AF_INET) ?
                 sizeof (struct sockaddr_in) :
                 sizeof (struct sockaddr_in6);
     char addrsrcbuf[INET6_ADDRSTRLEN];
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
 #if defined(USRSCTP_SUPPORT)
     if (neat_base_stack(candidate->pollable_socket->stack) == NEAT_STACK_SCTP) {
@@ -4438,14 +4438,14 @@ neat_connect(struct neat_he_candidate *candidate, uv_poll_cb callback_fx)
 #endif
     protocol = neat_stack_to_protocol(neat_base_stack(candidate->pollable_socket->stack));
     if (protocol == 0) {
-        neat_log(NEAT_LOG_ERROR, "Stack %d not supported", candidate->pollable_socket->stack);
+        neat_log(ctx, NEAT_LOG_ERROR, "Stack %d not supported", candidate->pollable_socket->stack);
         return -1;
     }
     if ((candidate->pollable_socket->fd =
                             socket(candidate->pollable_socket->family,
                                    candidate->pollable_socket->type,
                                    protocol)) < 0) {
-        neat_log(NEAT_LOG_ERROR, "Failed to create he socket");
+        neat_log(ctx, NEAT_LOG_ERROR, "Failed to create he socket");
         return -1;
     }
     setsockopt(candidate->pollable_socket->fd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int));
@@ -4481,7 +4481,7 @@ neat_connect(struct neat_he_candidate *candidate, uv_poll_cb callback_fx)
         free (tmp);
 #if defined(HAVE_SCTP) && !defined (USRSCTP_SUPPORT)
         if (sctp_bindx(candidate->pollable_socket->fd, (struct sockaddr *)candidate->pollable_socket->local_addr, candidate->pollable_socket->nr_local_addr, SCTP_BINDX_ADD_ADDR)) {
-            neat_log(NEAT_LOG_ERROR,
+            neat_log(ctx, NEAT_LOG_ERROR,
                     "Failed to bindx fd %d socket to IP. Error: %s",
                     candidate->pollable_socket->fd,
                     strerror(errno));
@@ -4494,13 +4494,13 @@ neat_connect(struct neat_he_candidate *candidate, uv_poll_cb callback_fx)
         } else {
             inet_ntop(AF_INET6, &(((struct sockaddr_in6 *) &(candidate->pollable_socket->src_sockaddr))->sin6_addr), addrsrcbuf, INET6_ADDRSTRLEN);
         }
-        neat_log(NEAT_LOG_INFO, "%s: Bind fd %d to %s", __func__, candidate->pollable_socket->fd, addrsrcbuf);
+        neat_log(ctx, NEAT_LOG_INFO, "%s: Bind fd %d to %s", __func__, candidate->pollable_socket->fd, addrsrcbuf);
 
         /* Bind to address + interface (if Linux) */
         if (bind(candidate->pollable_socket->fd,
                  (struct sockaddr*) &(candidate->pollable_socket->src_sockaddr),
                  candidate->pollable_socket->src_len)) {
-            neat_log(NEAT_LOG_ERROR,
+            neat_log(ctx, NEAT_LOG_ERROR,
                      "Failed to bind fd %d socket to IP. Error: %s",
                      candidate->pollable_socket->fd,
                      strerror(errno));
@@ -4516,7 +4516,7 @@ neat_connect(struct neat_he_candidate *candidate, uv_poll_cb callback_fx)
                        if_name,
                        strlen(if_name)) < 0) {
             //Not a critical error
-            neat_log(NEAT_LOG_WARNING,
+            neat_log(ctx, NEAT_LOG_WARNING,
                      "Could not bind fd %d socket to interface %s",
                      candidate->pollable_socket->fd, if_name);
         }
@@ -4549,13 +4549,13 @@ neat_connect(struct neat_he_candidate *candidate, uv_poll_cb callback_fx)
 #if defined(__FreeBSD__) && defined(FLOW_GROUPS)
         group = candidate->pollable_socket->flow->group;
         if (setsockopt(candidate->pollable_socket->fd, IPPROTO_TCP, 8192 /* Group ID */, &group, sizeof(int)) != 0) {
-            neat_log(NEAT_LOG_DEBUG, "Unable to set flow group: %s", strerror(errno));
+            neat_log(ctx, NEAT_LOG_DEBUG, "Unable to set flow group: %s", strerror(errno));
         }
 
         // Map the priority range to some integer range
         prio = candidate->pollable_socket->flow->priority * 255;
         if (setsockopt(candidate->pollable_socket->fd, IPPROTO_TCP, 4096 /* Priority */, &prio, sizeof(int)) != 0) {
-            neat_log(NEAT_LOG_DEBUG, "Unable to set flow priority: %s", strerror(errno));
+            neat_log(ctx, NEAT_LOG_DEBUG, "Unable to set flow priority: %s", strerror(errno));
         }
 #endif
 
@@ -4563,7 +4563,7 @@ neat_connect(struct neat_he_candidate *candidate, uv_poll_cb callback_fx)
         if (candidate->pollable_socket->flow->cc_algorithm) {
             algo = candidate->pollable_socket->flow->cc_algorithm;
             if (setsockopt(candidate->pollable_socket->fd, IPPROTO_TCP, TCP_CONGESTION, algo, strlen(algo)) != 0) {
-                neat_log(NEAT_LOG_DEBUG, "Unable to set CC algorithm: %s", strerror(errno));
+                neat_log(ctx, NEAT_LOG_DEBUG, "Unable to set CC algorithm: %s", strerror(errno));
             }
         }
 #endif
@@ -4627,7 +4627,7 @@ neat_connect(struct neat_he_candidate *candidate, uv_poll_cb callback_fx)
                         SCTP_RECVRCVINFO,
                         &enable,
                         sizeof(int)) < 0) {
-            neat_log(NEAT_LOG_ERROR, "Call to setsockopt(SCTP_RECVRCVINFO) failed");
+            neat_log(ctx, NEAT_LOG_ERROR, "Call to setsockopt(SCTP_RECVRCVINFO) failed");
             return -1;
         }
 #endif // defined(SCTP_RECVRCVINFO)
@@ -4638,7 +4638,7 @@ neat_connect(struct neat_he_candidate *candidate, uv_poll_cb callback_fx)
                         SCTP_RECVNXTINFO,
                         &enable,
                         sizeof(int)) < 0) {
-            neat_log(NEAT_LOG_ERROR, "Call to setsockopt(SCTP_RECVNXTINFO) failed");
+            neat_log(ctx, NEAT_LOG_ERROR, "Call to setsockopt(SCTP_RECVNXTINFO) failed");
             return -1;
         }
 #endif // defined(SCTP_RECVRCVINFO)
@@ -4652,7 +4652,7 @@ neat_connect(struct neat_he_candidate *candidate, uv_poll_cb callback_fx)
                         SCTP_ADAPTATION_LAYER,
                         &adaptation,
                         sizeof(adaptation)) < 0) {
-            neat_log(NEAT_LOG_ERROR, "Call to setsockopt(SCTP_ADAPTATION_LAYER) failed");
+            neat_log(ctx, NEAT_LOG_ERROR, "Call to setsockopt(SCTP_ADAPTATION_LAYER) failed");
             return -1;
         }
 #ifdef SCTP_MULTISTREAMING
@@ -4670,7 +4670,7 @@ neat_connect(struct neat_he_candidate *candidate, uv_poll_cb callback_fx)
                         SCTP_ENABLE_STREAM_RESET,
                         &assoc_value,
                         sizeof(assoc_value)) < 0) {
-            neat_log(NEAT_LOG_ERROR, "Call to setsockopt(SCTP_ENABLE_STREAM_RESET) failed");
+            neat_log(ctx, NEAT_LOG_ERROR, "Call to setsockopt(SCTP_ENABLE_STREAM_RESET) failed");
             return -1;
         }
 #endif // defined(SCTP_ENABLE_STREAM_RESET)
@@ -4694,11 +4694,11 @@ neat_connect(struct neat_he_candidate *candidate, uv_poll_cb callback_fx)
                        SCTP_INITMSG,
                        &init,
                        sizeof(struct sctp_initmsg)) < 0) {
-            neat_log(NEAT_LOG_ERROR, "Call to setsockopt(SCTP_INITMSG) failed - Unable to set inbound/outbound stream count");
+            neat_log(ctx, NEAT_LOG_ERROR, "Call to setsockopt(SCTP_INITMSG) failed - Unable to set inbound/outbound stream count");
             return -1;
         }
 
-        neat_log(NEAT_LOG_DEBUG, "SCTP stream negotiation - offering : %d in / %d out", init.sinit_max_instreams, init.sinit_num_ostreams);
+        neat_log(ctx, NEAT_LOG_DEBUG, "SCTP stream negotiation - offering : %d in / %d out", init.sinit_max_instreams, init.sinit_num_ostreams);
 #endif //defined(SCTP_INITMSG)
     }
 #endif //defined(IPPROTO_SCTP)
@@ -4717,7 +4717,7 @@ neat_connect(struct neat_he_candidate *candidate, uv_poll_cb callback_fx)
                      (struct sockaddr *) &(candidate->pollable_socket->dst_sockaddr),
                      slen);
     if (retval && errno != EINPROGRESS) {
-        neat_log(NEAT_LOG_DEBUG,
+        neat_log(ctx, NEAT_LOG_DEBUG,
                  "%s: Connect failed for fd %d connect error (%d): %s",
                  __func__,
                  candidate->pollable_socket->fd,
@@ -4738,13 +4738,13 @@ neat_connect(struct neat_he_candidate *candidate, uv_poll_cb callback_fx)
 static int
 neat_close_via_kernel(struct neat_ctx *ctx, struct neat_flow *flow)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
     if (flow->socket->fd != -1) {
         // we might want a fx callback here to split between
         // kernel and userspace.. same for connect read and write
 
         if (flow->socket->fd != 0) {
-            neat_log(NEAT_LOG_DEBUG, "%s: Close fd %d", __func__, flow->socket->fd);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s: Close fd %d", __func__, flow->socket->fd);
             close(flow->socket->fd);
         }
 
@@ -4758,11 +4758,11 @@ neat_close_via_kernel(struct neat_ctx *ctx, struct neat_flow *flow)
 }
 
 static int
-neat_close_via_kernel_2(int fd)
+neat_close_via_kernel_2(struct neat_ctx *ctx, int fd)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
     if (fd != -1) {
-        neat_log(NEAT_LOG_DEBUG, "%s: Close fd %d", __func__, fd);
+        neat_log(ctx, NEAT_LOG_DEBUG, "%s: Close fd %d", __func__, fd);
         close(fd);
     }
     return 0;
@@ -4782,47 +4782,47 @@ neat_listen_via_kernel(struct neat_ctx *ctx, struct neat_flow *flow,
 
     const socklen_t slen = (listen_socket->family == AF_INET) ? sizeof (struct sockaddr_in) : sizeof (struct sockaddr_in6);
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     protocol = neat_stack_to_protocol(neat_base_stack(listen_socket->stack));
     if (protocol == 0) {
-        neat_log(NEAT_LOG_ERROR, "Stack %d not supported", listen_socket->stack);
+        neat_log(ctx, NEAT_LOG_ERROR, "Stack %d not supported", listen_socket->stack);
         return -1;
     }
 
     if ((fd = socket(listen_socket->family, listen_socket->type, protocol)) < 0) {
-        neat_log(NEAT_LOG_ERROR, "%s: opening listening socket failed - %s", __func__, strerror(errno));
+        neat_log(ctx, NEAT_LOG_ERROR, "%s: opening listening socket failed - %s", __func__, strerror(errno));
         return -1;
     }
 
     if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int)) != 0) {
-        neat_log(NEAT_LOG_DEBUG, "Unable to set socket option SOL_SOCKET:SO_REUSEADDR");
+        neat_log(ctx, NEAT_LOG_DEBUG, "Unable to set socket option SOL_SOCKET:SO_REUSEADDR");
     }
     if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &enable, sizeof(int)) != 0) {
-        neat_log(NEAT_LOG_DEBUG, "Unable to set socket option SOL_SOCKET:SO_REUSEPORT");
+        neat_log(ctx, NEAT_LOG_DEBUG, "Unable to set socket option SOL_SOCKET:SO_REUSEPORT");
     }
 
     len = (socklen_t)sizeof(int);
     if (getsockopt(fd, SOL_SOCKET, SO_SNDBUF, &size, &len) == 0) {
         listen_socket->write_size = size;
     } else {
-        neat_log(NEAT_LOG_DEBUG, "Unable to get socket option SOL_SOCKET:SO_SNDBUF");
+        neat_log(ctx, NEAT_LOG_DEBUG, "Unable to get socket option SOL_SOCKET:SO_SNDBUF");
         listen_socket->write_size = 0;
     }
 
     len = (socklen_t)sizeof(int);
     if (getsockopt(fd, SOL_SOCKET, SO_RCVBUF, &size, &len) == 0) {
-        neat_log(NEAT_LOG_INFO, "%s - RCVBUF %d", __func__, size);
+        neat_log(ctx, NEAT_LOG_INFO, "%s - RCVBUF %d", __func__, size);
         listen_socket->read_size = size;
     } else {
-        neat_log(NEAT_LOG_DEBUG, "Unable to get socket option SOL_SOCKET:SO_RCVBUF");
+        neat_log(ctx, NEAT_LOG_DEBUG, "Unable to get socket option SOL_SOCKET:SO_RCVBUF");
         listen_socket->read_size = 0;
     }
 
     switch (listen_socket->stack) {
     case NEAT_STACK_TCP:
         if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &enable, sizeof(int)) != 0)
-            neat_log(NEAT_LOG_DEBUG, "Unable to set socket option IPPROTO_TCP:TCP_NODELAY");
+            neat_log(ctx, NEAT_LOG_DEBUG, "Unable to set socket option IPPROTO_TCP:TCP_NODELAY");
         break;
     case NEAT_STACK_SCTP_UDP:
 #if defined(__FreeBSD__)
@@ -4831,11 +4831,11 @@ neat_listen_via_kernel(struct neat_ctx *ctx, struct neat_flow *flow,
             memset(&encaps, 0, sizeof(struct sctp_udpencaps));
             encaps.sue_address.ss_family = AF_INET;
             encaps.sue_port = htons(SCTP_UDP_TUNNELING_PORT);
-            neat_log(NEAT_LOG_DEBUG, "Setting UDP encapsulation port to %d", SCTP_UDP_TUNNELING_PORT);
+            neat_log(ctx, NEAT_LOG_DEBUG, "Setting UDP encapsulation port to %d", SCTP_UDP_TUNNELING_PORT);
             if (setsockopt(fd, IPPROTO_SCTP, SCTP_REMOTE_UDP_ENCAPS_PORT, (const void*)&encaps, (socklen_t)sizeof(struct sctp_udpencaps)) != 0)
-                neat_log(NEAT_LOG_DEBUG, "Failed enabling UDP encapsulation!");
+                neat_log(ctx, NEAT_LOG_DEBUG, "Failed enabling UDP encapsulation!");
             else
-                neat_log(NEAT_LOG_DEBUG, "UDP encapsulation enabled");
+                neat_log(ctx, NEAT_LOG_DEBUG, "UDP encapsulation enabled");
         }
 #endif
         // Fallthrough
@@ -4849,7 +4849,7 @@ neat_listen_via_kernel(struct neat_ctx *ctx, struct neat_flow *flow,
         memset(&adaptation, 0, sizeof(adaptation));
         adaptation.ssb_adaptation_ind = SCTP_ADAPTATION_NEAT;
         if (setsockopt(fd, IPPROTO_SCTP, SCTP_ADAPTATION_LAYER, &adaptation, sizeof(adaptation)) < 0) {
-            neat_log(NEAT_LOG_DEBUG, "Call to setsockopt(SCTP_ADAPTATION_LAYER) failed");
+            neat_log(ctx, NEAT_LOG_DEBUG, "Call to setsockopt(SCTP_ADAPTATION_LAYER) failed");
             return -1;
         }
 #endif // defined(SCTP_ADAPTATION_LAYER) && !defined(USRSCTP_SUPPORT)
@@ -4858,7 +4858,7 @@ neat_listen_via_kernel(struct neat_ctx *ctx, struct neat_flow *flow,
         memset(&assoc_value, 0, sizeof(assoc_value));
         assoc_value.assoc_value = SCTP_ENABLE_RESET_STREAM_REQ;
         if (setsockopt(fd, IPPROTO_SCTP, SCTP_ENABLE_STREAM_RESET, &assoc_value, sizeof(assoc_value)) < 0) {
-            neat_log(NEAT_LOG_DEBUG, "Call to setsockopt(SCTP_ENABLE_STREAM_RESET) failed");
+            neat_log(ctx, NEAT_LOG_DEBUG, "Call to setsockopt(SCTP_ENABLE_STREAM_RESET) failed");
             return -1;
         }
 #endif // defined(SCTP_ENABLE_STREAM_RESET) && !defined(USRSCTP_SUPPORT)
@@ -4874,20 +4874,20 @@ neat_listen_via_kernel(struct neat_ctx *ctx, struct neat_flow *flow,
         }
 
         if (setsockopt(fd, IPPROTO_SCTP, SCTP_INITMSG, (char*) &initmsg, sizeof(struct sctp_initmsg)) < 0) {
-            neat_log(NEAT_LOG_ERROR, "Unable to set inbound/outbound stream count");
+            neat_log(ctx, NEAT_LOG_ERROR, "Unable to set inbound/outbound stream count");
         }
-        neat_log(NEAT_LOG_DEBUG, "Offering %d SCTP streams in/out", initmsg.sinit_num_ostreams);
+        neat_log(ctx, NEAT_LOG_DEBUG, "Offering %d SCTP streams in/out", initmsg.sinit_num_ostreams);
 #endif // defined(SCTP_INITMSG) && !defined(USRSCTP_SUPPORT)
         flow->socket->write_limit = flow->socket->write_size / 4;
 #ifdef SCTP_NODELAY
         if (setsockopt(fd, IPPROTO_SCTP, SCTP_NODELAY, &enable, sizeof(int)) != 0)
-            neat_log(NEAT_LOG_DEBUG, "Unable to set socket option IPPROTO_SCTP:SCTP_NODELAY");
+            neat_log(ctx, NEAT_LOG_DEBUG, "Unable to set socket option IPPROTO_SCTP:SCTP_NODELAY");
 #endif
 #ifdef SCTP_EXPLICIT_EOR
         if (setsockopt(fd, IPPROTO_SCTP, SCTP_EXPLICIT_EOR, &enable, sizeof(int)) == 0)
             flow->socket->sctp_explicit_eor = 1;
         else
-            neat_log(NEAT_LOG_DEBUG, "Unable to set socket option IPPROTO_SCTP:SCTP_EXPLICIT_EOR");
+            neat_log(ctx, NEAT_LOG_DEBUG, "Unable to set socket option IPPROTO_SCTP:SCTP_EXPLICIT_EOR");
 #endif
         break;
     default:
@@ -4897,12 +4897,12 @@ neat_listen_via_kernel(struct neat_ctx *ctx, struct neat_flow *flow,
     if (listen_socket->stack == NEAT_STACK_UDP || listen_socket->stack == NEAT_STACK_UDPLITE) {
         if (fd == -1 ||
             bind(fd, (struct sockaddr *)(&listen_socket->src_sockaddr), slen) == -1) {
-            neat_log(NEAT_LOG_ERROR, "%s: (%s) bind failed - %s", __func__, (listen_socket->stack == NEAT_STACK_UDP ? "UDP" : "UDPLite"), strerror(errno));
+            neat_log(ctx, NEAT_LOG_ERROR, "%s: (%s) bind failed - %s", __func__, (listen_socket->stack == NEAT_STACK_UDP ? "UDP" : "UDPLite"), strerror(errno));
             return -1;
         }
     } else {
         if (fd == -1 || bind(fd, (struct sockaddr *)(&listen_socket->src_sockaddr), slen) == -1 || listen(fd, 100) == -1) {
-            neat_log(NEAT_LOG_ERROR, "%s: bind/listen failed - %s", __func__, strerror(errno));
+            neat_log(ctx, NEAT_LOG_ERROR, "%s: bind/listen failed - %s", __func__, strerror(errno));
             return -1;
         }
     }
@@ -4917,7 +4917,7 @@ neat_shutdown_via_kernel(struct neat_ctx *ctx, struct neat_flow *flow)
     neat_flow *flow_itr = NULL;
 #endif // SCTP_MULTISTREAMING
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     // check for all multistream flows if they are ready to shutdown/close
     if (flow->socket->multistream) {
@@ -4925,7 +4925,7 @@ neat_shutdown_via_kernel(struct neat_ctx *ctx, struct neat_flow *flow)
 
         // check if shutdown was alread called
         if (flow->multistream_shutdown) {
-            neat_log(NEAT_LOG_DEBUG, "%s - shutdown already called, skipping", __func__);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s - shutdown already called, skipping", __func__);
             return NEAT_OK;
         }
 
@@ -4934,12 +4934,12 @@ neat_shutdown_via_kernel(struct neat_ctx *ctx, struct neat_flow *flow)
 
         LIST_FOREACH(flow_itr, &flow->socket->sctp_multistream_flows, multistream_next_flow) {
             if (flow_itr->multistream_state != NEAT_FLOW_CLOSED) {
-                neat_log(NEAT_LOG_DEBUG, "%s - not all streams closed, skipping socket shutdown", __func__);
+                neat_log(ctx, NEAT_LOG_DEBUG, "%s - not all streams closed, skipping socket shutdown", __func__);
                 return NEAT_OK;
             }
         }
 
-        neat_log(NEAT_LOG_INFO, "%s - all streames in closed state, calling socket shutdown", __func__);
+        neat_log(ctx, NEAT_LOG_INFO, "%s - all streames in closed state, calling socket shutdown", __func__);
 
 
 #else // SCTP_MULTISTREAMING
@@ -4960,7 +4960,7 @@ static void neat_sctp_init_events(struct socket *sock)
 static void neat_sctp_init_events(int sock)
 #endif
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    //neat_log(NEAT_LOG_DEBUG, "%s", __func__);
 
 #if defined(IPPROTO_SCTP)
 #if defined(SCTP_EVENT)
@@ -4991,7 +4991,7 @@ static void neat_sctp_init_events(int sock)
         if (setsockopt(
 #endif
         sock, IPPROTO_SCTP, SCTP_EVENT, &event, sizeof(struct sctp_event)) < 0) {
-            neat_log(NEAT_LOG_ERROR, "%s: failed to subscribe to event type %u - %s", __func__, event_types[i], strerror(errno));
+            //neat_log(NEAT_LOG_ERROR, "%s: failed to subscribe to event type %u - %s", __func__, event_types[i], strerror(errno));
         }
     }
 #else // defined(SCTP_EVENT)
@@ -5011,7 +5011,7 @@ static void neat_sctp_init_events(int sock)
     event.sctp_adaptation_layer_event = 1;
 
     if (setsockopt(sock, IPPROTO_SCTP, SCTP_EVENTS, &event, sizeof(struct sctp_event_subscribe)) < 0) {
-        neat_log(NEAT_LOG_ERROR, "%s: failed to subscribe to SCTP events - %s", __func__, strerror(errno));
+        //neat_log(NEAT_LOG_ERROR, "%s: failed to subscribe to SCTP events - %s", __func__, strerror(errno));
     }
 #endif // else HAVE_SCTP_EVENT_SUBSCRIBE
 #endif //else defined(SCTP_EVENT)
@@ -5456,7 +5456,7 @@ neat_write(struct neat_ctx *ctx, struct neat_flow *flow,
            const unsigned char *buffer, uint32_t amt,
            struct neat_tlv optional[], unsigned int opt_count)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
 #ifdef SCTP_MULTISTREAMING
     assert(flow->multistream_reset_out == false);
@@ -5498,7 +5498,7 @@ neat_read(struct neat_ctx *ctx, struct neat_flow *flow,
           unsigned char *buffer, uint32_t amt, uint32_t *actualAmt,
           struct neat_tlv optional[], unsigned int opt_count)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     *actualAmt = 0;
     neat_error_code rv = flow->readfx(ctx, flow, buffer, amt, actualAmt, optional, opt_count);
@@ -5513,7 +5513,7 @@ neat_read(struct neat_ctx *ctx, struct neat_flow *flow,
 neat_error_code
 neat_shutdown(struct neat_ctx *ctx, struct neat_flow *flow)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 #if defined(USRSCTP_SUPPORT)
     if (neat_base_stack(flow->socket->stack) == NEAT_STACK_SCTP) {
         return neat_shutdown_via_usrsctp(ctx, flow);
@@ -5523,10 +5523,10 @@ neat_shutdown(struct neat_ctx *ctx, struct neat_flow *flow)
 }
 
 neat_flow
-*neat_new_flow(neat_ctx *mgr)
+*neat_new_flow(neat_ctx *ctx)
 {
     neat_flow *rv;
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     rv = (neat_flow *)calloc (1, sizeof (neat_flow));
     if (!rv) {
@@ -5538,7 +5538,6 @@ neat_flow
     rv->acceptfx            = neat_accept_via_kernel;
     rv->connectfx           = neat_connect;
     rv->closefx             = neat_close_socket;
-    rv->close2fx            = neat_close_socket_2;
     rv->listenfx            = NULL; // TODO: Consider reimplementing
     rv->shutdownfx          = neat_shutdown_via_kernel;
 #if defined(USRSCTP_SUPPORT)
@@ -5580,7 +5579,7 @@ neat_flow
     rv->flow_stats.bytes_sent       = 0;
     rv->flow_stats.bytes_received   = 0;
 
-    LIST_INSERT_HEAD(&mgr->flows, rv, next_flow);
+    LIST_INSERT_HEAD(&ctx->flows, rv, next_flow);
 
     return rv;
 error:
@@ -5606,7 +5605,7 @@ void neat_notify_cc_congestion(neat_flow *flow, int ecn, uint32_t rate)
     neat_error_code code = NEAT_ERROR_OK;
     neat_ctx *ctx = flow->ctx;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     if (!flow->operations ||!flow->operations->on_slowdown) {
     return;
@@ -5625,7 +5624,7 @@ void neat_notify_cc_hint(neat_flow *flow, int ecn, uint32_t rate)
     neat_error_code code = NEAT_ERROR_OK;
     neat_ctx *ctx = flow->ctx;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     if (!flow->operations || !flow->operations->on_rate_hint) {
     return;
@@ -5646,7 +5645,7 @@ void neat_notify_send_failure(neat_flow *flow, neat_error_code code,
     //READYCALLBACKSTRUCT expects this:
     neat_ctx *ctx = flow->ctx;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     if (!flow->operations || !flow->operations->on_send_failure) {
         return;
@@ -5664,7 +5663,7 @@ void neat_notify_timeout(neat_flow *flow)
     neat_error_code code = NEAT_ERROR_OK;
     neat_ctx *ctx = flow->ctx;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     if (!flow->operations || !flow->operations->on_timeout) {
         return;
@@ -5683,7 +5682,7 @@ void neat_notify_aborted(neat_flow *flow)
     neat_error_code code = NEAT_ERROR_OK;
     neat_ctx *ctx = flow->ctx;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     if (!flow->operations || !flow->operations->on_aborted) {
         return;
@@ -5701,7 +5700,7 @@ void neat_notify_close(neat_flow *flow)
     neat_error_code code = NEAT_ERROR_OK;
     neat_ctx *ctx = flow->ctx;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
     if (!flow->operations || !flow->operations->on_close) {
         return;
     }
@@ -5718,7 +5717,7 @@ void neat_notify_network_status_changed(neat_flow *flow, neat_error_code code)
     //READYCALLBACKSTRUCT expects this:
     neat_ctx *ctx = flow->ctx;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     if (!flow->operations || !flow->operations->on_network_status_changed) {
     return;
@@ -5732,7 +5731,7 @@ void neat_notify_network_status_changed(neat_flow *flow, neat_error_code code)
 neat_error_code
 neat_close(struct neat_ctx *ctx, struct neat_flow *flow)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
 #ifdef SCTP_MULTISTREAMING
     if (flow->socket->multistream && flow->multistream_state == NEAT_FLOW_OPEN) {
@@ -5742,7 +5741,7 @@ neat_close(struct neat_ctx *ctx, struct neat_flow *flow)
     }
 
     if (!flow->socket->multistream || flow->socket->sctp_streams_used == 0) {
-        neat_log(NEAT_LOG_DEBUG, "%s - not multistream socket or all streams closed", __func__);
+        neat_log(ctx, NEAT_LOG_DEBUG, "%s - not multistream socket or all streams closed", __func__);
 #endif // SCTP_MULTISTREAMING
         if (flow->isPolling && uv_is_active((uv_handle_t*)flow->socket->handle)) {
             uv_poll_stop(flow->socket->handle);
@@ -5779,7 +5778,7 @@ neat_flow *
 neat_find_flow(neat_ctx *ctx, struct sockaddr_storage *src, struct sockaddr_storage *dst)
 {
     neat_flow *flow;
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     LIST_FOREACH(flow, &ctx->flows, next_flow) {
         if (flow->socket == NULL)
@@ -5807,26 +5806,26 @@ struct neat_pollable_socket *
 neat_find_multistream_socket(neat_ctx *ctx, neat_flow *new_flow)
 {
     neat_flow *flow_itr;
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     LIST_FOREACH(flow_itr, &ctx->flows, next_flow) {
         //neat_log(NEAT_LOG_DEBUG, "%s - checking: %p - %s", __func__, flow, flow->name);
 
         // skipping self
         if (flow_itr == new_flow) {
-            neat_log(NEAT_LOG_DEBUG, "%s - %p : skipping - self...", __func__, flow_itr);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s - %p : skipping - self...", __func__, flow_itr);
             continue;
         }
 
         // flow should have a socket
         if (flow_itr->socket->fd < 1) {
-            neat_log(NEAT_LOG_DEBUG, "%s - %p : skipping - no socket fd", __func__, flow_itr);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s - %p : skipping - no socket fd", __func__, flow_itr);
             continue;
         }
 
         // xxx todo : check needed?
         if (flow_itr->acceptPending == 1) {
-            neat_log(NEAT_LOG_DEBUG, "%s - %p : skipping - accept pending", __func__, flow_itr);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s - %p : skipping - accept pending", __func__, flow_itr);
             continue;
         }
 
@@ -5837,12 +5836,12 @@ neat_find_multistream_socket(neat_ctx *ctx, neat_flow *new_flow)
             flow_itr->socket->sctp_neat_peer == 1 &&
             flow_itr->socket->sctp_streams_used < flow_itr->socket->sctp_streams_available
         ) {
-            neat_log(NEAT_LOG_DEBUG, "%s - %p : match!", __func__, flow_itr);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s - %p : match!", __func__, flow_itr);
             return flow_itr->socket;
         } else {
-            neat_log(NEAT_LOG_DEBUG, "%s - %p : no match!", __func__, flow_itr);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s - %p : no match!", __func__, flow_itr);
 
-            neat_log(NEAT_LOG_WARNING, "%s - %d - %d - %d - %d - %d",
+            neat_log(ctx, NEAT_LOG_WARNING, "%s - %d - %d - %d - %d - %d",
                 __func__, !strcmp(flow_itr->name, new_flow->name), flow_itr->group == new_flow->group, flow_itr->socket->stack == NEAT_STACK_SCTP, flow_itr->socket->sctp_neat_peer, flow_itr->socket->sctp_streams_available);
         }
     }
@@ -5856,26 +5855,27 @@ static void
 neat_hook_mulitstream_flows(neat_flow *flow) {
     neat_flow *flow_itr = NULL;
     struct neat_he_candidate *candidate;
+    struct neat_ctx *ctx = flow->ctx;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
     return;
 
     LIST_FOREACH(flow_itr, &(flow->ctx->flows), next_flow) {
-        neat_log(NEAT_LOG_DEBUG, "%s - %p - checking", __func__, flow_itr);
+        neat_log(ctx, NEAT_LOG_DEBUG, "%s - %p - checking", __func__, flow_itr);
 
         // skipping self
         if (flow_itr == flow) {
-            neat_log(NEAT_LOG_DEBUG, "%s - %p : skipping - self...", __func__, flow);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s - %p : skipping - self...", __func__, flow);
             continue;
         }
 
         if (flow_itr->everConnected) {
-            neat_log(NEAT_LOG_DEBUG, "%s - %p - already connected", __func__, flow_itr);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s - %p - already connected", __func__, flow_itr);
         }
 
         // xxx todo : check needed?
         if (flow_itr->acceptPending == 1) {
-            neat_log(NEAT_LOG_DEBUG, "%s - %p : skipping - accept pending", __func__, flow_itr);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s - %p : skipping - accept pending", __func__, flow_itr);
             continue;
         }
 
@@ -5888,13 +5888,13 @@ neat_hook_mulitstream_flows(neat_flow *flow) {
                 // Flow candidates include SCTP
                 if (candidate->pollable_socket->stack == NEAT_STACK_SCTP) {
                     // we have a candidate
-                    neat_log(NEAT_LOG_DEBUG, "%s - %p : candidate matches - waiting", __func__, flow_itr);
+                    neat_log(ctx, NEAT_LOG_DEBUG, "%s - %p : candidate matches - waiting", __func__, flow_itr);
                 } else {
-                    neat_log(NEAT_LOG_DEBUG, "%s - %p : no match for candidate", __func__, flow_itr);
+                    neat_log(ctx, NEAT_LOG_DEBUG, "%s - %p : no match for candidate", __func__, flow_itr);
                 }
             }
         } else {
-            neat_log(NEAT_LOG_DEBUG, "%s - %p - no match", __func__, flow_itr);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s - %p - no match", __func__, flow_itr);
         }
     }
 
@@ -5911,28 +5911,28 @@ neat_wait_for_multistream_socket(neat_ctx *ctx, neat_flow *flow)
     neat_flow *flow_itr;
     struct neat_he_candidate *candidate;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     LIST_FOREACH(flow_itr, &ctx->flows, next_flow) {
-        //neat_log(NEAT_LOG_DEBUG, "%s - checking: %p - %s", __func__, flow_itr, flow_itr->name);
+        //neat_log(ctx, NEAT_LOG_DEBUG, "%s - checking: %p - %s", __func__, flow_itr, flow_itr->name);
 
         // skipping self
         if (flow_itr == flow) {
-            neat_log(NEAT_LOG_DEBUG, "%s - %p : skipping - self...", __func__, flow_itr);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s - %p : skipping - self...", __func__, flow_itr);
             continue;
         }
 
         // flow should have a socket
         /*
         if (flow_itr->socket->fd < 1) {
-            neat_log(NEAT_LOG_DEBUG, "%s - %p : skipping - no socket", __func__, flow_itr);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s - %p : skipping - no socket", __func__, flow_itr);
             continue;
         }
         */
 
         // xxx todo : check needed?
         if (flow_itr->acceptPending == 1) {
-            neat_log(NEAT_LOG_DEBUG, "%s - %p : skipping - accept pending", __func__, flow_itr);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s - %p : skipping - accept pending", __func__, flow_itr);
             continue;
         }
 
@@ -5945,14 +5945,14 @@ neat_wait_for_multistream_socket(neat_ctx *ctx, neat_flow *flow)
                 // Flow candidates include SCTP
                 if (candidate->pollable_socket->stack == NEAT_STACK_SCTP) {
                     // we have a candidate
-                    neat_log(NEAT_LOG_DEBUG, "%s - %p : candidate matches - waiting", __func__, flow_itr);
+                    neat_log(ctx, NEAT_LOG_DEBUG, "%s - %p : candidate matches - waiting", __func__, flow_itr);
                     return 1;
                 } else {
-                    neat_log(NEAT_LOG_DEBUG, "%s - %p : no match for candidate", __func__, flow_itr);
+                    neat_log(ctx, NEAT_LOG_DEBUG, "%s - %p : no match for candidate", __func__, flow_itr);
                 }
             }
         } else {
-            neat_log(NEAT_LOG_DEBUG, "%s - %p - no match", __func__, flow_itr);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s - %p - no match", __func__, flow_itr);
         }
     }
     return 0;
@@ -5965,7 +5965,7 @@ static neat_flow *
 neat_sctp_get_flow_by_sid(struct neat_pollable_socket *socket, uint16_t sid)
 {
     neat_flow *flow;
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    //neat_log(NEAT_LOG_DEBUG, "%s", __func__);
 
     if (!socket->multistream) {
         return NULL;
@@ -5973,7 +5973,7 @@ neat_sctp_get_flow_by_sid(struct neat_pollable_socket *socket, uint16_t sid)
 
     LIST_FOREACH(flow, &socket->sctp_multistream_flows, multistream_next_flow) {
 
-        neat_log(NEAT_LOG_DEBUG, "%s - want %d - have %d", __func__, sid, flow->multistream_id);
+        neat_log(flow->ctx, NEAT_LOG_DEBUG, "%s - want %d - have %d", __func__, sid, flow->multistream_id);
 
         if (flow->multistream_id == sid) {
             return flow;

--- a/neat_he.c
+++ b/neat_he.c
@@ -20,7 +20,7 @@ static void he_print_results(struct neat_resolver_results *results)
     char serv_name_src[6], serv_name_dst[6];
     char family[16];
 
-    neat_log(NEAT_LOG_INFO, "Happy-Eyeballs results:");
+    //neat_log(NEAT_LOG_INFO, "Happy-Eyeballs results:");
 
     LIST_FOREACH(result, results, next_res) {
         switch (result->ai_family) {
@@ -45,23 +45,23 @@ static void he_print_results(struct neat_resolver_results *results)
                     serv_name_dst, sizeof(serv_name_dst),
                     NI_NUMERICHOST | NI_NUMERICSERV);
 
-        neat_log(NEAT_LOG_INFO, "\t%s - %s:%s -> %s:%s", family,
-            addr_name_src, serv_name_src, addr_name_dst, serv_name_dst);
+        //neat_log(NEAT_LOG_INFO, "\t%s - %s:%s -> %s:%s", family,
+        //    addr_name_src, serv_name_src, addr_name_dst, serv_name_dst);
     }
 }
 
 
 static void free_handle_cb(uv_handle_t *handle)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    //neat_log(NEAT_LOG_DEBUG, "%s", __func__);
     free(handle);
 }
 
 
 static void free_prio_timer_handle_cb(uv_handle_t *handle)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
     struct neat_he_candidate *candidate  = (struct neat_he_candidate *) (handle->data);
+    neat_log(candidate->ctx, NEAT_LOG_DEBUG, "%s", __func__);
     free(handle);
     candidate->prio_timer = NULL;
 }
@@ -73,7 +73,8 @@ static void on_he_connect_req(uv_timer_t *handle)
     struct neat_he_candidates *candidate_list = candidate->pollable_socket->flow->candidate_list;
     uint8_t *heConnectAttemptCount            = &(candidate->pollable_socket->flow->heConnectAttemptCount);
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    struct neat_ctx *ctx = candidate->ctx;
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
     uv_timer_stop(candidate->prio_timer);
     candidate->prio_timer->data = candidate;
     uv_close((uv_handle_t *) candidate->prio_timer, free_prio_timer_handle_cb);
@@ -83,7 +84,7 @@ static void on_he_connect_req(uv_timer_t *handle)
                    candidate->callback_fx);
     if ((ret == -1) || (ret == -2)) {
 
-        neat_log(NEAT_LOG_DEBUG, "%s: Connect failed with ret = %d", __func__, ret);
+        neat_log(ctx, NEAT_LOG_DEBUG, "%s: Connect failed with ret = %d", __func__, ret);
         if (ret == -2) {
             uv_close((uv_handle_t *)(candidate->pollable_socket->handle), free_handle_cb);
             candidate->pollable_socket->handle = NULL;
@@ -91,10 +92,10 @@ static void on_he_connect_req(uv_timer_t *handle)
             free(candidate->pollable_socket->handle);
             candidate->pollable_socket->handle = NULL;
         }
-        // neat_log(NEAT_LOG_DEBUG, "%s:Release candidate", __func__ );
+        // neat_log(ctx, NEAT_LOG_DEBUG, "%s:Release candidate", __func__ );
         (*heConnectAttemptCount)--;
 
-        neat_log(NEAT_LOG_DEBUG, "he_conn_attempt: %d", *heConnectAttemptCount);
+        neat_log(ctx, NEAT_LOG_DEBUG, "he_conn_attempt: %d", *heConnectAttemptCount);
 
         if (*heConnectAttemptCount == 0) {
             neat_io_error(candidate->pollable_socket->flow->ctx,
@@ -102,11 +103,11 @@ static void on_he_connect_req(uv_timer_t *handle)
                           NEAT_ERROR_IO);
         } else {
             TAILQ_REMOVE(candidate_list, candidate, next);
-            neat_free_candidate(candidate);
+            neat_free_candidate(ctx, candidate);
         }
     } else {
 
-        neat_log(NEAT_LOG_DEBUG,
+        neat_log(ctx, NEAT_LOG_DEBUG,
             "%s: Connect successful for fd %d, ret = %d",
             __func__,
             candidate->pollable_socket->fd, ret);
@@ -124,7 +125,7 @@ static void delayed_he_connect_req(struct neat_he_candidate *candidate, uv_poll_
     candidate->prio_timer->data = (void *) candidate;
 
 #if 0
-    neat_log(NEAT_LOG_DEBUG,
+    neat_log(ctx, NEAT_LOG_DEBUG,
              "%s: Priority = %d, Delay = %d ms",
              __func__,
              candidate->priority,
@@ -136,8 +137,8 @@ static void delayed_he_connect_req(struct neat_he_candidate *candidate, uv_poll_
 static void
 on_delayed_he_open(uv_timer_t *handle)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s - sctp multistream HE timer fired", __func__);
     struct neat_flow *flow       = (struct neat_flow *) (handle->data);
+    neat_log(flow->ctx, NEAT_LOG_DEBUG, "%s - sctp multistream HE timer fired", __func__);
     uv_timer_stop(flow->multistream_timer);
     uv_close((uv_handle_t *) flow->multistream_timer, free_handle_cb);
 
@@ -197,7 +198,7 @@ neat_he_open(neat_ctx *ctx, neat_flow *flow, struct neat_he_candidates *candidat
             break;
         };
 
-        neat_log(NEAT_LOG_DEBUG, "HE Candidate %2d: %8s [%2d] %8s/%s <saddr %s> <dstaddr %s> port %5d priority %d",
+        neat_log(ctx, NEAT_LOG_DEBUG, "HE Candidate %2d: %8s [%2d] %8s/%s <saddr %s> <dstaddr %s> port %5d priority %d",
                  i++,
                  candidate->if_name,
                  candidate->if_idx,
@@ -210,7 +211,7 @@ neat_he_open(neat_ctx *ctx, neat_flow *flow, struct neat_he_candidates *candidat
 
 #if 0
         char *str = json_dumps(candidate->properties, JSON_INDENT(2));
-        neat_log(NEAT_LOG_DEBUG, "Properties:\n%s", str);
+        neat_log(ctx, NEAT_LOG_DEBUG, "Properties:\n%s", str);
 
         free(str);
 #endif
@@ -225,7 +226,7 @@ neat_he_open(neat_ctx *ctx, neat_flow *flow, struct neat_he_candidates *candidat
 #ifdef SCTP_MULTISTREAMING
         // check if there is already a piggyback assoc
         if ((multistream_socket = neat_find_multistream_socket(ctx, flow)) != NULL) {
-            neat_log(NEAT_LOG_DEBUG, "%s - using piggyback assoc", __func__);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s - using piggyback assoc", __func__);
             // we have a piggyback assoc...
 
             LIST_INSERT_HEAD(&multistream_socket->sctp_multistream_flows, flow, multistream_next_flow);
@@ -255,7 +256,7 @@ neat_he_open(neat_ctx *ctx, neat_flow *flow, struct neat_he_candidates *candidat
 
         // if there is no piggyback assoc, wait if we didnt already : We reschedule the *complete* he-process!
         } else if (flow->multistream_check == 0 && neat_wait_for_multistream_socket(ctx, flow)) {
-            neat_log(NEAT_LOG_DEBUG, "%s - waiting for another assoc", __func__);
+            neat_log(ctx, NEAT_LOG_DEBUG, "%s - waiting for another assoc", __func__);
             flow->multistream_check = 1;
 
             flow->multistream_timer = (uv_timer_t *) calloc(1, sizeof(uv_timer_t));
@@ -276,11 +277,11 @@ neat_he_open(neat_ctx *ctx, neat_flow *flow, struct neat_he_candidates *candidat
     flow->hefirstConnect = 1;
     flow->heConnectAttemptCount = 0;
 
-    neat_log(NEAT_LOG_DEBUG, "HE will now commence");
+    neat_log(ctx, NEAT_LOG_DEBUG, "HE will now commence");
     while (candidate) {
 
 #if 0
-        neat_log(NEAT_LOG_DEBUG, "HE Candidate: %8s [%2d] <saddr %s> <dstaddr %s> port %5d priority %d",
+        neat_log(ctx, NEAT_LOG_DEBUG, "HE Candidate: %8s [%2d] <saddr %s> <dstaddr %s> port %5d priority %d",
                  candidate->if_name,
                  candidate->if_idx,
                  candidate->pollable_socket->src_address,
@@ -322,7 +323,7 @@ neat_he_open(neat_ctx *ctx, neat_flow *flow, struct neat_he_candidates *candidat
             int ret = candidate->pollable_socket->flow->connectfx(candidate, callback_fx);
             if ((ret == -1) || (ret == -2)) {
 
-                neat_log(NEAT_LOG_DEBUG, "%s: Connect failed with ret = %d", __func__, ret);
+                neat_log(ctx, NEAT_LOG_DEBUG, "%s: Connect failed with ret = %d", __func__, ret);
                 if (ret == -2) {
                     uv_close((uv_handle_t *)(candidate->pollable_socket->handle), free_handle_cb);
                     candidate->pollable_socket->handle = NULL;
@@ -330,14 +331,14 @@ neat_he_open(neat_ctx *ctx, neat_flow *flow, struct neat_he_candidates *candidat
                     free(candidate->pollable_socket->handle);
                     candidate->pollable_socket->handle = NULL;
                 }
-                neat_log(NEAT_LOG_DEBUG, "%s:Release candidate", __func__ );
+                neat_log(ctx, NEAT_LOG_DEBUG, "%s:Release candidate", __func__ );
                 next_candidate = TAILQ_NEXT(candidate, next);
                 TAILQ_REMOVE(candidate_list, candidate, next);
-                neat_free_candidate(candidate);
+                neat_free_candidate(ctx, candidate);
                 candidate = next_candidate;
             } else {
 
-                neat_log(NEAT_LOG_DEBUG, "%s: Connect successful for fd %d, ret = %d", __func__, candidate->pollable_socket->fd, ret);
+                neat_log(ctx, NEAT_LOG_DEBUG, "%s: Connect successful for fd %d, ret = %d", __func__, candidate->pollable_socket->fd, ret);
                 candidate->pollable_socket->flow->heConnectAttemptCount++;
                 candidate = TAILQ_NEXT(candidate, next);
 

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -72,6 +72,12 @@ struct neat_ctx
 
     neat_error_code error;
 
+    /* logging members */
+    uint8_t log_level;
+    uint8_t color_supported;
+    struct timeval tv_init;
+    FILE *neat_log_fd;
+
     // resolver
     NEAT_INTERNAL_CTX;
     NEAT_INTERNAL_OS;
@@ -259,7 +265,6 @@ struct neat_flow
     neat_accept_impl    acceptfx;
     neat_connect_impl   connectfx;
     neat_close_impl     closefx;
-    neat_close2_impl    close2fx;
     neat_listen_impl    listenfx;
     neat_shutdown_impl  shutdownfx;
 
@@ -394,8 +399,8 @@ struct cib_he_res {
     int transport;
 };
 
-void neat_free_candidates(struct neat_he_candidates *candidates);
-void neat_free_candidate(struct neat_he_candidate *candidate);
+void neat_free_candidates(struct neat_ctx *ctx, struct neat_he_candidates *candidates);
+void neat_free_candidate(struct neat_ctx *ctx, struct neat_he_candidate *candidate);
 
 // Connect context needed during HE.
 struct he_cb_ctx {
@@ -513,7 +518,7 @@ extern const char *neat_tag_name[NEAT_TAG_LAST];
 #define OPTIONAL_ARGUMENT(tag, var, field, vartype, typestr)\
     case tag:\
              if (optional[i].type != vartype)\
-        neat_log(NEAT_LOG_DEBUG,\
+        neat_log(ctx, NEAT_LOG_DEBUG,\
                  "Optional argument \"%s\" passed to function %s: "\
                  "Expected type %s, specified as something else. "\
                  "Ignoring.", #tag, __func__, #typestr);\
@@ -540,7 +545,7 @@ extern const char *neat_tag_name[NEAT_TAG_LAST];
 #define OPTIONAL_ARGUMENT_PRESENT(tag, var, field, presence, vartype, typestr)\
     case tag:\
         if (optional[i].type != vartype) {\
-            neat_log(NEAT_LOG_DEBUG,\
+            neat_log(ctx, NEAT_LOG_DEBUG,\
                      "Optional argument \"%s\" passed to function %s: "\
                      "Expected type %s, specified as something else. "\
                      "Ignoring.", "stream", #tag, __func__, typestr);\
@@ -561,7 +566,7 @@ extern const char *neat_tag_name[NEAT_TAG_LAST];
 
 #define HANDLE_OPTIONAL_ARGUMENTS_END() \
                 default:\
-                    neat_log(NEAT_LOG_DEBUG,\
+                    neat_log(ctx, NEAT_LOG_DEBUG,\
                              "Unexpected optional argument \"%s\" passed to function %s, "\
                              "ignoring.", neat_tag_name[optional[i].tag], __func__);\
                     break;\

--- a/neat_json_helpers.c
+++ b/neat_json_helpers.c
@@ -123,7 +123,7 @@ neat_find_enabled_stacks(json_t *json, neat_protocol_stack_type *stacks,
                 }
 
             } else {
-                neat_log(NEAT_LOG_DEBUG, "Unknown transport %s", value);
+                // neat_log(NEAT_LOG_DEBUG, "Unknown transport %s", value);
                 *stack_count = 0;
             }
 
@@ -149,7 +149,7 @@ neat_find_enabled_stacks(json_t *json, neat_protocol_stack_type *stacks,
                     }
                 }
             } else {
-                neat_log(NEAT_LOG_DEBUG, "Unknown transport %s", value);
+                // neat_log(NEAT_LOG_DEBUG, "Unknown transport %s", value);
             }
 #else
             if ((stack = string_to_stack(value)) != 0) {
@@ -159,11 +159,11 @@ neat_find_enabled_stacks(json_t *json, neat_protocol_stack_type *stacks,
                     *(precedences++) = precedence;
                 }
             } else {
-                neat_log(NEAT_LOG_DEBUG, "Unknown transport %s", value);
+                // neat_log(NEAT_LOG_DEBUG, "Unknown transport %s", value);
             }
 #endif
         } else {
-            neat_log(NEAT_LOG_ERROR, "Invalid precedence %d in JSON", precedence);
+            // neat_log(NEAT_LOG_ERROR, "Invalid precedence %d in JSON", precedence);
             *stack_count = 0;
             return;
         }
@@ -198,17 +198,19 @@ get_property(json_t *json, const char *key, json_type expected_type)
     json_t *obj = json_object_get(json, key);
 
     if (!obj) {
-        neat_log(NEAT_LOG_DEBUG, "Unable to find property with key \"%s\"", key);
+        // neat_log(NEAT_LOG_DEBUG, "Unable to find property with key \"%s\"", key);
         return NULL;
     }
 
     obj = json_object_get(obj, "value");
     if (!obj) {
-        neat_log(NEAT_LOG_DEBUG, "Object with key \"%s\" is missing value key");
+        // neat_log(NEAT_LOG_DEBUG, "Object with key \"%s\" is missing value key");
         return NULL;
     }
 
     if (json_typeof(obj) != expected_type) {
+#if 0
+        // no ctx, can't log!
         const char *typename = NULL;
         switch (json_typeof(obj)) {
         case JSON_OBJECT:
@@ -235,7 +237,8 @@ get_property(json_t *json, const char *key, json_type expected_type)
             break;
         }
 
-        neat_log(NEAT_LOG_DEBUG, "Key \"%s\" had unexpected type", key, typename);
+        neat_log(ctx, NEAT_LOG_DEBUG, "Key \"%s\" had unexpected type", key, typename);
+#endif
         return NULL;
     }
 

--- a/neat_log.c
+++ b/neat_log.c
@@ -1,5 +1,7 @@
 #include <stdint.h>
 
+#include "neat.h"
+#include "neat_internal.h"
 #include "neat_core.h"
 
 #ifdef NEAT_LOG
@@ -21,26 +23,21 @@
 #define CYN   "\x1B[36m"
 #define WHT   "\x1B[37m"
 
-uint8_t log_level = NEAT_LOG_DEBUG;
-uint8_t color_supported = 0;
-struct timeval tv_init;
-FILE *neat_log_fd = NULL;
-
 /*
  * Initiate log system
  *  - currently supports stderr and file
  */
 uint8_t
-neat_log_init()
+neat_log_init(struct neat_ctx *ctx)
 {
     // set initial timestamp
-    gettimeofday(&tv_init, NULL);
+    gettimeofday(&(ctx->tv_init), NULL);
 
-    if (neat_log_fd == NULL) {
-        neat_log_fd = stderr;
+    if (ctx->neat_log_fd == NULL) {
+        ctx->neat_log_fd = stderr;
     }
 
-    neat_log(NEAT_LOG_INFO, "%s - opening logfile ...", __func__);
+    neat_log(ctx, NEAT_LOG_INFO, "%s - opening logfile ...", __func__);
 
     return RETVAL_SUCCESS;
 }
@@ -49,48 +46,48 @@ neat_log_init()
  * Set the NEAT log level
  */
 void
-neat_log_level(uint8_t level)
+neat_log_level(struct neat_ctx *ctx, uint8_t level)
 {
     switch (level) {
         case NEAT_LOG_OFF:
-            log_level = NEAT_LOG_OFF;
+            ctx->log_level = NEAT_LOG_OFF;
             break;
         case NEAT_LOG_ERROR:
-            log_level = NEAT_LOG_ERROR;
+            ctx->log_level = NEAT_LOG_ERROR;
             break;
         case NEAT_LOG_WARNING:
-            log_level = NEAT_LOG_WARNING;
+            ctx->log_level = NEAT_LOG_WARNING;
             break;
         case NEAT_LOG_INFO:
-            log_level = NEAT_LOG_INFO;
+            ctx->log_level = NEAT_LOG_INFO;
             break;
         case NEAT_LOG_DEBUG:
-            log_level = NEAT_LOG_DEBUG;
+            ctx->log_level = NEAT_LOG_DEBUG;
             break;
         default:
-            log_level = NEAT_LOG_DEBUG;
+            ctx->log_level = NEAT_LOG_DEBUG;
             fprintf(stderr, "%s - unknown log-level - using default\n", __func__);
             break;
     }
 }
 
 uint8_t
-neat_log_file(const char* file_name)
+neat_log_file(struct neat_ctx *ctx, const char* file_name)
 {
     // determine output fd
     if (file_name != NULL) {
-        neat_log(NEAT_LOG_INFO, "%s - using logfile: %s", __func__, file_name);
-        neat_log_fd = fopen(file_name, "w");
+        neat_log(ctx, NEAT_LOG_INFO, "%s - using logfile: %s", __func__, file_name);
+        ctx->neat_log_fd = fopen(file_name, "w");
 
-        if (neat_log_fd == NULL) {
-            neat_log_fd = stderr;
-            neat_log(NEAT_LOG_ERROR, "%s - could not open logfile, using stderr", __func__);
+        if (ctx->neat_log_fd == NULL) {
+            ctx->neat_log_fd = stderr;
+            neat_log(ctx, NEAT_LOG_ERROR, "%s - could not open logfile, using stderr", __func__);
             return RETVAL_FAILURE;
         }
 
         return RETVAL_SUCCESS;
     } else {
-        neat_log_fd = stderr;
+        ctx->neat_log_fd = stderr;
         return RETVAL_SUCCESS;
     }
 }
@@ -99,41 +96,41 @@ neat_log_file(const char* file_name)
  * Write log entry
  */
 void
-neat_log(uint8_t level, const char* format, ...)
+neat_log(struct neat_ctx *ctx, uint8_t level, const char* format, ...)
 {
 
     struct timeval tv_now, tv_diff;
     // skip unwanted loglevels
-    if (log_level < level) {
+    if (ctx->log_level < level) {
         return;
     }
 
-    if (neat_log_fd == NULL) {
+    if (ctx->neat_log_fd == NULL) {
         fprintf(stderr, "neat_log_fd is NULL - neat_log_init() required!\n");
         return;
     }
 
     gettimeofday(&tv_now, NULL);
 
-    tv_diff.tv_sec = tv_now.tv_sec - tv_init.tv_sec;
+    tv_diff.tv_sec = tv_now.tv_sec - ctx->tv_init.tv_sec;
 
-    if (tv_init.tv_usec <= tv_now.tv_usec) {
-        tv_diff.tv_usec = tv_now.tv_usec - tv_init.tv_usec;
+    if (ctx->tv_init.tv_usec <= tv_now.tv_usec) {
+        tv_diff.tv_usec = tv_now.tv_usec - ctx->tv_init.tv_usec;
     } else {
         tv_diff.tv_sec -= 1;
-        tv_diff.tv_usec = 1000000 + tv_now.tv_usec - tv_init.tv_usec;
+        tv_diff.tv_usec = 1000000 + tv_now.tv_usec - ctx->tv_init.tv_usec;
     }
 
-    if (isatty(fileno(neat_log_fd))) {
+    if (isatty(fileno(ctx->neat_log_fd))) {
         switch (level) {
             case NEAT_LOG_ERROR:
-                fprintf(neat_log_fd, RED);
+                fprintf(ctx->neat_log_fd, RED);
                 break;
             case NEAT_LOG_WARNING:
-                fprintf(neat_log_fd, YEL);
+                fprintf(ctx->neat_log_fd, YEL);
                 break;
             case NEAT_LOG_INFO:
-                fprintf(neat_log_fd, GRN);
+                fprintf(ctx->neat_log_fd, GRN);
                 break;
             case NEAT_LOG_DEBUG:
                 //fprintf(neat_log_fd, WHT);
@@ -141,32 +138,32 @@ neat_log(uint8_t level, const char* format, ...)
         }
     }
 
-    fprintf(neat_log_fd, "[%4ld.%06ld]", (long)tv_diff.tv_sec, (long)tv_diff.tv_usec);
+    fprintf(ctx->neat_log_fd, "[%4ld.%06ld]", (long)tv_diff.tv_sec, (long)tv_diff.tv_usec);
 
     switch (level) {
         case NEAT_LOG_ERROR:
-            fprintf(neat_log_fd, "[ERR] ");
+            fprintf(ctx->neat_log_fd, "[ERR] ");
             break;
         case NEAT_LOG_WARNING:
-            fprintf(neat_log_fd, "[WRN] ");
+            fprintf(ctx->neat_log_fd, "[WRN] ");
             break;
         case NEAT_LOG_INFO:
-            fprintf(neat_log_fd, "[INF] ");
+            fprintf(ctx->neat_log_fd, "[INF] ");
             break;
         case NEAT_LOG_DEBUG:
-            fprintf(neat_log_fd, "[DBG] ");
+            fprintf(ctx->neat_log_fd, "[DBG] ");
             break;
     }
 
     va_list argptr;
     va_start(argptr, format);
-    vfprintf(neat_log_fd, format, argptr);
+    vfprintf(ctx->neat_log_fd, format, argptr);
     va_end(argptr);
 
-    fprintf(neat_log_fd, "\n"); // xxx:ugly solution...
+    fprintf(ctx->neat_log_fd, "\n"); // xxx:ugly solution...
 
-    if (isatty(fileno(neat_log_fd))) {
-        fprintf(neat_log_fd, KNRM);
+    if (isatty(fileno(ctx->neat_log_fd))) {
+        fprintf(ctx->neat_log_fd, KNRM);
     }
 }
 
@@ -176,29 +173,31 @@ neat_log(uint8_t level, const char* format, ...)
 void
 neat_log_usrsctp(const char* format, ...)
 {
-
-    if (neat_log_fd == NULL) {
+#if 0
+    // this neats to get a ctx from somwhere!
+    if (ctx->neat_log_fd == NULL) {
         fprintf(stderr, "neat_log_fd is NULL - neat_log_init() required!\n");
         return;
     }
 
-    fprintf(neat_log_fd, "[DBG] ");
+    fprintf(ctx->neat_log_fd, "[DBG] ");
 
     va_list argptr;
     va_start(argptr, format);
-    vfprintf(neat_log_fd, format, argptr);
+    vfprintf(ctx->neat_log_fd, format, argptr);
     va_end(argptr);
+#endif
 }
 
 /*
  * Close logfile
  */
 uint8_t
-neat_log_close()
+neat_log_close(struct neat_ctx *ctx)
 {
-    neat_log(NEAT_LOG_INFO, "%s - closing logfile ...", __func__);
-    if (neat_log_fd != stderr) {
-        if (fclose(neat_log_fd) == 0) {
+    neat_log(ctx, NEAT_LOG_INFO, "%s - closing logfile ...", __func__);
+    if (ctx->neat_log_fd != stderr) {
+        if (fclose(ctx->neat_log_fd) == 0) {
             return RETVAL_SUCCESS;
         } else {
             return RETVAL_FAILURE;

--- a/neat_log.h
+++ b/neat_log.h
@@ -4,9 +4,9 @@
 #include <stdint.h>
 #include "neat.h"
 
-uint8_t neat_log_init();
-void neat_log(uint8_t level, const char* format, ...);
+uint8_t neat_log_init(struct neat_ctx *ctx);
+void neat_log(struct neat_ctx *ctx, uint8_t level, const char* format, ...);
 void neat_log_usrsctp(const char* format, ...);
-uint8_t neat_log_close();
+uint8_t neat_log_close(struct neat_ctx *ctx);
 
 #endif

--- a/neat_pm_socket.c
+++ b/neat_pm_socket.c
@@ -12,12 +12,12 @@ on_pm_written(struct neat_ctx *ctx, struct neat_flow *flow, struct neat_ipc_cont
 {
     struct neat_pm_context *pm_context = context->data;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     if (neat_unix_json_start_read(context) ||
         neat_unix_json_shutdown(context)) {
 
-        neat_log(NEAT_LOG_DEBUG, "Failed to initiate read/shutdown for PM socket");
+        neat_log(ctx, NEAT_LOG_DEBUG, "Failed to initiate read/shutdown for PM socket");
 
         pm_context->on_pm_error(ctx, flow, PM_ERROR_SOCKET);
     }
@@ -34,7 +34,7 @@ on_pm_close(void* data)
 {
     struct neat_pm_context *pm_context = data;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    //neat_log(NEAT_LOG_DEBUG, "%s", __func__);
 
     free(pm_context->output_buffer);
     free(pm_context->ipc_context);
@@ -49,7 +49,7 @@ on_pm_timeout(uv_timer_t* timer)
 {
     struct neat_pm_context *pm_context = timer->data;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    //neat_log(NEAT_LOG_DEBUG, "%s", __func__);
 
     pm_context->on_pm_error(pm_context->ipc_context->ctx, pm_context->ipc_context->flow, PM_ERROR_SOCKET);
 
@@ -61,7 +61,7 @@ on_pm_read(struct neat_ctx *ctx, struct neat_flow *flow, json_t *json, void *dat
 {
     struct neat_pm_context *pm_context = data;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     if (pm_context->on_pm_reply != NULL) {
         pm_context->on_pm_reply(ctx, flow, json);
@@ -75,7 +75,7 @@ on_pm_error(struct neat_ctx *ctx, struct neat_flow *flow, int error, void *data)
 {
     struct neat_pm_context *pm_context = data;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     pm_context->on_pm_error(ctx, flow, error);
 
@@ -98,7 +98,7 @@ neat_json_send_once(struct neat_ctx *ctx, struct neat_flow *flow, const char *pa
     struct neat_ipc_context *context;
     struct neat_pm_context *pm_context;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     if ((context = calloc(1, sizeof(*context))) == NULL)
         return NEAT_ERROR_OUT_OF_MEMORY;
@@ -121,13 +121,13 @@ neat_json_send_once(struct neat_ctx *ctx, struct neat_flow *flow, const char *pa
     }
 
     if ((rc = uv_timer_init(ctx->loop, pm_context->timer))) {
-        neat_log(NEAT_LOG_DEBUG, "uv_timer_init error: %s", uv_strerror(rc));
+        neat_log(ctx, NEAT_LOG_DEBUG, "uv_timer_init error: %s", uv_strerror(rc));
         rc = NEAT_ERROR_INTERNAL;
         goto error;
     }
 
     if ((rc = uv_timer_start(pm_context->timer, on_pm_timeout, 3000, 0))) {
-        neat_log(NEAT_LOG_DEBUG, "uv_timer_start error: %s", uv_strerror(rc));
+        neat_log(ctx, NEAT_LOG_DEBUG, "uv_timer_start error: %s", uv_strerror(rc));
         rc = NEAT_ERROR_INTERNAL;
         goto error;
     }

--- a/neat_pvd.c
+++ b/neat_pvd.c
@@ -72,8 +72,8 @@ compute_reverse_ip(struct neat_addr *src_addr)
     }
 
     if ((out = (char *) malloc(sizeof(char) * (strlen(reverse_ip)+1))) == NULL) {
-        neat_log(NEAT_LOG_ERROR,
-                "%s: can't allocate buffer");
+        // neat_log(NEAT_LOG_ERROR,
+        //          "%s: can't allocate buffer");
         return NULL;
     }
     strcpy(out, reverse_ip);
@@ -98,8 +98,8 @@ add_pvd_result(struct pvds* pvds, ldns_rr_list *pvd_txt_list)
     ldns_rdf *dns_record = NULL;
 
     if ((pvd = (struct pvd *) malloc(sizeof(struct pvd))) == NULL) {
-        neat_log(NEAT_LOG_ERROR,
-                "%s: can't allocate buffer");
+        // neat_log(NEAT_LOG_ERROR,
+        //        "%s: can't allocate buffer");
         return;
     }
     LIST_INIT(&pvd_infos);
@@ -121,8 +121,8 @@ add_pvd_result(struct pvds* pvds, ldns_rr_list *pvd_txt_list)
 
         if ((pvd_info = (struct pvd_info *) malloc(sizeof(struct pvd_info))) == NULL) {
             free(txt_record_original);
-            neat_log(NEAT_LOG_ERROR,
-                    "%s: can't allocate buffer");
+            // neat_log(NEAT_LOG_ERROR,
+            //      "%s: can't allocate buffer");
             continue;
         }
         pvd_info->key   = strsep(&txt_record, "=");
@@ -152,21 +152,21 @@ neat_pvd_dns_async(uv_loop_t *loop,
     struct sockaddr_in6 *server_addr6;
 
     if ((async_query->dns_uv_snd_buf = calloc(sizeof(uv_buf_t), 1)) == NULL) {
-        neat_log(NEAT_LOG_ERROR,
-                "%s: can't allocate buffer");
+        // neat_log(NEAT_LOG_ERROR,
+        //         "%s: can't allocate buffer");
         return 1;
     }
     if ((async_query->dns_snd_handle = calloc(sizeof(uv_udp_send_t), 1)) == NULL) {
         free(async_query->dns_uv_snd_buf);
-        neat_log(NEAT_LOG_ERROR,
-                "%s: can't allocate buffer");
+        // neat_log(NEAT_LOG_ERROR,
+        //         "%s: can't allocate buffer");
         return 1;
     }
     if ((async_query->resolve_handle = calloc(sizeof(uv_udp_t), 1)) == NULL) {
         free(async_query->dns_uv_snd_buf);
         free(async_query->dns_snd_handle);
-        neat_log(NEAT_LOG_ERROR,
-                "%s: can't allocate buffer");
+        // neat_log(NEAT_LOG_ERROR,
+        //         "%s: can't allocate buffer");
         return 1;
     }
 
@@ -181,7 +181,7 @@ neat_pvd_dns_async(uv_loop_t *loop,
         //Closed is normally set in close_cb, but since we will never get that
         //far, set it here instead
         //pair->closed = 1;
-        neat_log(NEAT_LOG_ERROR, "%s - Failure to initialize UDP handle", __func__);
+        // neat_log(NEAT_LOG_ERROR, "%s - Failure to initialize UDP handle", __func__);
         return 1;
     }
 
@@ -191,20 +191,20 @@ neat_pvd_dns_async(uv_loop_t *loop,
     if (uv_udp_bind(async_query->resolve_handle,
                     (struct sockaddr*) &(src_addr->u.generic.addr),
                     0)) {
-        neat_log(NEAT_LOG_ERROR, "%s - Failed to bind UDP socket", __func__);
+        //neat_log(NEAT_LOG_ERROR, "%s - Failed to bind UDP socket", __func__);
         return 1;
     }
 
     if (uv_udp_recv_start(async_query->resolve_handle,
                           alloc_cb,
                           recv_cb)) {
-        neat_log(NEAT_LOG_ERROR, "%s - Failed to start receiving UDP", __func__);
+        //neat_log(NEAT_LOG_ERROR, "%s - Failed to start receiving UDP", __func__);
         return 1;
     }
 
     async_query->dns_snd_buf = ldns_buffer_new(LDNS_MIN_BUFLEN);
     if (ldns_pkt2buffer_wire(async_query->dns_snd_buf, pkt) != LDNS_STATUS_OK) {
-        neat_log(NEAT_LOG_ERROR, "%s - Could not convert pkt to buf", __func__);
+        //neat_log(NEAT_LOG_ERROR, "%s - Could not convert pkt to buf", __func__);
         ldns_pkt_free(pkt);
         return 1;
     }
@@ -220,8 +220,8 @@ neat_pvd_dns_async(uv_loop_t *loop,
             free(async_query->resolve_handle);
             free(async_query->dns_uv_snd_buf);
             free(async_query->dns_snd_handle);
-            neat_log(NEAT_LOG_ERROR,
-                    "%s: can't allocate buffer");
+            //neat_log(NEAT_LOG_ERROR,
+            //        "%s: can't allocate buffer");
             return 1;
         }
         async_query->dst_addr4->sin_family  = AF_INET;
@@ -237,7 +237,7 @@ neat_pvd_dns_async(uv_loop_t *loop,
                         1,
                         (const struct sockaddr*) async_query->dst_addr4,
                         send_cb)) {
-            neat_log(NEAT_LOG_ERROR, "%s - Failed to start DNS send", __func__);
+            //neat_log(NEAT_LOG_ERROR, "%s - Failed to start DNS send", __func__);
             return 1;
         }
     } else {
@@ -246,8 +246,8 @@ neat_pvd_dns_async(uv_loop_t *loop,
             free(async_query->resolve_handle);
             free(async_query->dns_uv_snd_buf);
             free(async_query->dns_snd_handle);
-            neat_log(NEAT_LOG_ERROR,
-                    "%s: can't allocate buffer");
+            // neat_log(NEAT_LOG_ERROR,
+            //        "%s: can't allocate buffer");
             return 1;
         }
         async_query->dst_addr6->sin6_family = AF_INET6;
@@ -263,7 +263,7 @@ neat_pvd_dns_async(uv_loop_t *loop,
                         1,
                         (const struct sockaddr*) async_query->dst_addr6,
                         send_cb)) {
-            neat_log(NEAT_LOG_ERROR, "%s - Failed to start DNS send", __func__);
+            // neat_log(NEAT_LOG_ERROR, "%s - Failed to start DNS send", __func__);
             return 1;
         }
     }
@@ -425,15 +425,15 @@ neat_pvd_dns_ptr_recv_cb(uv_udp_t *handle,
             != LDNS_STATUS_OK) {
 
             free(ptr_record);
-            neat_log(NEAT_LOG_ERROR, "%s - Could not create DNS packet", __func__);
+            //neat_log(NEAT_LOG_ERROR, "%s - Could not create DNS packet", __func__);
             continue;
         }
         free(ptr_record);
 
         struct pvd_async_query *async_query_new;
         if ((async_query_new = malloc(sizeof(struct pvd_async_query))) == NULL) {
-            neat_log(NEAT_LOG_ERROR,
-                    "%s: can't allocate buffer");
+            //neat_log(NEAT_LOG_ERROR,
+            //        "%s: can't allocate buffer");
             continue;
         }
         LIST_INSERT_HEAD(&(async_query->pvd->queries), async_query_new, next_query);
@@ -456,11 +456,11 @@ neat_pvd_dns_ptr_recv_cb(uv_udp_t *handle,
 }
 
 static void
-neat_pvd_handle_newaddr(struct neat_ctx *nc,
+neat_pvd_handle_newaddr(struct neat_ctx *ctx,
                         void *p_ptr,
                         void *data)
 {
-    if (LIST_EMPTY(&(nc->resolver->server_list))) {
+    if (LIST_EMPTY(&(ctx->resolver->server_list))) {
         // No DNS servers
         return;
     }
@@ -476,7 +476,7 @@ neat_pvd_handle_newaddr(struct neat_ctx *nc,
 
     if ((pvd_result = (struct pvd_result *) malloc(sizeof(struct pvd_result))) == NULL) {
         free(reverse_ip);
-        neat_log(NEAT_LOG_ERROR,
+        neat_log(ctx, NEAT_LOG_ERROR,
                 "%s: can't allocate buffer");
         return;
     }
@@ -484,7 +484,7 @@ neat_pvd_handle_newaddr(struct neat_ctx *nc,
     LIST_INIT(&(pvd_result->pvds));
     pvd_result->src_addr = src_addr;
 
-    LIST_FOREACH(dns_server, &(nc->resolver->server_list), next_server) {
+    LIST_FOREACH(dns_server, &(ctx->resolver->server_list), next_server) {
         // Avoid static servers
         if (dns_server->mark != NEAT_RESOLVER_SERVER_ACTIVE) {
             continue;
@@ -494,11 +494,11 @@ neat_pvd_handle_newaddr(struct neat_ctx *nc,
 
         struct pvd_dns_query *dns_query;
         if ((dns_query = malloc(sizeof(struct pvd_dns_query))) == NULL) {
-            neat_log(NEAT_LOG_ERROR,
+            neat_log(ctx, NEAT_LOG_ERROR,
                     "%s: can't allocate buffer");
             continue;
         }
-        dns_query->loop                 = nc->loop;
+        dns_query->loop                 = ctx->loop;
         dns_query->src_addr             = src_addr;
         dns_query->dns_addr             = dns_addr;
         dns_query->pvd_result           = pvd_result;
@@ -510,21 +510,21 @@ neat_pvd_handle_newaddr(struct neat_ctx *nc,
                                        LDNS_RR_CLASS_IN, LDNS_RD)
             != LDNS_STATUS_OK) {
             free(dns_query);
-            neat_log(NEAT_LOG_ERROR, "%s - Could not create DNS packet", __func__);
+            neat_log(ctx, NEAT_LOG_ERROR, "%s - Could not create DNS packet", __func__);
             continue;
         }
 
         struct pvd_async_query *async_query;
         if ((async_query = malloc(sizeof(struct pvd_async_query))) == NULL) {
             free(dns_query);
-            neat_log(NEAT_LOG_ERROR,
+            neat_log(ctx, NEAT_LOG_ERROR,
                     "%s: can't allocate buffer");
             continue;
         }
-        async_query->pvd = nc->pvd;
-        LIST_INSERT_HEAD(&(nc->pvd->queries), async_query, next_query);
+        async_query->pvd = ctx->pvd;
+        LIST_INSERT_HEAD(&(ctx->pvd->queries), async_query, next_query);
 
-        if (neat_pvd_dns_async(nc->loop,
+        if (neat_pvd_dns_async(ctx->loop,
                                async_query,
                                dns_addr,
                                src_addr,
@@ -538,25 +538,25 @@ neat_pvd_handle_newaddr(struct neat_ctx *nc,
     }
     free(reverse_ip);
 
-    LIST_INSERT_HEAD(&(nc->pvd->results), pvd_result, next_result);
+    LIST_INSERT_HEAD(&(ctx->pvd->results), pvd_result, next_result);
 }
 
 struct neat_pvd *
-neat_pvd_init(struct neat_ctx *nc)
+neat_pvd_init(struct neat_ctx *ctx)
 {
     struct neat_pvd *pvd = calloc(sizeof(struct neat_pvd), 1);
     if (!pvd)
         return NULL;
 
-    pvd->nc = nc;
+    pvd->nc = ctx;
 
     pvd->newaddr_cb.event_cb    = neat_pvd_handle_newaddr;
     pvd->newaddr_cb.data        = pvd;
     LIST_INIT(&(pvd->results));
     LIST_INIT(&(pvd->queries));
 
-    if (neat_add_event_cb(nc, NEAT_NEWADDR, &(pvd->newaddr_cb))) {
-        neat_log(NEAT_LOG_ERROR, "%s - Could not add one pvd callbacks", __func__);
+    if (neat_add_event_cb(ctx, NEAT_NEWADDR, &(pvd->newaddr_cb))) {
+        neat_log(ctx, NEAT_LOG_ERROR, "%s - Could not add one pvd callbacks", __func__);
         return NULL;
     }
 

--- a/neat_resolver.c
+++ b/neat_resolver.c
@@ -77,7 +77,7 @@ static void neat_resolver_handle_deladdr(struct neat_ctx *nic,
         inet_ntop(AF_INET6, &(src_addr6->sin6_addr), addr_str, INET6_ADDRSTRLEN);
     }
 
-    neat_log(NEAT_LOG_INFO, "%s: Deleted %s", __func__, addr_str);
+    neat_log(nic, NEAT_LOG_INFO, "%s: Deleted %s", __func__, addr_str);
 
     request_itr = resolver->request_queue.tqh_first;
 
@@ -224,7 +224,7 @@ static uint32_t neat_resolver_literal_populate_results(struct neat_resolver_requ
         struct sockaddr_in6 *dst_addr6;
     } u;
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    //neat_log(NEAT_LOG_DEBUG, "%s", __func__);
 
     char *tmp = strdup(request->domain_name);
     char *ptr = NULL;
@@ -570,7 +570,7 @@ static uint8_t neat_resolver_send_query(struct neat_resolver_src_dst_addr *pair,
     //Create a DNS query for aUrl
     if (ldns_pkt_query_new_frm_str(&pkt, request->domain_name, rr_type,
                 LDNS_RR_CLASS_IN, 0) != LDNS_STATUS_OK) {
-        neat_log(NEAT_LOG_ERROR, "%s - Could not create DNS packet", __func__);
+        // neat_log(NEAT_LOG_ERROR, "%s - Could not create DNS packet", __func__);
         return RETVAL_FAILURE;
     }
 
@@ -584,7 +584,7 @@ static uint8_t neat_resolver_send_query(struct neat_resolver_src_dst_addr *pair,
     //Convert internal LDNS structure to query buffer
     pair->dns_snd_buf = ldns_buffer_new(LDNS_MIN_BUFLEN);
     if (ldns_pkt2buffer_wire(pair->dns_snd_buf, pkt) != LDNS_STATUS_OK) {
-        neat_log(NEAT_LOG_ERROR, "%s - Could not convert pkt to buf", __func__);
+        //neat_log(NEAT_LOG_ERROR, "%s - Could not convert pkt to buf", __func__);
         ldns_pkt_free(pkt);
         return RETVAL_FAILURE;
     }
@@ -598,18 +598,18 @@ static uint8_t neat_resolver_send_query(struct neat_resolver_src_dst_addr *pair,
             &(pair->dns_uv_snd_buf), 1,
             (const struct sockaddr*) &(pair->dst_addr.u.generic.addr),
             neat_resolver_dns_sent_cb)) {
-        neat_log(NEAT_LOG_ERROR, "%s - Failed to start DNS send", __func__);
+        //neat_log(NEAT_LOG_ERROR, "%s - Failed to start DNS send", __func__);
         return RETVAL_FAILURE;
     }
 
-    neat_log(NEAT_LOG_DEBUG, "%s - Request for %s sent", __func__,
-             request->domain_name);
+    //neat_log(NEAT_LOG_DEBUG, "%s - Request for %s sent", __func__,
+    //         request->domain_name);
 
     return RETVAL_SUCCESS;
 }
 
 //Create one SRC/DST DNS resolver pair. Pair has already been allocated
-static uint8_t neat_resolver_create_pair(struct neat_ctx *nc,
+static uint8_t neat_resolver_create_pair(struct neat_ctx *ctx,
         struct neat_resolver_src_dst_addr *pair,
         const struct sockaddr_storage *server_addr)
 {
@@ -642,11 +642,11 @@ static uint8_t neat_resolver_create_pair(struct neat_ctx *nc,
     }
 
     //Configure uv_udp_handle
-    if (uv_udp_init(nc->loop, &(pair->resolve_handle))) {
+    if (uv_udp_init(ctx->loop, &(pair->resolve_handle))) {
         //Closed is normally set in close_cb, but since we will never get that
         //far, set it here instead
         //pair->closed = 1;
-        neat_log(NEAT_LOG_ERROR, "%s - Failure to initialize UDP handle", __func__);
+        neat_log(ctx, NEAT_LOG_ERROR, "%s - Failure to initialize UDP handle", __func__);
         return RETVAL_FAILURE;
     }
 
@@ -655,13 +655,13 @@ static uint8_t neat_resolver_create_pair(struct neat_ctx *nc,
     if (uv_udp_bind(&(pair->resolve_handle),
                 (struct sockaddr*) &(pair->src_addr->u.generic.addr),
                 0)) {
-        neat_log(NEAT_LOG_ERROR, "%s - Failed to bind UDP socket", __func__);
+        neat_log(ctx, NEAT_LOG_ERROR, "%s - Failed to bind UDP socket", __func__);
         return RETVAL_FAILURE;
     }
 
     if (uv_udp_recv_start(&(pair->resolve_handle), neat_resolver_dns_alloc_cb,
                 neat_resolver_dns_recv_cb)) {
-        neat_log(NEAT_LOG_ERROR, "%s - Failed to start receiving UDP", __func__);
+        neat_log(ctx, NEAT_LOG_ERROR, "%s - Failed to start receiving UDP", __func__);
         return RETVAL_FAILURE;
     }
 
@@ -671,14 +671,14 @@ static uint8_t neat_resolver_create_pair(struct neat_ctx *nc,
     uv_fileno((uv_handle_t*) &(pair->resolve_handle), &socket_fd);
 
     if (!if_indextoname(pair->src_addr->if_idx, if_name)) {
-        /*neat_log(NEAT_LOG_ERROR, "%s - Could not get interface name for index %u",
+        /*neat_log(ctx, NEAT_LOG_ERROR, "%s - Could not get interface name for index %u",
                 __func__, pair->src_addr->if_idx);*/
         return RETVAL_IGNORE;
     }
 
     if (setsockopt(socket_fd, SOL_SOCKET, SO_BINDTODEVICE, if_name,
                 strlen(if_name)) < 0) {
-        /*neat_log(NEAT_LOG_ERROR, "%s - Could not bind socket to interface %s\n",
+        /*neat_log(ctx, NEAT_LOG_ERROR, "%s - Could not bind socket to interface %s\n",
         __func__, if_name); */
         return RETVAL_IGNORE;
     }
@@ -709,7 +709,7 @@ static uint8_t neat_resolver_create_pairs(struct neat_addr *src_addr,
             calloc(sizeof(struct neat_resolver_src_dst_addr), 1);
 
         if (!resolver_pair) {
-            neat_log(NEAT_LOG_ERROR, "%s - Failed to allocate memory for resolver pair", __func__);
+            //neat_log(NEAT_LOG_ERROR, "%s - Failed to allocate memory for resolver pair", __func__);
             continue;
         }
 
@@ -718,13 +718,13 @@ static uint8_t neat_resolver_create_pairs(struct neat_addr *src_addr,
 
         if (neat_resolver_create_pair(request->resolver->nc, resolver_pair,
                     &(server_itr->server_addr)) == RETVAL_FAILURE) {
-            neat_log(NEAT_LOG_ERROR, "%s - Failed to create resolver pair", __func__);
+            //neat_log(NEAT_LOG_ERROR, "%s - Failed to create resolver pair", __func__);
             neat_resolver_mark_pair_del(request->resolver, resolver_pair);
             continue;
         }
 
         if (neat_resolver_send_query(resolver_pair, request)) {
-            neat_log(NEAT_LOG_ERROR, "%s - Failed to start lookup", __func__);
+            //neat_log(NEAT_LOG_ERROR, "%s - Failed to start lookup", __func__);
             neat_resolver_mark_pair_del(request->resolver, resolver_pair);
         } else {
             //printf("Will lookup %s\n", resolver->domain_name);
@@ -798,7 +798,7 @@ static void neat_start_request(struct neat_resolver *resolver,
 
     //No point starting to query if we don't have any source addresses
     if (!resolver->nc->src_addr_cnt) {
-        neat_log(NEAT_LOG_ERROR, "%s - No available src addresses", __func__);
+        //neat_log(NEAT_LOG_ERROR, "%s - No available src addresses", __func__);
         return;
     }
 
@@ -831,17 +831,17 @@ uint8_t neat_resolve(struct neat_resolver *resolver,
     int8_t is_literal = 0;
 
     if (port == 0) {
-        neat_log(NEAT_LOG_ERROR, "%s - Invalid port specified", __func__);
+        //neat_log(NEAT_LOG_ERROR, "%s - Invalid port specified", __func__);
         return RETVAL_FAILURE;
     }
 
     if (family && family != AF_INET && family != AF_INET6 && family != AF_UNSPEC) {
-        neat_log(NEAT_LOG_ERROR, "%s - Invalid family specified", __func__);
+        //neat_log(NEAT_LOG_ERROR, "%s - Invalid family specified", __func__);
         return RETVAL_FAILURE;
     }
 
     if ((strlen(node) + 1) > MAX_DOMAIN_LENGTH) {
-        neat_log(NEAT_LOG_ERROR, "%s - Domain name too long", __func__);
+        //neat_log(NEAT_LOG_ERROR, "%s - Domain name too long", __func__);
         return RETVAL_FAILURE;
     }
 
@@ -878,7 +878,7 @@ uint8_t neat_resolve(struct neat_resolver *resolver,
 
 //Initialize the resolver. Set up callbacks etc.
 struct neat_resolver *
-neat_resolver_init(struct neat_ctx *nc, const char *resolv_conf_path)
+neat_resolver_init(struct neat_ctx *ctx, const char *resolv_conf_path)
 {
     struct neat_resolver *resolver;
 
@@ -891,7 +891,7 @@ neat_resolver_init(struct neat_ctx *nc, const char *resolv_conf_path)
     TAILQ_INIT(&(resolver->dead_request_queue));
 
     //We want to bind a resolver to one context to access address list
-    resolver->nc = nc;
+    resolver->nc = ctx;
 
     //Same timeouts accross all requests
     //TODO: Might be changed, for example due to different networks. Policy?
@@ -903,19 +903,19 @@ neat_resolver_init(struct neat_ctx *nc, const char *resolv_conf_path)
     resolver->deladdr_cb.event_cb = neat_resolver_handle_deladdr;
     resolver->deladdr_cb.data = resolver;
 
-    if (neat_add_event_cb(nc, NEAT_NEWADDR, &(resolver->newaddr_cb)) ||
-        neat_add_event_cb(nc, NEAT_DELADDR, &(resolver->deladdr_cb))) {
-        neat_log(NEAT_LOG_ERROR, "%s - Could not add one or more resolver callbacks", __func__);
+    if (neat_add_event_cb(ctx, NEAT_NEWADDR, &(resolver->newaddr_cb)) ||
+        neat_add_event_cb(ctx, NEAT_DELADDR, &(resolver->deladdr_cb))) {
+        neat_log(ctx, NEAT_LOG_ERROR, "%s - Could not add one or more resolver callbacks", __func__);
         return NULL;
     }
 
     LIST_INIT(&(resolver->resolver_pairs_del));
 
-    uv_idle_init(nc->loop, &(resolver->idle_handle));
+    uv_idle_init(ctx->loop, &(resolver->idle_handle));
     resolver->idle_handle.data = resolver;
 
-    if (uv_fs_event_init(nc->loop, &(resolver->resolv_conf_handle))) {
-        neat_log(NEAT_LOG_ERROR, "%s - Could not initialize fs event handle", __func__);
+    if (uv_fs_event_init(ctx->loop, &(resolver->resolv_conf_handle))) {
+        neat_log(ctx, NEAT_LOG_ERROR, "%s - Could not initialize fs event handle", __func__);
         return NULL;
     }
 
@@ -924,7 +924,7 @@ neat_resolver_init(struct neat_ctx *nc, const char *resolv_conf_path)
     if (uv_fs_event_start(&(resolver->resolv_conf_handle),
                       neat_resolver_resolv_conf_updated,
                       resolv_conf_path, 0)) {
-        neat_log(NEAT_LOG_WARNING, "%s - Could not start fs event handle", __func__);
+        neat_log(ctx, NEAT_LOG_WARNING, "%s - Could not start fs event handle", __func__);
     }
 
     if (!neat_resolver_add_initial_servers(resolver))

--- a/neat_resolver_conf.c
+++ b/neat_resolver_conf.c
@@ -48,7 +48,7 @@ static void neat_resolver_delete_servers(struct neat_resolver *resolver)
         LIST_REMOVE(server_to_delete, next_server);
         free(server_to_delete);
 
-        neat_log(NEAT_LOG_INFO, "Deleted address %s from DNS list", dst_addr_buf);
+        //neat_log(NEAT_LOG_INFO, "Deleted address %s from DNS list", dst_addr_buf);
     }
 }
 
@@ -81,7 +81,7 @@ static void neat_resolver_resolv_check_addr(struct neat_resolver *resolver,
         }
 
         if (addr_equal) {
-            neat_log(NEAT_LOG_INFO, "Addr %s found in resolver list", dst_addr_buf);
+            // neat_log(NEAT_LOG_INFO, "Addr %s found in resolver list", dst_addr_buf);
             server->mark = NEAT_RESOLVER_SERVER_ACTIVE;
             return;
         }
@@ -89,7 +89,7 @@ static void neat_resolver_resolv_check_addr(struct neat_resolver *resolver,
 
     //TODO: Decide how to handle this error!
     if (!(server = calloc(sizeof(struct neat_resolver_server), 1))) {
-        neat_log(NEAT_LOG_ERROR, "Failed to allocate memory for DNS server");
+        // neat_log(NEAT_LOG_ERROR, "Failed to allocate memory for DNS server");
         return;
     }
 
@@ -105,7 +105,7 @@ static void neat_resolver_resolv_check_addr(struct neat_resolver *resolver,
         inet_ntop(AF_INET6, &(dst_addr6->sin6_addr), dst_addr_buf, INET6_ADDRSTRLEN);
     }
 
-    neat_log(NEAT_LOG_INFO, "Added %s to resolver list", dst_addr_buf);
+    //neat_log(NEAT_LOG_INFO, "Added %s to resolver list", dst_addr_buf);
 }
 
 void neat_resolver_resolv_conf_updated(uv_fs_event_t *handle,
@@ -127,13 +127,13 @@ void neat_resolver_resolv_conf_updated(uv_fs_event_t *handle,
 
     memset(resolv_path, 0, resolv_path_len);
     if (uv_fs_event_getpath(handle, resolv_path, &resolv_path_len)) {
-        neat_log(NEAT_LOG_WARNING, "Could not store resolv.conf path in buffer");
+        //neat_log(NEAT_LOG_WARNING, "Could not store resolv.conf path in buffer");
         return;
     }
 
     //TODO: Read filename dynamically
     if (!(resolv_ptr = fopen(resolv_path, "r"))) {
-        neat_log(NEAT_LOG_WARNING, "Failed to open resolv-file");
+        //neat_log(NEAT_LOG_WARNING, "Failed to open resolv-file");
         return;
     }
 
@@ -143,7 +143,7 @@ void neat_resolver_resolv_conf_updated(uv_fs_event_t *handle,
     while ((resolv_line = fgets(nameserver_str, sizeof(nameserver_str),
                                 resolv_ptr))) {
         if (ferror(resolv_ptr)) {
-            neat_log(NEAT_LOG_ERROR, "Failed to read line from resolv-file");
+            //neat_log(NEAT_LOG_ERROR, "Failed to read line from resolv-file");
             //Reason for break and not return is that we might have got SOME
             //useful information from resolv.conf
             break;
@@ -184,7 +184,7 @@ void neat_resolver_resolv_conf_updated(uv_fs_event_t *handle,
             neat_resolver_resolv_check_addr(resolver, &server_addr);
             continue;
         } else {
-            neat_log(NEAT_LOG_ERROR, "Could not parse server %s", token);
+            //neat_log(NEAT_LOG_ERROR, "Could not parse server %s", token);
         }
     }
 
@@ -212,7 +212,7 @@ uint8_t neat_resolver_add_initial_servers(struct neat_resolver *resolver)
         inet_pton(AF_INET, INET_DNS_SERVERS[i], &(addr4->sin_addr));
 
         if (!(server = calloc(sizeof(struct neat_resolver_server), 1))) {
-            neat_log(NEAT_LOG_ERROR, "Failed to allocate memory for DNS server");
+            //neat_log(NEAT_LOG_ERROR, "Failed to allocate memory for DNS server");
             return 0;
         }
 
@@ -230,7 +230,7 @@ uint8_t neat_resolver_add_initial_servers(struct neat_resolver *resolver)
         inet_pton(AF_INET, INET6_DNS_SERVERS[i], &(addr6->sin6_addr));
 
         if (!(server = calloc(sizeof(struct neat_resolver_server), 1))) {
-            neat_log(NEAT_LOG_ERROR, "Failed to allocate memory for DNS server");
+            //neat_log(NEAT_LOG_ERROR, "Failed to allocate memory for DNS server");
             return 0;
         }
 

--- a/neat_resolver_helpers.c
+++ b/neat_resolver_helpers.c
@@ -41,7 +41,7 @@ neat_resolver_helpers_check_for_literal(uint8_t *family,
     int32_t v4_literal = 0, v6_literal = 0;
 
     if (*family != AF_UNSPEC && *family != AF_INET && *family != AF_INET6) {
-        neat_log(NEAT_LOG_ERROR, "%s - Unsupported address family", __func__);
+      // neat_log(NEAT_LOG_ERROR, "%s - Unsupported address family", __func__);
         return -1;
     }
 
@@ -73,7 +73,7 @@ neat_resolver_helpers_check_for_literal(uint8_t *family,
     //mistake and must be notifed
     if ((*family == AF_INET && v6_literal) ||
         (*family == AF_INET6 && v4_literal)) {
-        neat_log(NEAT_LOG_ERROR, "%s - Mismatch between family and literal", __func__);
+      // neat_log(NEAT_LOG_ERROR, "%s - Mismatch between family and literal", __func__);
         return -1;
     }
 

--- a/neat_security.c
+++ b/neat_security.c
@@ -93,7 +93,7 @@ drain_output(struct neat_ctx *ctx, struct neat_flow *flow,
             return rv;
         }
     }
-    neat_log(NEAT_LOG_DEBUG, "wrote out %d cipher text to transport",
+    neat_log(ctx, NEAT_LOG_DEBUG, "wrote out %d cipher text to transport",
              private->outCipherBufferUsed);
 
     // wrote it all.
@@ -106,7 +106,7 @@ static neat_error_code
 gather_input(struct neat_ctx *ctx, struct neat_flow *flow,
              struct neat_iofilter *filter, struct neat_tlv optional[], unsigned int opt_count)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
     struct security_data *private = (struct security_data *) filter->userData;
     uint32_t actualAmt;
     uint32_t avail = CIPHER_BUFFER_SIZE - private->inCipherBufferUsed;
@@ -115,7 +115,7 @@ gather_input(struct neat_ctx *ctx, struct neat_flow *flow,
     }
     neat_error_code rv = flow->readfx(ctx, flow, private->inCipherBuffer + private->inCipherBufferUsed,
                                       avail, &actualAmt, optional, opt_count);
-    neat_log(NEAT_LOG_DEBUG, "read in %d cipher text from transport (%u)",
+    neat_log(ctx, NEAT_LOG_DEBUG, "read in %d cipher text from transport (%u)",
              (rv == NEAT_OK) ? actualAmt : 0, rv);
     if (rv == NEAT_OK && actualAmt) {
         private->inCipherBufferUsed += actualAmt;
@@ -140,12 +140,12 @@ neat_security_filter_read(struct neat_ctx *ctx, struct neat_flow *flow,
 
 static neat_error_code neat_security_handshake(struct neat_flow_operations *opCB)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    // neat_log(NEAT_LOG_DEBUG, "%s", __func__);
     neat_error_code rv = neat_write(opCB->ctx, opCB->flow, NULL, 0, NULL, 0);
     if (rv == NEAT_ERROR_WOULD_BLOCK) {
         return rv;
     }
-    neat_log(NEAT_LOG_DEBUG, "%s handshake not blocking", __func__);
+    // neat_log(NEAT_LOG_DEBUG, "%s handshake not blocking", __func__);
     for (struct neat_iofilter *filter = opCB->flow->iofilters;
          filter; filter = filter->next) {
         if (filter->writefx == neat_security_filter_write ||
@@ -249,7 +249,7 @@ neat_security_filter_write(struct neat_ctx *ctx, struct neat_flow *flow,
                            const unsigned char *buffer, uint32_t amt,
                            struct neat_tlv optional[], unsigned int opt_count)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
     neat_error_code rv;
     struct security_data *private;
     private = (struct security_data *) filter->userData;
@@ -294,7 +294,7 @@ neat_security_filter_read(struct neat_ctx *ctx, struct neat_flow *flow,
                           uint32_t *actualAmt,
                           struct neat_tlv optional[], unsigned int opt_count)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s %d", __func__, *actualAmt);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s %d", __func__, *actualAmt);
     struct security_data *private;
     private = (struct security_data *) filter->userData;
     neat_error_code rv;
@@ -316,10 +316,10 @@ neat_security_filter_read(struct neat_ctx *ctx, struct neat_flow *flow,
         return NEAT_ERROR_SECURITY;
     }
     int amtRead = SSL_read(private->ssl, buffer, amt);
-    neat_log(NEAT_LOG_DEBUG, "%s read %d", __func__, amtRead);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s read %d", __func__, amtRead);
     if (amtRead < 0) {
         int err = SSL_get_error(private->ssl, amtRead);
-        neat_log(NEAT_LOG_DEBUG, "%s err %d", __func__, err);
+        neat_log(ctx, NEAT_LOG_DEBUG, "%s err %d", __func__, err);
         if (err != SSL_ERROR_NONE && err != SSL_ERROR_WANT_READ &&
             err != SSL_ERROR_WANT_WRITE && err != SSL_ERROR_ZERO_RETURN &&
             err != SSL_ERROR_SYSCALL) {
@@ -336,7 +336,7 @@ void tls_init_trust_list(SSL_CTX *ctx);
 neat_error_code
 neat_security_install(neat_ctx *ctx, neat_flow *flow)
 {
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     // todo list
     // sctp client (via dtls over sctp)
@@ -370,13 +370,13 @@ neat_security_install(neat_ctx *ctx, neat_flow *flow)
             SSL_CTX_set_ecdh_auto(private->ctx, 1);
 
             if (!flow->server_pem) {
-                neat_log(NEAT_LOG_ERROR, "PEM file not set via neat_secure_identity()");
+                neat_log(ctx, NEAT_LOG_ERROR, "PEM file not set via neat_secure_identity()");
                 return NEAT_ERROR_SECURITY;
             }
 
             if ((SSL_CTX_use_certificate_file(private->ctx, flow->server_pem, SSL_FILETYPE_PEM) < 0) ||
                 (SSL_CTX_use_PrivateKey_file(private->ctx, flow->server_pem, SSL_FILETYPE_PEM) < 0 )) {
-                neat_log(NEAT_LOG_ERROR, "unable to use cert or private key");
+                neat_log(ctx, NEAT_LOG_ERROR, "unable to use cert or private key");
                 return NEAT_ERROR_SECURITY;
             }
         }

--- a/neat_stat.c
+++ b/neat_stat.c
@@ -16,7 +16,7 @@ void neat_get_tcp_info(neat_flow *flow, struct neat_tcp_info *tcpinfo)
 {
     /* Call the os-specific TCP-info-gathering function and copy the outputs into the
      * relevant fields of the neat-generic tcp-info struct */
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(flow->ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
 #ifdef __linux__
     linux_get_tcp_info(flow, tcpinfo);
@@ -28,7 +28,7 @@ void neat_get_tcp_info(neat_flow *flow, struct neat_tcp_info *tcpinfo)
 
 /* Traverse the relevant subsystems of NEAT and gather the stats
    then format the stats as a json string to return */
-void neat_stats_build_json(struct neat_ctx *mgr, char **json_stats)
+void neat_stats_build_json(struct neat_ctx *ctx, char **json_stats)
 {
     json_t *json_root, *protostat, *newflow;
     struct neat_flow *flow;
@@ -36,12 +36,12 @@ void neat_stats_build_json(struct neat_ctx *mgr, char **json_stats)
     uint flowcount;
     char flow_name[128];
 
-    neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+    neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     flowcount = 0;
     json_root = json_object();
 
-    LIST_FOREACH(flow, &mgr->flows, next_flow) {
+    LIST_FOREACH(flow, &ctx->flows, next_flow) {
         flowcount++;
 
         /* Create entries for flow#n in a separate object */

--- a/neat_unix_json_socket.c
+++ b/neat_unix_json_socket.c
@@ -8,6 +8,10 @@
 #include <jansson.h>
 #include <assert.h>
 
+// Disable logging in this source file. They require a context as first
+// argument and there are no such ones here.
+#define neat_log(x, ...)
+
 // TODO: Store a list of buffers and read JSON from them instead, if possible
 
 static void

--- a/neat_usrsctp.c
+++ b/neat_usrsctp.c
@@ -92,6 +92,7 @@ struct neat_ctx *neat_usrsctp_init_ctx(struct neat_ctx *ctx)
     ctx->usrsctp_timer_handle.data = ctx;
     uv_timer_start(&(ctx->usrsctp_timer_handle), neat_handle_usrsctp_timeout, 10, 10);
 
+    /* TODO: fix this call to neat_log_usrsctp */
     usrsctp_init(SCTP_UDP_TUNNELING_PORT, NULL, neat_log_usrsctp);
 
     ctx->sctp4_fd = usrsctp_open_sctp4_socket();


### PR DESCRIPTION
To avoid global variables and thus fix both threading problems and
issues with using multiple contexts in the same thread.

NOTE: that in **67** places in the code, I had to comment out the `neat_log()` call since there was no obvious way for me to extract a context pointer to pass in to the function.

NOTE2: this patch touches 700 lines in 26 files and will thus bitrot really fast.

Fixes issue #261 