### PR TITLE
Fixed URL for libuv-v1.9.1.tar.gz in Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,8 @@ before_script:
     if [ $TRAVIS_OS_NAME = linux ]; then
       if [ ! -e $HOME/libuv-v1.9.1/Makefile ]; then
         (cd $HOME && \
-        wget archive.ubuntu.com/ubuntu/pool/universe/libu/libuv1/libuv1_1.9.1.orig.tar.gz && \
-        tar -xzf libuv1_1.9.1.orig.tar.gz && \
+        curl -O https://dist.libuv.org/dist/v1.9.1/libuv-v1.9.1.tar.gz && \
+        tar xzf libuv-v1.9.1.tar.gz && \
         cd libuv-v1.9.1 && \
         sh autogen.sh && \
         ./configure && \

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,9 +116,9 @@ script:
         fi
 
 # whitelist branches to avoid testing feature branches twice (as branch and as pull request)
-branches:
-    only:
-        - master
+#branches:
+#    only:
+#        - master
 
 notifications:
   email: false


### PR DESCRIPTION
The URL for libuv-v1.9.1.tar.gz was invalid, causing the Travis CI build to fail.