### PR TITLE
IETF Hackathon improvement: more socket API examples improvements

### DIFF
--- a/socketapi/examples/httpserver1.cc
+++ b/socketapi/examples/httpserver1.cc
@@ -147,7 +147,7 @@ int main(int argc, char** argv)
 
          if(fileName[0] != '.') {   // No access to top-level directories!
             std::cout << "Trying to upload file \"" << fileName << "\"..." << std::endl;
-            int fd = nsa_open(fileName.c_str(), 0,0);
+            int fd = nsa_open(fileName.c_str(), 0, 0);
             if(fd >= 0) {
                const char* status = "HTTP/1.0 200 OK\r\n"
                                     "X-Frame-Options: SAMEORIGIN\r\n"

--- a/socketapi/examples/httpserver1.cc
+++ b/socketapi/examples/httpserver1.cc
@@ -20,7 +20,6 @@
  */
 
 #include <iostream>
-#include <fstream>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -102,11 +101,11 @@ int main(int argc, char** argv)
                               NI_NUMERICHOST);
       if(error != 0) {
          std::cerr << "ERROR: getnameinfo() failed: " << gai_strerror(error) << std::endl;
-         exit(1);
       }
-      std::cout << "Got connection from "
-                << remoteHost << ", service " << remoteService << ":" << std::endl;
-
+      else {
+         std::cout << "Got connection from "
+                   << remoteHost << ", service " << remoteService << ":" << std::endl;
+      }
 
       // ====== Get command =================================================
       char   command[8192];
@@ -148,8 +147,8 @@ int main(int argc, char** argv)
 
          if(fileName[0] != '.') {   // No access to top-level directories!
             std::cout << "Trying to upload file \"" << fileName << "\"..." << std::endl;
-            std::ifstream is(fileName.c_str(), std::ios::binary);
-            if(is.good()) {
+            int fd = nsa_open(fileName.c_str(), 0,0);
+            if(fd >= 0) {
                const char* status = "HTTP/1.0 200 OK\r\n"
                                     "X-Frame-Options: SAMEORIGIN\r\n"
                                     "X-XSS-Protection: 1; mode=block\r\n"
@@ -159,10 +158,10 @@ int main(int argc, char** argv)
                result = nsa_write(newSD, status, strlen(status));
 
                char str[256];
-               std::streamsize s = is.rdbuf()->sgetn(str, sizeof(str));
+               ssize_t s = nsa_read(fd, str, sizeof(str));
                while((s > 0) && (result > 0)) {
                   result = nsa_write(newSD, str, s);
-                  s = is.rdbuf()->sgetn(str, sizeof(str));
+                  s = nsa_read(fd, str, sizeof(str));
                }
             }
             else {

--- a/socketapi/examples/httpserver2-select.cc
+++ b/socketapi/examples/httpserver2-select.cc
@@ -71,7 +71,7 @@ void handleHTTPCommand(int sd, const unsigned int id, char* command)
       if(fileName[0] != '.') {   // No access to top-level directories!
          std::cout << "Client " << id << ": Trying to upload file \""
                    << fileName << "\"..." << std::endl;
-         int fd = nsa_open(fileName.c_str(), 0,0);
+         int fd = nsa_open(fileName.c_str(), 0, 0);
          if(fd >= 0) {
             const char* status = "HTTP/1.0 200 OK\r\n"
                                  "X-Frame-Options: SAMEORIGIN\r\n"

--- a/socketapi/examples/httpserver2-select.cc
+++ b/socketapi/examples/httpserver2-select.cc
@@ -20,7 +20,6 @@
  */
 
 #include <iostream>
-#include <fstream>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -72,8 +71,8 @@ void handleHTTPCommand(int sd, const unsigned int id, char* command)
       if(fileName[0] != '.') {   // No access to top-level directories!
          std::cout << "Client " << id << ": Trying to upload file \""
                    << fileName << "\"..." << std::endl;
-         std::ifstream is(fileName.c_str(), std::ios::binary);
-         if(is.good()) {
+         int fd = nsa_open(fileName.c_str(), 0,0);
+         if(fd >= 0) {
             const char* status = "HTTP/1.0 200 OK\r\n"
                                  "X-Frame-Options: SAMEORIGIN\r\n"
                                  "X-XSS-Protection: 1; mode=block\r\n"
@@ -83,11 +82,12 @@ void handleHTTPCommand(int sd, const unsigned int id, char* command)
             result = nsa_write(sd, status, strlen(status));
 
             char str[8192];
-            std::streamsize s = is.rdbuf()->sgetn(str, sizeof(str));
+            ssize_t s = nsa_read(fd, str, sizeof(str));
             while((s > 0) && (result > 0)) {
                result = nsa_write(sd, str, s);
-               s = is.rdbuf()->sgetn(str, sizeof(str));
+               s = nsa_read(fd, str, sizeof(str));
             }
+            nsa_close(fd);
          }
          else {
             std::cout << "Client " << id << ": File <" << fileName << "> not found!" << std::endl;
@@ -335,11 +335,11 @@ int main(int argc, char** argv)
                                     NI_NUMERICHOST);
             if(error != 0) {
                std::cerr << "ERROR: getnameinfo() failed: " << gai_strerror(error) << std::endl;
-               exit(1);
             }
-            std::cout << "Got connection from "
-                      << remoteHost << ", service " << remoteService << ":" << std::endl;
-
+            else {
+               std::cout << "Got connection from "
+                         << remoteHost << ", service " << remoteService << ":" << std::endl;
+            }
 
             // ====== Start new service thread ==============================
             clientList.add(newSD);

--- a/socketapi/examples/httpserver2-threads.cc
+++ b/socketapi/examples/httpserver2-threads.cc
@@ -20,7 +20,6 @@
  */
 
 #include <iostream>
-#include <fstream>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -137,8 +136,8 @@ void ServiceThread::run()
       if(fileName[0] != '.') {   // No access to top-level directories!
          std::cout << "Thread " << ID << ": Trying to upload file \""
                    << fileName << "\"..." << std::endl;
-         std::ifstream is(fileName.c_str(), std::ios::binary);
-         if(is.good()) {
+         int fd = nsa_open(fileName.c_str(), 0,0);
+         if(fd >= 0) {
             const char* status = "HTTP/1.0 200 OK\r\n"
                                  "X-Frame-Options: SAMEORIGIN\r\n"
                                  "X-XSS-Protection: 1; mode=block\r\n"
@@ -148,11 +147,12 @@ void ServiceThread::run()
             result = nsa_write(SocketDesc, status, strlen(status));
 
             char str[8192];
-            std::streamsize s = is.rdbuf()->sgetn(str, sizeof(str));
+            ssize_t s = nsa_read(fd, str, sizeof(str));
             while((s > 0) && (result > 0)) {
                result = nsa_write(SocketDesc, str, s);
-               s = is.rdbuf()->sgetn(str, sizeof(str));
+               s = nsa_read(fd, str, sizeof(str));
             }
+            nsa_close(fd);
          }
          else {
             std::cout << "Thread " << ID << ": File <" << fileName << "> not found!" << std::endl;
@@ -333,11 +333,11 @@ int main(int argc, char** argv)
                               NI_NUMERICHOST);
       if(error != 0) {
          std::cerr << "ERROR: getnameinfo() failed: " << gai_strerror(error) << std::endl;
-         exit(1);
       }
-      std::cout << "Got connection from "
-                << remoteHost << ", service " << remoteService << ":" << std::endl;
-
+      else {
+         std::cout << "Got connection from "
+                   << remoteHost << ", service " << remoteService << ":" << std::endl;
+      }
 
       // ====== Start new service thread ====================================
       stl.add(new ServiceThread(newSD));

--- a/socketapi/examples/httpserver2-threads.cc
+++ b/socketapi/examples/httpserver2-threads.cc
@@ -136,7 +136,7 @@ void ServiceThread::run()
       if(fileName[0] != '.') {   // No access to top-level directories!
          std::cout << "Thread " << ID << ": Trying to upload file \""
                    << fileName << "\"..." << std::endl;
-         int fd = nsa_open(fileName.c_str(), 0,0);
+         int fd = nsa_open(fileName.c_str(), 0, 0);
          if(fd >= 0) {
             const char* status = "HTTP/1.0 200 OK\r\n"
                                  "X-Frame-Options: SAMEORIGIN\r\n"


### PR DESCRIPTION
- Got rid of "using namespace".
- Using NEAT I/O functions instead of fstream.