### PR TITLE
neat_resolver_create_pairs: return error on calloc() fail

### DIFF
--- a/neat_resolver.c
+++ b/neat_resolver.c
@@ -739,8 +739,7 @@ neat_resolver_create_pairs(struct neat_addr *src_addr,
             calloc(sizeof(struct neat_resolver_src_dst_addr), 1);
 
         if (!resolver_pair) {
-            //neat_log(NEAT_LOG_ERROR, "%s - Failed to allocate memory for resolver pair", __func__);
-            continue;
+            return RETVAL_FAILURE;
         }
 
         resolver_pair->request = request;


### PR DESCRIPTION
... resource fatique must be a terminal error, not just try-again.