### PR TITLE
neat_request_capacity: removed

### DIFF
--- a/neat.h
+++ b/neat.h
@@ -158,8 +158,6 @@ NEAT_EXTERN neat_error_code neat_change_timeout(struct neat_ctx *ctx, struct nea
                                     unsigned int seconds);
 NEAT_EXTERN neat_error_code neat_set_primary_dest(struct neat_ctx *ctx, struct neat_flow *flow,
                                       const char *name);
-NEAT_EXTERN neat_error_code neat_request_capacity(struct neat_ctx *ctx, struct neat_flow *flow,
-                                      int rate, int seconds);
 NEAT_EXTERN neat_error_code neat_set_checksum_coverage(struct neat_ctx *ctx, struct neat_flow *flow,
                                       unsigned int send_coverage, unsigned int receive_coverage);
 // The filename should be a PEM file with both cert and key

--- a/neat_core.c
+++ b/neat_core.c
@@ -3741,12 +3741,6 @@ neat_set_primary_dest(struct neat_ctx *ctx, struct neat_flow *flow, const char *
 }
 
 neat_error_code
-neat_request_capacity(struct neat_ctx *ctx, struct neat_flow *flow, int rate, int seconds)
-{
-    return NEAT_ERROR_UNABLE;
-}
-
-neat_error_code
 neat_set_checksum_coverage(struct neat_ctx *ctx, struct neat_flow *flow, unsigned int send_coverage, unsigned int receive_coverage)
 {
     neat_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);


### PR DESCRIPTION
Initial stub for this function was added in May 2016 but it doesn't do
anything and it isn't documented.