### PR TITLE
neat_pvd_release: avoid free twice

### DIFF
--- a/neat_pvd.c
+++ b/neat_pvd.c
@@ -586,6 +586,7 @@ neat_pvd_release(struct neat_pvd *pvd)
         LIST_REMOVE(async_query, next_query);
 
         free(async_query->data);
+        async_query->data = NULL;
         neat_pvd_free_async_query(async_query);
     }
 }


### PR DESCRIPTION
I could easily trigger this problem when loading a large amount of images with Firefox-NEAT and with this fix it no longer occurs.