### PR TITLE
Added missing wrappers to the Sockets API

### DIFF
--- a/socketapi/neat-socketapi.c
+++ b/socketapi/neat-socketapi.c
@@ -818,6 +818,34 @@ int nsa_creat(const char* pathname, mode_t mode)
 }
 
 
+/* ###### NEAT lseek() implementation #################################### */
+off_t nsa_lseek(int fd, off_t offset, int whence);
+{
+   GET_NEAT_SOCKET(fd)
+   if(neatSocket->ns_flow != NULL) {
+      errno = EOPNOTSUPP;
+      return(-1);
+   }
+   else {
+      return(lseek(neatSocket->ns_socket_sd, offset, whence));
+   }
+}
+
+
+/* ###### NEAT lseek64() implementation ################################## */
+off64_t nsa_lseek64(int fd, off64_t offset, int whence);
+{
+   GET_NEAT_SOCKET(fd)
+   if(neatSocket->ns_flow != NULL) {
+      errno = EOPNOTSUPP;
+      return(-1);
+   }
+   else {
+      return(lseek64(neatSocket->ns_socket_sd, offset, whence));
+   }
+}
+
+
 /* ###### NEAT ioctl() implementation #################################### */
 int nsa_ioctl(int fd, int request, const void* argp)
 {

--- a/socketapi/neat-socketapi.c
+++ b/socketapi/neat-socketapi.c
@@ -46,7 +46,7 @@
 #include <netdb.h>
 #include <sys/ioctl.h>
 #include <sys/param.h>
-#if defined(HAVE_NETINET_SCTP_H) && !defined(USRSCTP_SUPPORT)
+#if defined(HAVE_NETINET_SCTP_H)
 #include <netinet/sctp.h>
 #endif
 
@@ -819,7 +819,7 @@ int nsa_creat(const char* pathname, mode_t mode)
 
 
 /* ###### NEAT lseek() implementation #################################### */
-off_t nsa_lseek(int fd, off_t offset, int whence);
+off_t nsa_lseek(int fd, off_t offset, int whence)
 {
    GET_NEAT_SOCKET(fd)
    if(neatSocket->ns_flow != NULL) {
@@ -832,8 +832,9 @@ off_t nsa_lseek(int fd, off_t offset, int whence);
 }
 
 
+#ifdef _LARGEFILE64_SOURCE
 /* ###### NEAT lseek64() implementation ################################## */
-off64_t nsa_lseek64(int fd, off64_t offset, int whence);
+off64_t nsa_lseek64(int fd, off64_t offset, int whence)
 {
    GET_NEAT_SOCKET(fd)
    if(neatSocket->ns_flow != NULL) {
@@ -844,6 +845,7 @@ off64_t nsa_lseek64(int fd, off64_t offset, int whence);
       return(lseek64(neatSocket->ns_socket_sd, offset, whence));
    }
 }
+#endif
 
 
 /* ###### NEAT ftruncate() implementation ################################ */

--- a/socketapi/neat-socketapi.c
+++ b/socketapi/neat-socketapi.c
@@ -846,6 +846,36 @@ off64_t nsa_lseek64(int fd, off64_t offset, int whence);
 }
 
 
+/* ###### NEAT ftruncate() implementation ################################ */
+int nsa_ftruncate(int fd, off_t length)
+{
+   GET_NEAT_SOCKET(fd)
+   if(neatSocket->ns_flow != NULL) {
+      errno = EOPNOTSUPP;
+      return(-1);
+   }
+   else {
+      return(ftruncate(neatSocket->ns_socket_sd, length));
+   }
+}
+
+
+#ifdef _LARGEFILE64_SOURCE
+/* ###### NEAT ftruncate64() implementation ############################## */
+int nsa_ftruncate64(int fd, off64_t length)
+{
+   GET_NEAT_SOCKET(fd)
+   if(neatSocket->ns_flow != NULL) {
+      errno = EOPNOTSUPP;
+      return(-1);
+   }
+   else {
+      return(ftruncate64(neatSocket->ns_socket_sd, length));
+   }
+}
+#endif
+
+
 /* ###### NEAT ioctl() implementation #################################### */
 int nsa_ioctl(int fd, int request, const void* argp)
 {

--- a/socketapi/neat-socketapi.h
+++ b/socketapi/neat-socketapi.h
@@ -286,7 +286,11 @@ void nsa_freepaddrs(struct sockaddr* addrs);
 int nsa_open(const char* pathname, int flags, mode_t mode);
 int nsa_creat(const char* pathname, mode_t mode);
 off_t nsa_lseek(int fd, off_t offset, int whence);
+int nsa_ftruncate(int fd, off_t length);
+#ifdef _LARGEFILE64_SOURCE
 off64_t nsa_lseek64(int fd, off64_t offset, int whence);
+int nsa_ftruncate64(int fd, off64_t length);
+#endif
 int nsa_pipe(int fds[2]);
 int nsa_ioctl(int fd, int request, const void* argp);
 

--- a/socketapi/neat-socketapi.h
+++ b/socketapi/neat-socketapi.h
@@ -285,6 +285,8 @@ void nsa_freepaddrs(struct sockaddr* addrs);
 /* ====== Miscellaneous ================================================== */
 int nsa_open(const char* pathname, int flags, mode_t mode);
 int nsa_creat(const char* pathname, mode_t mode);
+off_t nsa_lseek(int fd, off_t offset, int whence);
+off64_t nsa_lseek64(int fd, off64_t offset, int whence);
 int nsa_pipe(int fds[2]);
 int nsa_ioctl(int fd, int request, const void* argp);
 


### PR DESCRIPTION
The sockets API needs wrappers for lseek() and ftruncate(), in order to handle FDs in nsa_poll()/nsa_select() correctly.