### PR TITLE
do_accept: fix "Uninitialized scalar variable"

### DIFF
--- a/neat_core.c
+++ b/neat_core.c
@@ -2693,6 +2693,7 @@ do_accept(neat_ctx *ctx, neat_flow *flow, struct neat_pollable_socket *listen_so
                 neat_free_flow(newFlow);
                 return NULL;
             } else {
+                optval = 1;
                 setsockopt(newFlow->socket->fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
                 setsockopt(newFlow->socket->fd, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval));
 


### PR DESCRIPTION
Assign optval before use. Coverity CID 1452614.