### PR TITLE
neat_core: check return codes from memory functions

### DIFF
--- a/neat_core.c
+++ b/neat_core.c
@@ -1475,6 +1475,10 @@ io_readable(neat_ctx *ctx, neat_flow *flow,
                 neat_flow *multistream_flow = neat_new_flow(ctx);
 
                 multistream_flow->name                      = strdup(listen_flow->name);
+                if (!multistream_flow->name) {
+                    neat_log(ctx, NEAT_LOG_WARNING, "Out of memory");
+                    return READ_WITH_ERROR;
+                }
                 multistream_flow->port                      = listen_flow->port;
                 multistream_flow->everConnected             = 1;
                 multistream_flow->socket                    = socket;
@@ -1482,6 +1486,8 @@ io_readable(neat_ctx *ctx, neat_flow *flow,
                 multistream_flow->ownedByCore               = 1;
                 multistream_flow->isServer                  = 1;
                 multistream_flow->operations                = calloc (sizeof(struct neat_flow_operations), 1);
+                if (!multistream_flow->operations)
+                    return READ_WITH_ERROR;
                 multistream_flow->operations->on_connected  = listen_flow->operations->on_connected;
                 multistream_flow->operations->on_readable   = listen_flow->operations->on_readable;
                 multistream_flow->operations->on_writable   = listen_flow->operations->on_writable;
@@ -1893,9 +1899,20 @@ he_connected_cb(uv_poll_t *handle, int status, int events)
     neat_log(ctx, NEAT_LOG_DEBUG, "%s - Connection status: %d", __func__, status);
 
     he_res = calloc(1, sizeof(struct cib_he_res));
-    assert(he_res);
+    if (!he_res)
+        return;
+
     he_res->interface   = strdup(candidate->if_name);
+    if (!he_res->interface) {
+        free(he_res);
+        return;
+    }
     he_res->remote_ip   = strdup(candidate->pollable_socket->dst_address);
+    if (!he_res->remote_ip) {
+        free(he_res->interface);
+        free(he_res);
+        return;
+    }
     he_res->remote_port = candidate->pollable_socket->port;
     he_res->transport   = candidate->pollable_socket->stack;
 
@@ -2200,14 +2217,14 @@ do_accept(neat_ctx *ctx, neat_flow *flow, struct neat_pollable_socket *listen_so
         return NULL;
     }
 
-    newFlow->name = strdup (flow->name);
+    newFlow->name = strdup(flow->name);
     if (newFlow->name == NULL) {
         neat_io_error(ctx, newFlow, NEAT_ERROR_OUT_OF_MEMORY);
         return NULL;
     }
 
     if (flow->server_pem) {
-        newFlow->server_pem = strdup (flow->server_pem);
+        newFlow->server_pem = strdup(flow->server_pem);
         if (newFlow->server_pem == NULL) {
             neat_io_error(ctx, flow, NEAT_ERROR_OUT_OF_MEMORY);
             return NULL;
@@ -2529,6 +2546,10 @@ build_he_candidates(neat_ctx *ctx, neat_flow *flow, json_t *json, struct neat_he
                 case JSON_STRING:
                     sockopt->type = NEAT_SOCKOPT_STRING;
                     sockopt->value.s_val = strdup(json_string_value(get_property(value, so_key, JSON_STRING)));
+                    if (!sockopt->value.s_val) {
+                        free(sockopt);
+                        goto out_of_memory;
+                    }
                     neat_log(ctx, NEAT_LOG_DEBUG, "Got socket option \"%s\" with value \"%s\"", so_key, sockopt->value.s_val);
                     break;
                 case JSON_TRUE:
@@ -2675,11 +2696,17 @@ combine_candidates(neat_flow *flow, struct neat_he_candidates *candidate_list)
                                 free(candidate->pollable_socket->src_address);
                             }
                             candidate->pollable_socket->src_address = strdup(cand->pollable_socket->src_address);
+                            if (!candidate->pollable_socket->src_address)
+                                return;
                         }
                     } else {
                         candidate->pollable_socket->src_address =
-                                        realloc(candidate->pollable_socket->src_address,
-                                            strlen(candidate->pollable_socket->src_address) + strlen(cand->pollable_socket->src_address) + 2 * sizeof(char));
+                            realloc(candidate->pollable_socket->src_address,
+                                    strlen(candidate->pollable_socket->src_address) +
+                                    strlen(cand->pollable_socket->src_address) +
+                                    2 * sizeof(char));
+                        if (!candidate->pollable_socket->src_address)
+                            return;
                         strcat(candidate->pollable_socket->src_address, ",");
                         strcat(candidate->pollable_socket->src_address, cand->pollable_socket->src_address);
                     }
@@ -2727,7 +2754,10 @@ on_pm_reply_post_resolve(neat_ctx *ctx, neat_flow *flow, json_t *json)
 #endif
 
     candidate_list = calloc(1, sizeof(*candidate_list));
-    assert(candidate_list);
+    if (!candidate_list) {
+        neat_log(ctx, NEAT_LOG_WARNING, "Out of memory");
+        return;
+    }
     TAILQ_INIT(candidate_list);
 
     build_he_candidates(ctx, flow, json, candidate_list);
@@ -3117,9 +3147,11 @@ open_resolve_cb(struct neat_resolver_results *results, uint8_t code,
             // struct neat_he_candidate *tmp;
 
             struct neat_he_candidate *candidate = calloc(1, sizeof(*candidate));
-            assert(candidate);
+            if (!candidate)
+                return NEAT_ERROR_OUT_OF_MEMORY;
             candidate->pollable_socket = calloc(1, sizeof(struct neat_pollable_socket));
-            assert(candidate->pollable_socket);
+            if (!candidate->pollable_socket)
+                return NEAT_ERROR_OUT_OF_MEMORY;
 
 
             // This ensures we use only one address from each address family for
@@ -3129,12 +3161,23 @@ open_resolve_cb(struct neat_resolver_results *results, uint8_t code,
             //         goto skip;
             // }
             candidate->if_name                      = strdup(iface);
+            if (!candidate->if_name)
+                return NEAT_ERROR_OUT_OF_MEMORY;
             candidate->if_idx                       = result->if_idx;
             candidate->priority = prio++;
 
             candidate->pollable_socket->family      = result->ai_family;
             candidate->pollable_socket->src_address = strdup(src_buffer);
+            if (!candidate->pollable_socket->src_address) {
+                free(candidate->if_name);
+                return NEAT_ERROR_OUT_OF_MEMORY;
+            }
             candidate->pollable_socket->dst_address = strdup(dst_buffer);
+            if (!candidate->pollable_socket->dst_address) {
+                free(candidate->if_name);
+                free(candidate->pollable_socket->src_address);
+                return NEAT_ERROR_OUT_OF_MEMORY;
+            }
             candidate->pollable_socket->port        = flow->port;
             candidate->pollable_socket->stack       = stacks[i];
             candidate->pollable_socket->dst_len     = result->src_addr_len;
@@ -3181,11 +3224,15 @@ open_resolve_cb(struct neat_resolver_results *results, uint8_t code,
             } else {
                 free(candidate->pollable_socket->src_address);
                 candidate->pollable_socket->src_address = strdup(src_buffer);
+                if (!candidate->pollable_socket->src_address)
+                    return NEAT_ERROR_OUT_OF_MEMORY;
                 candidate->pollable_socket->src_len     = result->src_addr_len;
                 memcpy(&candidate->pollable_socket->src_sockaddr, &result->src_addr, result->src_addr_len);
             }
             free(candidate->pollable_socket->dst_address);
             candidate->pollable_socket->dst_address = strdup(dst_buffer);
+            if (!candidate->pollable_socket->dst_address)
+                return NEAT_ERROR_OUT_OF_MEMORY;
             candidate->pollable_socket->dst_len     = result->dst_addr_len;
 
             memcpy(&candidate->pollable_socket->dst_sockaddr, &result->dst_addr, result->dst_addr_len);
@@ -3486,8 +3533,13 @@ send_properties_to_pm(neat_ctx *ctx, neat_flow *flow)
     if ((domains = json_array()) == NULL)
         goto end;
 
-    char *tmp = strdup(flow->name);
     char *ptr = NULL;
+    char *tmp = strdup(flow->name);
+
+    if (!tmp) {
+        rc = NEAT_ERROR_OUT_OF_MEMORY;
+        goto end;
+    }
 
     char *address_name = strtok_r((char *)tmp, ",", &ptr);
     if (address_name == NULL) {
@@ -3884,7 +3936,8 @@ accept_resolve_cb(struct neat_resolver_results *results,
         }
 
         listen_socket = calloc(1, sizeof(*listen_socket));
-        assert(listen_socket);
+        if (!listen_socket)
+            return NEAT_ERROR_OUT_OF_MEMORY;
 
         listen_socket->flow     = flow;
         listen_socket->stack    = neat_base_stack(stacks[i]);
@@ -3917,7 +3970,8 @@ accept_resolve_cb(struct neat_resolver_results *results,
         listen_socket->fd = fd;
 
         handle = calloc(1, sizeof(*handle));
-        assert(handle);
+        if (!handle)
+            return NEAT_ERROR_OUT_OF_MEMORY;
         listen_socket->handle = handle;
         handle->data = listen_socket;
 
@@ -4673,6 +4727,9 @@ neat_connect(struct neat_he_candidate *candidate, uv_poll_cb callback_fx)
         char *local_addr_ptr = (char*) (candidate->pollable_socket->local_addr);
         char *address_name, *ptr;
         char *tmp = strdup(candidate->pollable_socket->src_address);
+        if (!tmp) {
+            return -1;
+        }
 
         address_name = strtok_r((char *)tmp, ",", &ptr);
         while (address_name != NULL) {
@@ -5260,7 +5317,8 @@ neat_accept_via_usrsctp(struct neat_ctx *ctx, struct neat_flow *flow, struct nea
     }
 
     pollable_socket = calloc(1, sizeof(*pollable_socket));
-    assert(pollable_socket);
+    if (!pollable_socket)
+        return NULL;
 
     pollable_socket->fd = -1;
     pollable_socket->flow = flow;
@@ -5330,6 +5388,9 @@ neat_connect_via_usrsctp(struct neat_he_candidate *candidate)
         char *local_addr_ptr = (char*) (candidate->pollable_socket->local_addr);
         char *address_name, *ptr;
         char *tmp = strdup(candidate->pollable_socket->src_address);
+
+        if (!tmp)
+            return -1;
 
         address_name = strtok_r((char *)tmp, ",", &ptr);
         while (address_name != NULL) {
@@ -5485,9 +5546,20 @@ handle_connect(struct socket *sock, void *arg, int flags)
              candidate->priority);
 
     he_res = calloc(1, sizeof(struct cib_he_res));
-    assert(he_res);
+    if (!he_res)
+        return;
+
     he_res->interface = strdup(candidate->if_name);
+    if (!he_res->interface) {
+        free(he_res);
+        return;
+    }
     he_res->remote_ip = strdup(candidate->pollable_socket->dst_address);
+    if (!he_res->remote_ip) {
+        free(he_res->interface);
+        free(re_res);
+        return;
+    }
     he_res->remote_port = candidate->pollable_socket->port;
     he_res->transport = candidate->pollable_socket->stack;
 


### PR DESCRIPTION
This change adds run-time checks of all *alloc() and strdup() calls made in neat_core.c. I'd say it is likely that one or more of these introduce memory leaks in the OOM path but I suspect more review, Coverity and plain old test cases can help us point those out.

(Doing a pull-request for feedback/considerations, especially while the buildbot page is down, see #293)