### PR TITLE
Improve asynchronous address handling

### DIFF
--- a/neat_bsd.c
+++ b/neat_bsd.c
@@ -140,6 +140,8 @@ neat_bsd_get_addresses(struct neat_ctx *ctx)
           break;
     }
     freeifaddrs(ifp);
+
+    ctx->src_addr_dump_done = 1;
     return rc;
 }
 

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -32,7 +32,9 @@
     void (*cleanup)(struct neat_ctx *nc); \
     struct neat_src_addrs src_addrs; \
     struct neat_event_cbs* event_cbs; \
-    uint8_t src_addr_cnt
+    uint8_t src_addr_cnt; \
+    uint8_t src_addr_dump_done; \
+    uint16_t __pad
 
 #define NEAT_MAX_NUM_PROTO 4
 

--- a/neat_linux.c
+++ b/neat_linux.c
@@ -127,8 +127,11 @@ static void neat_linux_nl_recv(uv_udp_t *handle, ssize_t nread,
 
     while (mnl_nlmsg_ok(nl_hdr, numbytes)) {
         if (nl_hdr->nlmsg_type == RTM_NEWADDR ||
-            nl_hdr->nlmsg_type == RTM_DELADDR)
+            nl_hdr->nlmsg_type == RTM_DELADDR) {
             neat_ctx_fail_on_error(nc, neat_linux_handle_addr(nc, nl_hdr));
+        } else if (nl_hdr->nlmsg_type == NLMSG_DONE) {
+            nc->src_addr_dump_done = 1;
+        }
 
         nl_hdr = mnl_nlmsg_next(nl_hdr, &numbytes);
     }

--- a/neat_resolver.h
+++ b/neat_resolver.h
@@ -13,6 +13,7 @@
 //Timeout after first good reply
 #define DNS_RESOLVED_TIMEOUT    1000
 #define DNS_LITERAL_TIMEOUT     1
+#define DNS_ADDRESS_TIMEOUT     100
 #define DNS_BUF_SIZE            1472
 #define MAX_NUM_RESOLVED        3
 #define NO_PROTOCOL             0xFFFFFFFF
@@ -121,6 +122,8 @@ struct neat_resolver_request {
 
     TAILQ_ENTRY(neat_resolver_request) next_req;
     TAILQ_ENTRY(neat_resolver_request) next_dead_req;
+
+    uint8_t is_literal;
 };
 
 #endif


### PR DESCRIPTION
When the DNS literal timeout was reduced to 1ms, a bug in how we
retrieve addresses asynchronous (i.e., the initial address dump on
Linux) was exposed. neat_resolver_timeout_shared() was sometimes called
before any source address was received, causing the resolve callback to
be called with NEAT_ERROR (which is not handled btw).

I have chosen to fix this issue by adding a flag which is set when the
inital address dump is done. Addresses are read synchronously on BSD, so
the flag is set immediatly. Until this flag is set, we will keep calling
neat_resolver_timeout_shared() with a given interval.

Another "bug" discovered when fixing this issue, is that resolving
domains/literals on machines that has no IP (for example right after
boot) will fail. However, I don't think handling this error is the
responsibility of the resolver. How to handle a resolve failure is up to
for example the application, shall we give up or keep trying?

Waiting for buildbot to become available and tests run before merging.