### PR TITLE
Addressed Coverity issue with CID 1463045.

### DIFF
--- a/neat_core.c
+++ b/neat_core.c
@@ -2769,6 +2769,9 @@ do_accept(neat_ctx *ctx, neat_flow *flow, struct neat_pollable_socket *listen_so
                 memset(buffer, 0, sizeof(buffer));
 
                 rc = getpeername(newFlow->socket->fd, (struct sockaddr*)&sockaddr, &socklen);
+                if (rc == -1) {
+                    nt_log(ctx, NEAT_LOG_ERROR, "%s - getpeername(() failed - %s", __func__, strerror(errno));
+                }
                 assert(rc == 0);
 
                 ptr = (void*)inet_ntop(AF_INET, (void*)&((struct sockaddr_in*)(&sockaddr))->sin_addr, buffer, INET6_ADDRSTRLEN);


### PR DESCRIPTION
Checked return value from 'getpeername' and in so doing avoid UNUSED_VALUE defect from Coverity on variable 'rc'.