### PR TITLE
IETF Hackathon bugfix: nsa_accept() needs a loop for blocking mode

### DIFF
--- a/socketapi/neat-socketapi.c
+++ b/socketapi/neat-socketapi.c
@@ -402,8 +402,8 @@ int nsa_accept(int sockfd, struct sockaddr* addr, socklen_t* addrlen)
          if(neatSocket->ns_flags & NSAF_LISTENING) {
             /* ====== Accept new socket ================================== */
             struct neat_socket* newSocket = TAILQ_FIRST(&neatSocket->ns_accept_list);
-            if( (newSocket == NULL) &&
-                (!(neatSocket->ns_flags & NSAF_NONBLOCKING)) ) {
+            while( (newSocket == NULL) &&
+                   (!(neatSocket->ns_flags & NSAF_NONBLOCKING)) ) {
                /* ====== Blocking mode: wait ============================= */
                es_has_fired(&neatSocket->ns_read_signal);   /* Clear read signal */
                nsa_set_socket_event_on_read(neatSocket, true);


### PR DESCRIPTION
nsa_accept() needs a loop for blocking mode. It may be possible that incoming connects are already closed (and removed) -> continue waiting.