### PR TITLE
Fix: on_all_written() would fire although neat_write() fails to send data

### DIFF
--- a/neat_core.c
+++ b/neat_core.c
@@ -5047,6 +5047,9 @@ neat_write_to_lower_layer(struct neat_ctx *ctx, struct neat_flow *flow,
 #endif
         if (rv < 0 ) {
             nt_log(ctx, NEAT_LOG_WARNING, "%s - sending failed - %s", __func__, strerror(errno));
+            if (errno == ENOENT) {
+                flow->isClosing = 1;
+            }
             if (errno != EWOULDBLOCK) {
                 return NEAT_ERROR_IO;
             }


### PR DESCRIPTION
In some cases when calling `neat_write()` it will fail to send data because the remote end has closed the connection. Still, `on_all_written()` can be called for that flow afterwards through `io_writable()`.

This PR sets the `flow->isClosing` variable to `true` in `neat_write_to_lower_layer()` so that `neat_shutdown()` will be called in `io_writable()` instead of `io_all_written()`. I don't know if it is correct to call `neat_shutdown()` in this case.

The code can be extended to check for other error codes for which `neat_write()` will fail to send data.