### PR TITLE
Added support for tproxy property

### DIFF
--- a/neat_core.c
+++ b/neat_core.c
@@ -5843,6 +5843,7 @@ nt_listen_via_kernel(struct neat_ctx *ctx, struct neat_flow *flow, struct neat_p
         nt_log(ctx, NEAT_LOG_DEBUG, "Unable to set socket option SOL_SOCKET:SO_REUSEPORT");
     }
 
+#ifdef __linux__
     if (flow->tproxy) {
         // Mark that this socket can be used for transparent proxying
         // This allows the socket to accept connections for non-local IPs
@@ -5852,6 +5853,7 @@ nt_listen_via_kernel(struct neat_ctx *ctx, struct neat_flow *flow, struct neat_p
             nt_log(ctx, NEAT_LOG_DEBUG, "Socket option SOL_IP:IP_TRANSPARENT set OK");
         }
     }
+#endif // __linux__
 
     len = (socklen_t)sizeof(int);
     if (getsockopt(fd, SOL_SOCKET, SO_SNDBUF, &size, &len) == 0) {

--- a/neat_core.c
+++ b/neat_core.c
@@ -4570,7 +4570,7 @@ neat_accept(struct neat_ctx *ctx, struct neat_flow *flow,
 {
     const char *local_name  = NULL;
     json_t *val             = NULL;
-    json_t *security        = NULL;
+    json_t *property        = NULL;
     int stream_count        = 0;
 
     nt_log(ctx, NEAT_LOG_DEBUG, "%s", __func__);
@@ -4608,12 +4608,20 @@ neat_accept(struct neat_ctx *ctx, struct neat_flow *flow,
     flow->port  = port;
     flow->ctx   = ctx;
 
-    if ((security = json_object_get(flow->properties, "security")) != NULL &&
-        (val = json_object_get(security, "value")) != NULL &&
+    if ((property = json_object_get(flow->properties, "security")) != NULL &&
+        (val = json_object_get(property, "value")) != NULL &&
         json_typeof(val) == JSON_TRUE) {
         flow->security_needed = 1;
     } else {
         flow->security_needed = 0;
+    }
+
+    if ((property = json_object_get(flow->properties, "tproxy")) != NULL &&
+        (val = json_object_get(property, "value")) != NULL &&
+        json_typeof(val) == JSON_TRUE) {
+        flow->tproxy = 1;
+    } else {
+        flow->tproxy = 0;
     }
 
     if (!ctx->resolver) {
@@ -5833,6 +5841,16 @@ nt_listen_via_kernel(struct neat_ctx *ctx, struct neat_flow *flow, struct neat_p
     }
     if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &enable, sizeof(int)) != 0) {
         nt_log(ctx, NEAT_LOG_DEBUG, "Unable to set socket option SOL_SOCKET:SO_REUSEPORT");
+    }
+
+    if (flow->tproxy) {
+        // Mark that this socket can be used for transparent proxying
+        // This allows the socket to accept connections for non-local IPs
+        if (setsockopt(fd, SOL_IP, IP_TRANSPARENT, &enable, sizeof(int)) != 0) {
+           nt_log(ctx, NEAT_LOG_ERROR, "Unable to set socket option SOL_IP:IP_TRANSPARENT");
+        } else {
+            nt_log(ctx, NEAT_LOG_DEBUG, "Socket option SOL_IP:IP_TRANSPARENT set OK");
+        }
     }
 
     len = (socklen_t)sizeof(int);

--- a/neat_internal.h
+++ b/neat_internal.h
@@ -347,6 +347,7 @@ struct neat_flow
     unsigned int eofSeen                    : 1;
     unsigned int skipCertVerification       : 1;
     unsigned int webrtcEnabled              : 1;
+    unsigned int tproxy                     : 1; // is transparent proxy socket
 
     unsigned int streams_requested;
 


### PR DESCRIPTION
For the purpose of transparent proxing, this PR adds a possibility to specify 'tproxy' property (true/false) for a listening flow. When such a property is specified IP_TRANSPARENT socket option is set for underlying socket, which allows the socket to accept connections for non-local IPs.