### PR TITLE
DSCP failover mechanism 

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -13,6 +13,7 @@ LIST(APPEND neat_programs
     tneat.c
     peer.c
     http_client_multihomed.c
+    dscp_test.c
 )
 
 LIST(APPEND neat_property_examples

--- a/examples/dscp_test.c
+++ b/examples/dscp_test.c
@@ -1,0 +1,488 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <uv.h>
+#include "../neat.h"
+#include "../neat_internal.h"
+#include "util.h"
+
+/**********************************************************************
+
+    simple neat client
+
+    * connect to HOST and PORT
+    * read from stdin and send data to HOST
+    * write received data from peer to stdout
+
+    client [OPTIONS] HOST PORT
+    -P : neat properties
+    -R : receive buffer in byte
+    -S : send buffer in byte
+    -J : print json stats for each time data is sent
+    -T : write timeout in seconds (where available)
+    -v : log level (0 .. 2)
+    -A : set primary destination address
+
+**********************************************************************/
+
+static uint32_t config_rcv_buffer_size = 256;
+static uint32_t config_snd_buffer_size = 128;
+static uint16_t config_log_level = 1;
+static uint16_t config_json_stats = 0;
+static uint16_t config_timeout = 0;
+static char *config_primary_dest_addr = NULL;
+static char *config_property = "{\n\
+    \"transport\": [\n\
+        {\n\
+            \"value\": \"SCTP\",\n\
+            \"precedence\": 1\n\
+        },\n\
+        {\n\
+            \"value\": \"TCP\",\n\
+            \"precedence\": 1\n\
+        }\n\
+    ]\n\
+}";
+
+struct std_buffer {
+    unsigned char *buffer;
+    uint32_t buffer_filled;
+};
+
+static struct neat_flow_operations ops;
+static struct std_buffer stdin_buffer;
+static struct neat_ctx *ctx = NULL;
+static struct neat_flow *flow = NULL;
+static unsigned char *buffer_rcv = NULL;
+static unsigned char *buffer_snd= NULL;
+static uv_tty_t tty;
+
+void tty_read(uv_stream_t *stream, ssize_t bytes_read, const uv_buf_t *buffer);
+void tty_alloc(uv_handle_t *handle, size_t suggested, uv_buf_t *buf);
+static neat_error_code on_all_written(struct neat_flow_operations *opCB);
+
+
+// Print usage and exit
+static void
+print_usage()
+{
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    printf("client [OPTIONS] HOST PORT\n");
+    printf("\t- P <filename>\tneat properties, default properties:\n%s\n", config_property);
+    printf("\t- R \treceive buffer in byte (%d)\n", config_rcv_buffer_size);
+    printf("\t- S \tsend buffer in byte (%d)\n", config_snd_buffer_size);
+    printf("\t- J \tprint json stats for each time data is sent\n");
+    printf("\t- T \twrite timeout in seconds (where available) (%d)\n", config_timeout);
+    printf("\t- v \tlog level 0..2 (%d)\n", config_log_level);
+    printf("\t- A \tprimary dest. addr. (auto)\n");
+}
+
+// Error handler
+static neat_error_code
+on_error(struct neat_flow_operations *opCB)
+{
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+    // Placeholder until neat_error handling is implemented
+    return 1;
+}
+
+// Abort handler
+static neat_error_code
+on_abort(struct neat_flow_operations *opCB)
+{
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    fprintf(stderr, "The flow was aborted!\n");
+
+    exit(EXIT_FAILURE);
+}
+
+// Network change handler
+static neat_error_code
+on_network_changed(struct neat_flow_operations *opCB)
+{
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    if (config_log_level >= 1) {
+        fprintf(stderr, "Something happened in the network: %d\n", (int)opCB->status);
+    }
+
+    return NEAT_OK;
+}
+
+// Timeout handler
+static neat_error_code
+on_timeout(struct neat_flow_operations *opCB)
+{
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    fprintf(stderr, "The flow reached a timeout!\n");
+
+    exit(EXIT_FAILURE);
+}
+
+// Read data from neat
+static neat_error_code
+on_readable(struct neat_flow_operations *opCB)
+{
+    // data is available to read
+    uint32_t buffer_filled;
+    neat_error_code code;
+
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    code = neat_read(opCB->ctx, opCB->flow, buffer_rcv, config_rcv_buffer_size, &buffer_filled, NULL, 0);
+    if (code != NEAT_OK) {
+        if (code == NEAT_ERROR_WOULD_BLOCK) {
+            if (config_log_level >= 1) {
+                fprintf(stderr, "%s - neat_read - NEAT_ERROR_WOULD_BLOCK\n", __func__);
+            }
+            return NEAT_OK;
+        } else if (code == NEAT_ERROR_DSCP_RETRY) {
+            return NEAT_OK;
+        } else {
+            fprintf(stderr, "%s - neat_read - error: %d\n", __func__, (int)code);
+            return on_error(opCB);
+        }
+    }
+
+    // all fine
+    if (buffer_filled > 0) {
+        if (config_log_level >= 1) {
+            fprintf(stderr, "%s - received %d bytes\n", __func__, buffer_filled);
+        }
+        fwrite(buffer_rcv, sizeof(char), buffer_filled, stdout);
+        fflush(stdout);
+
+    } else {
+        if (config_log_level >= 1) {
+            fprintf(stderr, "%s - disconnected\n", __func__);
+        }
+        ops.on_readable = NULL;
+        ops.on_writable = NULL;
+        neat_set_operations(ctx, flow, &ops);
+        neat_stop_event_loop(opCB->ctx);
+    }
+
+    return NEAT_OK;
+}
+
+// Send data from stdin
+static neat_error_code
+on_writable(struct neat_flow_operations *opCB)
+{
+    neat_error_code code;
+
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    code = neat_write(opCB->ctx, opCB->flow, stdin_buffer.buffer, stdin_buffer.buffer_filled, NULL, 0);
+    if (code != NEAT_OK) {
+        fprintf(stderr, "%s - neat_write - error: %d\n", __func__, (int)code);
+        return on_error(opCB);
+    }
+
+    if (config_log_level >= 1) {
+        fprintf(stderr, "%s - sent %d bytes\n", __func__, stdin_buffer.buffer_filled);
+    }
+
+    // stop writing
+    ops.on_writable = NULL;
+    neat_set_operations(ctx, flow, &ops);
+    return NEAT_OK;
+}
+
+static neat_error_code
+on_all_written(struct neat_flow_operations *opCB)
+{
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    // data sent completely - continue reading from stdin
+    uv_read_start((uv_stream_t*) &tty, tty_alloc, tty_read);
+    return NEAT_OK;
+}
+
+static neat_error_code
+on_connected(struct neat_flow_operations *opCB)
+{
+    int rc;
+
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    uv_tty_init(ctx->loop, &tty, 0, 1);
+    uv_read_start((uv_stream_t*) &tty, tty_alloc, tty_read);
+
+    ops.on_readable = on_readable;
+    neat_set_operations(ctx, flow, &ops);
+
+    if (config_primary_dest_addr != NULL) {
+        rc = neat_set_primary_dest(ctx, flow, config_primary_dest_addr);
+        if (rc) {
+            fprintf(stderr, "Failed to set primary dest. addr.: %u\n", rc);
+        } else {
+            if (config_log_level > 1)
+                fprintf(stderr, "Primary dest. addr. set to: '%s'.\n",
+            config_primary_dest_addr);
+        }
+    }
+
+    if (config_timeout)
+        neat_change_timeout(ctx, flow, config_timeout);
+
+    return NEAT_OK;
+}
+
+static neat_error_code
+on_close(struct neat_flow_operations *opCB)
+{
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    fprintf(stderr, "%s - flow closed OK!\n", __func__);
+
+    return NEAT_OK;
+    }
+
+/*
+    Read from stdin
+*/
+void
+tty_read(uv_stream_t *stream, ssize_t buffer_filled, const uv_buf_t *buffer)
+{
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    if (config_log_level >= 1) {
+        fprintf(stderr, "%s - tty_read called with buffer_filled %zd\n", __func__, buffer_filled);
+    }
+
+    // error case
+    if (buffer_filled == UV_EOF) {
+        if (config_log_level >= 1) {
+            fprintf(stderr, "%s - tty_read - UV_EOF\n", __func__);
+        }
+        uv_read_stop(stream);
+        ops.on_writable = NULL;
+        neat_set_operations(ctx, flow, &ops);
+        neat_shutdown(ctx, flow);
+    } else if (strncmp(buffer->base, "close\n", buffer_filled) == 0) {
+        if (config_log_level >= 1) {
+            fprintf(stderr, "%s - tty_read - CLOSE\n", __func__);
+        }
+        uv_read_stop(stream);
+        ops.on_writable = NULL;
+        neat_set_operations(ctx, flow, &ops);
+        neat_close(ctx, flow);
+        buffer_filled = UV_EOF;
+    } else if (strncmp(buffer->base, "abort\n", buffer_filled) == 0) {
+        if (config_log_level >= 1) {
+            fprintf(stderr, "%s - tty_read - ABORT\n", __func__);
+        }
+        uv_read_stop(stream);
+        ops.on_writable = NULL;
+        neat_set_operations(ctx, flow, &ops);
+        neat_abort(ctx, flow);
+        buffer_filled = UV_EOF;
+    }
+
+    // all fine
+    if (buffer_filled > 0) {
+        // copy input to app buffer
+        stdin_buffer.buffer_filled = buffer_filled;
+        memcpy(stdin_buffer.buffer, buffer->base, buffer_filled);
+
+        // stop reading from stdin and set write callbacks
+        uv_read_stop(stream);
+        ops.on_writable = on_writable;
+        ops.on_all_written = on_all_written;
+        neat_set_operations(ctx, flow, &ops);
+    }
+
+    free(buffer->base);
+}
+
+void
+tty_alloc(uv_handle_t *handle, size_t suggested, uv_buf_t *buffer)
+{
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    buffer->len = config_rcv_buffer_size;
+    buffer->base = malloc(config_rcv_buffer_size);
+}
+
+
+int
+main(int argc, char *argv[])
+{
+    int arg, result;
+    char *arg_property = NULL;
+
+    memset(&ops, 0, sizeof(ops));
+    memset(&stdin_buffer, 0, sizeof(stdin_buffer));
+
+    result = EXIT_SUCCESS;
+
+    while ((arg = getopt(argc, argv, "P:R:S:T:Jv:A:")) != -1) {
+        switch(arg) {
+        case 'P':
+            // arg_property = optarg;
+            if (read_file(optarg, &arg_property) < 0) {
+                fprintf(stderr, "Unable to read properties from %s: %s",
+                        optarg, strerror(errno));
+                result = EXIT_FAILURE;
+                goto cleanup;
+            }
+            if (config_log_level >= 1) {
+                fprintf(stderr, "%s - option - properties: %s\n", __func__, arg_property);
+            }
+            break;
+        case 'R':
+            config_rcv_buffer_size = atoi(optarg);
+            if (config_log_level >= 1) {
+                fprintf(stderr, "%s - option - receive buffer size: %d\n", __func__, config_rcv_buffer_size);
+            }
+            break;
+        case 'S':
+            config_snd_buffer_size = atoi(optarg);
+            if (config_log_level >= 1) {
+                fprintf(stderr, "%s - option - send buffer size: %d\n", __func__, config_snd_buffer_size);
+            }
+            break;
+        case 'J':
+            config_json_stats = 1;
+            if (config_log_level >= 1) {
+                fprintf(stderr, "%s - option - json stats on send enabled\n", __func__);
+            }
+            break;
+        case 'v':
+            config_log_level = atoi(optarg);
+            if (config_log_level >= 1) {
+                fprintf(stderr, "%s - option - log level: %d\n", __func__, config_log_level);
+            }
+            break;
+        case 'T':
+            config_timeout = atoi(optarg);
+            if (config_log_level >= 1) {
+                fprintf(stderr, "%s - option - timeout: %d seconds\n", __func__, config_timeout);
+            }
+            break;
+        case 'A':
+            config_primary_dest_addr = optarg;
+            if (config_log_level >= 1) {
+                fprintf(stderr, "%s - option - primary dest. address: %s\n", __func__, config_primary_dest_addr);
+            }
+            break;
+        default:
+            print_usage();
+            goto cleanup;
+            break;
+        }
+    }
+
+    if (optind + 2 != argc) {
+        fprintf(stderr, "%s - error: option - argument error\n", __func__);
+        print_usage();
+        goto cleanup;
+    }
+
+    if ((buffer_rcv = malloc(config_rcv_buffer_size)) == NULL) {
+        fprintf(stderr, "%s - error: could not allocate receive buffer\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+    if ((buffer_snd = malloc(config_snd_buffer_size)) == NULL) {
+        fprintf(stderr, "%s - error: could not allocate send buffer\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+    if ((stdin_buffer.buffer = malloc(config_snd_buffer_size)) == NULL) {
+        fprintf(stderr, "%s - error: could not allocate stdin buffer\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    if ((ctx = neat_init_ctx()) == NULL) {
+        fprintf(stderr, "%s - error: could not initialize context\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    // new neat flow
+    if ((flow = neat_new_flow(ctx)) == NULL) {
+        fprintf(stderr, "%s - error: could not create new neat flow\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    // set properties
+    if (neat_set_property(ctx, flow, arg_property ? arg_property : config_property)) {
+        fprintf(stderr, "%s - error: neat_set_property\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    neat_set_property(ctx, flow, "{ \"dscp\": 1 }");
+
+    // set callbacks
+    ops.on_connected = on_connected;
+    ops.on_error = on_error;
+    ops.on_close = on_close;
+    ops.on_aborted = on_abort;
+    ops.on_network_status_changed = on_network_changed;
+    ops.on_timeout = on_timeout;
+
+    if (neat_set_operations(ctx, flow, &ops)) {
+        fprintf(stderr, "%s - error: neat_set_operations\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    // wait for on_connected or on_error to be invoked
+    if (neat_open(ctx, flow, argv[argc - 2], strtoul (argv[argc - 1], NULL, 0), NULL, 0) == NEAT_OK) {
+        neat_start_event_loop(ctx, NEAT_RUN_DEFAULT);
+    } else {
+        fprintf(stderr, "%s - error: neat_open\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+cleanup:
+    free(buffer_rcv);
+    free(buffer_snd);
+    free(stdin_buffer.buffer);
+
+    if (arg_property)
+        free(arg_property);
+
+    // cleanup
+    if (flow != NULL) {
+        // neat_free_flow(flow);
+    }
+    if (ctx != NULL) {
+        neat_free_ctx(ctx);
+    }
+    exit(result);
+}

--- a/examples/tneat_fg.c
+++ b/examples/tneat_fg.c
@@ -1,0 +1,521 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/time.h>
+#include "../neat.h"
+
+/**********************************************************************
+
+    tneat - neat testing tool
+
+    tneat [OPTIONS] [HOST]
+    -l : message length in byte (client)
+    -n : number off messages to send (client)
+    -p : port
+    -P : neat properties
+    -R : receive buffer in byte (server)
+    -T : max runtime (client)
+    -v : log level (0 .. 2)
+
+**********************************************************************/
+
+/*
+    default values
+*/
+static uint32_t config_rcv_buffer_size = 512;
+static uint32_t config_snd_buffer_size = 1024;
+static uint32_t config_message_count = 32;
+static uint32_t config_runtime_max = 0;
+static uint16_t config_active = 0;
+static uint16_t config_chargen_offset = 0;
+static uint16_t config_port = 8080;
+static uint16_t config_log_level = 1;
+static float config_priority = 1.0f;
+static uint16_t config_group = 0;
+static char *config_property = "{\
+    \"transport\": [\
+        {\
+            \"value\": \"TCP\",\
+            \"precedence\": 1\
+        }\
+    ]\
+}";
+static uint8_t done = 0;
+
+/*
+    macro - tvp-uvp=vvp
+*/
+
+#ifndef timersub
+#define timersub(tvp, uvp, vvp)                                 \
+    do {                                                        \
+        (vvp)->tv_sec = (tvp)->tv_sec - (uvp)->tv_sec;          \
+        (vvp)->tv_usec = (tvp)->tv_usec - (uvp)->tv_usec;       \
+        if ((vvp)->tv_usec < 0) {                               \
+            (vvp)->tv_sec--;                                    \
+            (vvp)->tv_usec += 1000000;                          \
+        }                                                       \
+    } while (0)
+#endif
+
+struct tneat_flow_direction {
+    unsigned char *buffer;
+    uint32_t calls;
+    uint32_t bytes;
+    struct timeval tv_first;
+    struct timeval tv_last;
+};
+
+struct tneat_flow {
+    struct tneat_flow_direction rcv;
+    struct tneat_flow_direction snd;
+};
+
+static neat_error_code on_writable(struct neat_flow_operations *opCB);
+
+/*
+    print usage
+*/
+static void
+print_usage()
+{
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    printf("tneat [OPTIONS] [HOST]\n");
+    printf("\t- l \tsize for each message in byte (%d)\n", config_snd_buffer_size);
+    printf("\t- n \tmax number of messages to send (%d)\n", config_message_count);
+    printf("\t- p \tport [receive on|send to] (%d)\n", config_port);
+    printf("\t- P \tneat properties (%s)\n", config_property);
+    printf("\t- R \treceive buffer in byte (%d)\n", config_rcv_buffer_size);
+    printf("\t- T \tmax runtime in seconds (%d)\n", config_runtime_max);
+    printf("\t- w \tpriority (%f)\n", config_priority);
+    printf("\t- g \tgroup (%d)\n", config_group);
+    printf("\t- v \tlog level 0..3 (%d)\n", config_log_level);
+}
+
+/*
+    print human readable file sizes - helper function
+*/
+static char
+*filesize_human(double bytes, char *buffer, size_t buffersize)
+{
+    uint8_t i = 0;
+    const char* units[] = {"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"};
+
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    while (bytes > 1000) {
+        bytes /= 1000;
+        i++;
+    }
+    snprintf(buffer, buffersize, "%.*f %s", i, bytes, units[i]);
+    return buffer;
+}
+
+/*
+    error handler
+*/
+static neat_error_code
+on_error(struct neat_flow_operations *opCB)
+{
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+    exit(EXIT_FAILURE);
+}
+
+static neat_error_code
+on_all_written(struct neat_flow_operations *opCB)
+{
+    struct tneat_flow *tnf = opCB->userData;
+    struct timeval now, diff_time;
+    double time_elapsed;
+    char buffer_filesize_human[32];
+
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    gettimeofday(&now, NULL);
+    timersub(&(tnf->snd.tv_last), &(tnf->snd.tv_first), &diff_time);
+    time_elapsed = diff_time.tv_sec + (double)diff_time.tv_usec/1000000.0;
+
+    // runtime- or message-limit reached
+    if ((config_runtime_max > 0 && time_elapsed >= config_runtime_max) ||
+        (config_message_count > 0 && tnf->snd.calls >= config_message_count)) {
+
+        // print statistics
+        printf("neat_write finished - statistics\n");
+        printf("\tbytes\t\t: %u\n", tnf->snd.bytes);
+        printf("\tsnd-calls\t: %u\n", tnf->snd.calls);
+        printf("\tduration\t: %.2fs\n", time_elapsed);
+        printf("\tbandwidth\t: %s/s\n", filesize_human(tnf->snd.bytes/time_elapsed, buffer_filesize_human, sizeof(buffer_filesize_human)));
+
+        done = 1;
+    }
+
+    opCB->on_writable = on_writable;
+    opCB->on_all_written = NULL;
+    neat_set_operations(opCB->ctx, opCB->flow, opCB);
+    return NEAT_OK;
+}
+
+/*
+    send *config_message_size* chars to peer
+*/
+static neat_error_code
+on_writable(struct neat_flow_operations *opCB)
+{
+    struct tneat_flow *tnf = opCB->userData;
+    neat_error_code code;
+
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    // record first send call
+    if (tnf->snd.calls == 0) {
+        gettimeofday(&(tnf->snd.tv_first), NULL);
+    }
+
+    // set callbacks
+    opCB->on_writable = NULL;
+    opCB->on_all_written = on_all_written;
+    neat_set_operations(opCB->ctx, opCB->flow, opCB);
+
+    // increase stats
+    tnf->snd.calls++;
+    tnf->snd.bytes += config_snd_buffer_size;
+    gettimeofday(&(tnf->snd.tv_last), NULL);
+
+    // every message contains a different payload (i++)
+    config_chargen_offset = (config_chargen_offset+1) % 72;
+    memset(tnf->snd.buffer, 33 + config_chargen_offset, config_snd_buffer_size);
+
+    if (config_log_level >= 2) {
+        printf("neat_write - # %u - %d byte\n", tnf->snd.calls, config_snd_buffer_size);
+        if (config_log_level >= 3) {
+            printf("neat_write - content\n");
+            fwrite(tnf->snd.buffer, sizeof(char), config_snd_buffer_size, stdout);
+            printf("\n");
+        }
+    }
+
+    code = neat_write(opCB->ctx, opCB->flow, tnf->snd.buffer, config_snd_buffer_size, NULL, 0);
+
+    if (done) {
+        opCB->on_writable = NULL;
+        opCB->on_all_written = NULL;
+        neat_set_operations(opCB->ctx, opCB->flow, opCB);
+        neat_shutdown(opCB->ctx, opCB->flow);
+        return NEAT_OK;
+    }
+
+    if (code != NEAT_OK) {
+        fprintf(stderr, "%s - neat_write error: code %d\n", __func__, (int)code);
+        return on_error(opCB);
+    }
+
+    return NEAT_OK;
+}
+
+static neat_error_code
+on_readable(struct neat_flow_operations *opCB)
+{
+    struct tneat_flow *tnf = opCB->userData;
+    uint32_t buffer_filled;
+    struct timeval diff_time;
+    neat_error_code code;
+    char buffer_filesize_human[32];
+    double time_elapsed;
+
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    code = neat_read(opCB->ctx, opCB->flow, tnf->rcv.buffer, config_rcv_buffer_size, &buffer_filled, NULL, 0);
+    if (code) {
+        if (code == NEAT_ERROR_WOULD_BLOCK) {
+            fprintf(stderr, "%s - neat_read warning: NEAT_ERROR_WOULD_BLOCK\n", __func__);
+            return NEAT_OK;
+        } else {
+            fprintf(stderr, "%s - neat_read error: code %d\n", __func__, (int)code);
+            return on_error(opCB);
+        }
+    }
+
+    if (buffer_filled > 0) {
+        // we got data!
+        if (tnf->rcv.calls == 0) {
+            gettimeofday(&(tnf->rcv.tv_first), NULL);
+        }
+        tnf->rcv.calls++;
+        tnf->rcv.bytes += buffer_filled;
+        gettimeofday(&(tnf->rcv.tv_last), NULL);
+
+        if (config_log_level >= 2) {
+            printf("neat_read - # %u- %d byte\n", tnf->rcv.calls, buffer_filled);
+            if (config_log_level >= 3) {
+                fwrite(tnf->rcv.buffer, sizeof(char), buffer_filled, stdout);
+                printf("\n");
+            }
+        }
+    // peer disconnected
+    } else if (buffer_filled == 0){
+        if (config_log_level >= 1) {
+            printf("connection closed\n");
+        }
+
+        opCB->on_readable = NULL;
+        opCB->on_writable = NULL;
+        opCB->on_all_written = NULL;
+        neat_set_operations(opCB->ctx, opCB->flow, opCB);
+
+        // we are client
+        if (config_active) {
+            // neat_free_flow(opCB->flow);
+            neat_stop_event_loop(opCB->ctx);
+        } else  { // we are server
+            // print statistics
+            timersub(&(tnf->rcv.tv_last), &(tnf->rcv.tv_first), &diff_time);
+            time_elapsed = diff_time.tv_sec + (double)diff_time.tv_usec/1000000.0;
+
+            printf("%u, %u, %.2f, %.2f, %s\n", tnf->rcv.bytes, tnf->rcv.calls, time_elapsed, tnf->rcv.bytes/time_elapsed, filesize_human(tnf->rcv.bytes/time_elapsed, buffer_filesize_human, sizeof(buffer_filesize_human)));
+
+            if (config_log_level >= 1) {
+                printf("client disconnected - statistics\n");
+                printf("\tbytes\t\t: %u\n", tnf->rcv.bytes);
+                printf("\trcv-calls\t: %u\n", tnf->rcv.calls);
+                printf("\tduration\t: %.2fs\n", time_elapsed);
+                printf("\tbandwidth\t: %s/s\n", filesize_human(tnf->rcv.bytes/time_elapsed, buffer_filesize_human, sizeof(buffer_filesize_human)));
+            }
+
+            // neat_free_flow(opCB->flow);
+        }
+
+        free(tnf->snd.buffer);
+        free(tnf->rcv.buffer);
+        free(tnf);
+    }
+
+    return NEAT_OK;
+}
+
+/*
+    Connection established - set callbacks and reset statistics
+*/
+static neat_error_code
+on_connected(struct neat_flow_operations *opCB)
+{
+    struct tneat_flow *tnf = NULL;
+
+    if (config_log_level >= 2) {
+        fprintf(stderr, "%s()\n", __func__);
+    }
+
+    if (config_log_level >= 1) {
+        printf("connected\n");
+    }
+
+    if ((opCB->userData = calloc(1, sizeof(struct tneat_flow))) == NULL) {
+        fprintf(stderr, "%s - could not allocate tneat_flow\n", __func__);
+        exit(EXIT_FAILURE);
+    }
+
+    tnf = opCB->userData;
+
+    if ((tnf->snd.buffer = malloc(config_snd_buffer_size)) == NULL) {
+        fprintf(stderr, "%s - could not allocate send buffer\n", __func__);
+        exit(EXIT_FAILURE);
+    }
+
+    if ((tnf->rcv.buffer = malloc(config_rcv_buffer_size)) == NULL) {
+        fprintf(stderr, "%s - could not allocate receive buffer\n", __func__);
+        exit(EXIT_FAILURE);
+    }
+
+    // reset stats
+    tnf->snd.calls = 0;
+    tnf->snd.bytes = 0;
+    tnf->rcv.calls = 0;
+    tnf->rcv.bytes = 0;
+
+    // set callbacks
+    opCB->on_readable = on_readable;
+    if (config_active) {
+        opCB->on_writable = on_writable;
+    }
+    neat_set_operations(opCB->ctx, opCB->flow, opCB);
+
+    return NEAT_OK;
+}
+
+int
+main(int argc, char *argv[])
+{
+    struct neat_ctx *ctx = NULL;
+    struct neat_flow *flow = NULL;
+    struct neat_flow_operations ops;
+    int arg, result;
+    char *arg_property = config_property;
+    NEAT_OPTARGS_DECLARE(2);
+    NEAT_OPTARGS_INIT();
+
+    memset(&ops, 0, sizeof(ops));
+
+    result = EXIT_SUCCESS;
+
+    while ((arg = getopt(argc, argv, "l:n:p:w:g:P:R:T:v:")) != -1) {
+        switch(arg) {
+        case 'l':
+            config_snd_buffer_size = atoi(optarg);
+            if (config_log_level >= 1) {
+                printf("option - send buffer size: %d\n", config_snd_buffer_size);
+            }
+            break;
+        case 'n':
+            config_message_count = atoi(optarg);
+            if (config_log_level >= 1) {
+                printf("option - message limit: %d\n", config_message_count);
+            }
+            break;
+        case 'p':
+            config_port = atoi(optarg);
+            if (config_log_level >= 1) {
+                printf("option - port: %d\n", config_port);
+            }
+            break;
+        case 'P':
+            arg_property = optarg;
+            if (config_log_level >= 1) {
+                printf("option - properties: %s\n", arg_property);
+            }
+            break;
+        case 'R':
+            config_rcv_buffer_size = atoi(optarg);
+            if (config_log_level >= 1) {
+                printf("option - receive buffer size: %d\n", config_rcv_buffer_size);
+            }
+            break;
+        case 'T':
+            config_runtime_max = atoi(optarg);
+            if (config_log_level >= 1) {
+                printf("option - runtime limit: %d\n", config_runtime_max);
+            }
+            break;
+        case 'v':
+            config_log_level = atoi(optarg);
+            if (config_log_level >= 1) {
+                printf("option - log level: %d\n", config_log_level);
+            }
+            break;
+        case 'g':
+            config_group = atoi(optarg);
+            if (config_log_level >= 1) {
+                printf("option - group: %d\n", config_group);
+            }
+            break;
+        case 'w':
+            config_priority = atof(optarg);
+            if (config_log_level >= 1) {
+                printf("option - priority: %f\n", config_priority);
+            }
+            break;
+        default:
+            print_usage();
+            goto cleanup;
+            break;
+        }
+    }
+
+    if (optind == argc) {
+        config_active = 0;
+        if (config_log_level >= 1) {
+            printf("role: passive\n");
+        }
+    } else if (optind + 1 == argc) {
+        config_active = 1;
+        if (config_log_level >= 1) {
+            printf("role: active\n");
+        }
+    } else {
+        fprintf(stderr, "%s - argument error\n", __func__);
+        print_usage();
+        goto cleanup;
+    }
+
+    if ((ctx = neat_init_ctx()) == NULL) {
+        fprintf(stderr, "%s - neat_init_ctx failed\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    // new neat flow
+    if ((flow = neat_new_flow(ctx)) == NULL) {
+        fprintf(stderr, "%s - neat_new_flow failed\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    ops.on_connected = on_connected;
+    ops.on_error = on_error;
+
+    //ops.on_all_written = on_all_written;
+    if (neat_set_operations(ctx, flow, &ops)) {
+        fprintf(stderr, "%s - neat_set_operations failed\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    // set properties
+    if (neat_set_property(ctx, flow, arg_property)) {
+        fprintf(stderr, "%s - neat_set_property failed\n", __func__);
+        result = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    if (config_active) {
+        if (config_group) {
+            NEAT_OPTARG_INT(NEAT_TAG_FLOW_GROUP, config_group);
+            NEAT_OPTARG_FLOAT(NEAT_TAG_PRIORITY, config_priority);
+            NEAT_OPTARG_STRING(NEAT_TAG_CC_ALGORITHM, "newreno_afse");
+        }
+
+        // connect to peer
+        if (neat_open(ctx, flow, argv[optind], config_port, NEAT_OPTARGS, NEAT_OPTARGS_COUNT) == NEAT_OK) {
+            if (config_log_level >= 1) {
+                printf("neat_open - connecting to %s:%d\n", argv[optind], config_port);
+            }
+            neat_start_event_loop(ctx, NEAT_RUN_DEFAULT);
+        } else {
+            fprintf(stderr, "%s - neat_open failed\n", __func__);
+            result = EXIT_FAILURE;
+            goto cleanup;
+        }
+    } else {
+        // wait for on_connected or on_error to be invoked
+        if (neat_accept(ctx, flow, config_port, NULL, 0)) {
+            fprintf(stderr, "%s - neat_accept failed\n", __func__);
+            result = EXIT_FAILURE;
+            goto cleanup;
+        }
+
+        neat_start_event_loop(ctx, NEAT_RUN_DEFAULT);
+    }
+
+    if (config_log_level >= 1) {
+        printf("freeing ctx bye bye!\n");
+    }
+
+    // cleanup
+cleanup:
+    if (ctx != NULL) {
+        neat_free_ctx(ctx);
+    }
+    exit(result);
+}

--- a/neat.h
+++ b/neat.h
@@ -209,6 +209,7 @@ NEAT_EXTERN neat_error_code neat_set_ecn(struct neat_ctx *ctx,
 #define NEAT_ERROR_MESSAGE_TOO_BIG  (8)
 #define NEAT_ERROR_REMOTE           (9)
 #define NEAT_ERROR_OUT_OF_MEMORY    (10)
+#define NEAT_ERROR_DSCP_RETRY       (11)
 
 #define NEAT_INVALID_STREAM (-1)
 

--- a/neat_core.c
+++ b/neat_core.c
@@ -1787,6 +1787,7 @@ he_connected_cb(uv_poll_t *handle, int status, int events)
     struct neat_he_candidates *candidate_list = flow->candidate_list;
     struct cib_he_res *he_res = NULL;
     struct neat_ctx *ctx = flow->ctx;
+    json_t *prop;
     neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
 
     c++;
@@ -1923,6 +1924,18 @@ he_connected_cb(uv_poll_t *handle, int status, int events)
         flow->isPolling = 1;
 
         send_result_connection_attempt_to_pm(flow->ctx, flow, he_res, true);
+
+        if ((prop = json_object_get(candidate->properties, "dscp")) != NULL) {
+            if (json_typeof(prop) == JSON_INTEGER) {
+                int i = json_integer_value(prop);
+                neat_set_qos(ctx, flow, i);
+                neat_log(ctx, NEAT_LOG_DEBUG, "-- Applied property \"dscp\"");
+            } else {
+                neat_log(ctx, NEAT_LOG_DEBUG, "Expected property 'dscp' to be integer, ignoring");
+            }
+        } else {
+            neat_log(ctx, NEAT_LOG_DEBUG, "No dscp value");
+        }
 
         if (!install_security(candidate)) {
             // Transfer this handle to the "main" polling callback
@@ -3686,6 +3699,30 @@ neat_set_checksum_coverage(struct neat_ctx *ctx, struct neat_flow *flow, unsigne
     return NEAT_ERROR_UNABLE;
 }
 
+static int
+neat_dscp_second_chance(struct neat_ctx *ctx, struct neat_flow *flow)
+{
+    json_t *dscp;
+    // neat_log(NEAT_LOG_DEBUG, "%s", __func__);
+
+    if (flow->qos == 0)
+        return -1;
+
+    neat_close_socket(ctx, flow);
+
+    uv_poll_stop(flow->socket->handle);
+    uv_close((uv_handle_t*)flow->socket->handle, NULL);
+
+    dscp = json_integer(0);
+    json_object_set(flow->properties, "dscp", dscp);
+    json_decref(dscp);
+
+    neat_resolve(ctx->resolver, AF_UNSPEC, flow->name, flow->port,
+                 open_resolve_cb, flow);
+
+    return 0;
+}
+
 static neat_error_code
 accept_resolve_cb(struct neat_resolver_results *results,
                   uint8_t code,
@@ -4411,6 +4448,11 @@ neat_read_from_lower_layer(struct neat_ctx *ctx, struct neat_flow *flow,
             neat_log(ctx, NEAT_LOG_ERROR, "%s: err %d (%s)", __func__,
                      errno, strerror(errno));
         }
+
+        if (neat_dscp_second_chance(ctx, flow) == 0) {
+            return NEAT_ERROR_DSCP_RETRY;
+        }
+
         return NEAT_ERROR_IO;
     }
     neat_log(ctx, NEAT_LOG_DEBUG, "%s %d", __func__, rv);

--- a/neat_qos.c
+++ b/neat_qos.c
@@ -55,6 +55,8 @@ neat_set_tos(struct neat_ctx *ctx, struct neat_flow *flow)
         return NEAT_OK;
     }
 #endif //SCTP_PEER_ADDR_PARAMS
+    case NEAT_STACK_TCP:
+        // fallthrough;
     case NEAT_STACK_UDP:
     {
         if(setsockopt(flow->socket->fd, 

--- a/tests/dscp_failover_preload.c
+++ b/tests/dscp_failover_preload.c
@@ -1,0 +1,75 @@
+/*
+ * Code for testing the DSCP failover mechanism.
+ *
+ * Compile:
+ * gcc -Wall -fPIC -shared -o dscp_failover_preload.so dscp_failover_preload.c -ldl
+ *
+ * Run:
+ * LD_PRELOAD=<neat_dir>/tests/dscp_failover_preload.so:/usr/lib/libuv.so [command]
+ */
+
+#define _GNU_SOURCE
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <dlfcn.h>
+#include <errno.h>
+
+#include <netinet/in.h>
+
+#define ORIGINAL_FUNC(name, retval, params...) \
+    retval (*original_ ## name)(params); \
+    original_## name = (retval (*)(params))dlsym(RTLD_NEXT, #name);
+
+static int victim_fd = 0;
+
+int setsockopt(int sockfd, int level, int optname, const void *optval, socklen_t optlen)
+{
+    ORIGINAL_FUNC(setsockopt, int, int, int, int, const void*, socklen_t);
+
+    if (level != IPPROTO_IP)
+        goto passthrough;
+
+    if (optname != IP_TOS)
+        goto passthrough;
+
+    if (optval == NULL || *(int*)optval == 0)
+        goto passthrough;
+
+    fprintf(stderr, ">>> SETTING TOS TO 0x%x\n", *(int*)optval);
+
+    victim_fd = sockfd;
+    fprintf(stderr, ">>> VICTIM IS FD %d\n", victim_fd);
+
+passthrough:
+    return original_setsockopt(sockfd, level, optname, optval, optlen);
+}
+
+ssize_t recv(int sockfd, void* buf, size_t len, int flags)
+{
+    static int deploy_trap_in = 3;
+    ORIGINAL_FUNC(recv, ssize_t, int, void*, size_t, int);
+
+    if (victim_fd == 0 || sockfd != victim_fd)
+        goto passthrough;
+
+    if (deploy_trap_in && --deploy_trap_in)
+        goto passthrough;
+
+    // IT'S A TRAP!
+    //      - Admiral Ackbar
+
+    errno = ETIMEDOUT;
+    return -1;
+passthrough:
+    return original_recv(sockfd, buf, len, flags);
+}
+
+int close(int sockfd)
+{
+    ORIGINAL_FUNC(close, int, int);
+    if (victim_fd != 0 && sockfd == victim_fd)
+        victim_fd = 0;
+
+    return original_close(sockfd);
+}


### PR DESCRIPTION
This piece of code is an attempt to provide a **DSCP fallback mechanism** in NEAT. When non-zero DSCP code-points is tried and if the connection fails, it will issue a new resolver+PM call, this time with DSCP=0. _dscp_second_chance()_ is the function that implements this mechanism.

**NOTE:**  connection failures must likely to be checked in multiple places for this to work in practice, not just in the single location in _neat_read_from_lower_layer()_ that is currently being checked. It is by no means complete in its current state.   

comments/more testing is highly appreciated :)