### PR TITLE
neat_close: fix use after free

### DIFF
--- a/neat_core.c
+++ b/neat_core.c
@@ -6857,7 +6857,7 @@ neat_close(struct neat_ctx *ctx, struct neat_flow *flow)
         }
 
         neat_close_socket(ctx, flow);
-
+        return NEAT_OK;
 #ifdef SCTP_MULTISTREAMING
     }
 #endif


### PR DESCRIPTION
After neat_close_socket(), the flow is freed and must not be used
further. And it already calls notift_socket() itself.

Coverity CID 1452611.