### PR TITLE
neat_new_flow: assign 'ctx' early

### DIFF
--- a/neat_core.c
+++ b/neat_core.c
@@ -3482,7 +3482,6 @@ neat_open(neat_ctx *ctx, neat_flow *flow, const char *name, uint16_t port,
         return NEAT_ERROR_OUT_OF_MEMORY;
     flow->port = port;
     //flow->stream_count = stream_count;
-    flow->ctx = ctx;
     flow->group = group;
     flow->priority = priority;
     if ((multihoming = json_object_get(flow->properties, "multihoming")) != NULL &&
@@ -5658,6 +5657,7 @@ neat_flow
         goto error;
     }
 
+    rv->ctx                 = ctx;
     rv->writefx             = neat_write_to_lower_layer;
     rv->readfx              = neat_read_from_lower_layer;
     rv->acceptfx            = neat_accept_via_kernel;


### PR DESCRIPTION
... since we need it for logging and things and we want to do that
before we do neat_open() which previously was the one to assign the ctx
field.