### PR TITLE
IETF Hackathon bugfix: avoid freeing already-removed sockets during nsa_accept().

### DIFF
--- a/socketapi/neat-socketapi-internals.c
+++ b/socketapi/neat-socketapi-internals.c
@@ -241,6 +241,8 @@ static neat_error_code on_connected(struct neat_flow_operations* ops)
       if(newSD >= 0) {
          struct neat_socket* newSocket = nsa_get_socket_for_descriptor(newSD);
          assert(newSocket != NULL);
+         
+         newSocket->ns_acceptor = neatSocket;
 
          neat_set_operations(gSocketAPIInternals->nsi_neat_context,
                              newSocket->ns_flow, &newSocket->ns_flow_ops);
@@ -593,6 +595,12 @@ void nsa_close_internal(struct neat_socket* neatSocket)
 
    pthread_mutex_lock(&neatSocket->ns_mutex);
 
+   /* ====== Remove this socket from accepting socket ==================== */
+   if(neatSocket->ns_acceptor != NULL) {
+      TAILQ_REMOVE(&neatSocket->ns_acceptor->ns_accept_list, neatSocket, ns_accept_node);
+      neatSocket->ns_acceptor = NULL;
+   }
+   
    /* ====== Close accepted sockets first ================================ */
    struct neat_socket* acceptedSocket;
    while( (acceptedSocket = TAILQ_FIRST(&neatSocket->ns_accept_list)) != NULL ) {

--- a/socketapi/neat-socketapi-internals.h
+++ b/socketapi/neat-socketapi-internals.h
@@ -97,6 +97,7 @@ struct neat_socket
    int                                ns_listen_backlog;
    TAILQ_ENTRY(neat_socket)           ns_accept_node;   // Node to handle *this* socket as accepted socekt
    TAILQ_HEAD(slisthead, neat_socket) ns_accept_list;   // Sockets accepted by this socket
+   struct neat_socket*                ns_acceptor;
 
    /* ====== Signals and notification queue ============================== */
    struct event_signal                ns_read_signal;

--- a/socketapi/neat-socketapi.c
+++ b/socketapi/neat-socketapi.c
@@ -390,7 +390,7 @@ int nsa_accept(int sockfd, struct sockaddr* addr, socklen_t* addrlen)
 
          pthread_mutex_lock(&gSocketAPIInternals->nsi_socket_set_mutex);
          pthread_mutex_lock(&neatSocket->ns_mutex);
-
+      
          if(neatSocket->ns_flags & NSAF_LISTENING) {
             /* ====== Accept new socket ================================== */
             struct neat_socket* newSocket = TAILQ_FIRST(&neatSocket->ns_accept_list);
@@ -421,6 +421,8 @@ int nsa_accept(int sockfd, struct sockaddr* addr, socklen_t* addrlen)
             /* ====== Remove new socket from accept queue ================ */
             if(newSocket) {
                TAILQ_REMOVE(&neatSocket->ns_accept_list, newSocket, ns_accept_node);
+               newSocket->ns_acceptor = NULL;
+
                result = newSocket->ns_descriptor;
 
                /* ====== Fill in peer address ============================ */


### PR DESCRIPTION
Bugfix: need to keep track of accepting socket, in order to avoid trying to accept already-removed sockets.